### PR TITLE
quality of life: show error when trying to execute resolve without blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ make tests-basic
 
 That's it! You've successfully installed DocETL and are ready to start processing documents.
 
-For more detailed information on usage and configuration, please refer to our [documentation](https://shreyashankar.github.io/docetl).
+For more detailed information on usage and configuration, please refer to our [documentation](https://ucbepic.github.io/docetl).

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -229,7 +229,11 @@ class DSLRunner:
 
             operation_class = get_operation(op_object["type"])
             operation_instance = operation_class(
-                op_object, self.default_model, self.max_threads, self.console
+                op_object,
+                self.default_model,
+                self.max_threads,
+                self.console,
+                self.status,
             )
             if op_object["type"] == "equijoin":
                 left_data = self.datasets[op_object["left"]]


### PR DESCRIPTION
This PR introduces a prompt to confirm, to the user, that they want to continue executing a resolve operation (if they have not specified any blocking configurations).