### PR TITLE
Add Configurable Timeouts for Operations and Ollama Integration Documentation

### DIFF
--- a/docetl/api.py
+++ b/docetl/api.py
@@ -80,6 +80,7 @@ class MapOp(BaseOp):
     num_retries_on_validate_failure: Optional[int] = None
     gleaning: Optional[Dict[str, Any]] = None
     drop_keys: Optional[List[str]] = None
+    timeout: Optional[int] = None
 
 
 @dataclass
@@ -98,6 +99,7 @@ class ResolveOp(BaseOp):
     compare_batch_size: Optional[int] = None
     limit_comparisons: Optional[int] = None
     optimize: Optional[bool] = None
+    timeout: Optional[int] = None
 
 
 @dataclass
@@ -115,6 +117,7 @@ class ReduceOp(BaseOp):
     fold_batch_size: Optional[int] = None
     value_sampling: Optional[Dict[str, Any]] = None
     verbose: Optional[bool] = None
+    timeout: Optional[int] = None
 
 
 @dataclass
@@ -126,6 +129,7 @@ class ParallelMapOp(BaseOp):
     recursively_optimize: Optional[bool] = None
     sample_size: Optional[int] = None
     drop_keys: Optional[List[str]] = None
+    timeout: Optional[int] = None
 
 
 @dataclass
@@ -138,6 +142,7 @@ class FilterOp(BaseOp):
     sample_size: Optional[int] = None
     validate: Optional[List[str]] = None
     num_retries_on_validate_failure: Optional[int] = None
+    timeout: Optional[int] = None
 
 
 @dataclass
@@ -156,6 +161,7 @@ class EquijoinOp(BaseOp):
     compare_batch_size: Optional[int] = None
     limit_comparisons: Optional[int] = None
     blocking_keys: Optional[Dict[str, List[str]]] = None
+    timeout: Optional[int] = None
 
 
 @dataclass

--- a/docetl/operations/equijoin.py
+++ b/docetl/operations/equijoin.py
@@ -54,7 +54,12 @@ def process_left_item(
 
 
 def compare_pair(
-    comparison_prompt: str, model: str, item1: Dict, item2: Dict
+    comparison_prompt: str,
+    model: str,
+    item1: Dict,
+    item2: Dict,
+    timeout_seconds: int = 120,
+    max_retries_per_timeout: int = 2,
 ) -> Tuple[bool, float]:
     """
     Compares two items using an LLM model to determine if they match.
@@ -64,6 +69,8 @@ def compare_pair(
         model (str): The LLM model to use for comparison.
         item1 (Dict): The first item to compare.
         item2 (Dict): The second item to compare.
+        timeout_seconds (int): The timeout for the LLM call in seconds.
+        max_retries_per_timeout (int): The maximum number of retries per timeout.
 
     Returns:
         Tuple[bool, float]: A tuple containing a boolean indicating whether the items match and the cost of the comparison.
@@ -76,6 +83,8 @@ def compare_pair(
         "compare",
         [{"role": "user", "content": prompt}],
         {"is_match": "bool"},
+        timeout_seconds=timeout_seconds,
+        max_retries_per_timeout=max_retries_per_timeout,
     )
     output = parse_llm_response(response)[0]
     return output["is_match"], completion_cost(response)
@@ -384,6 +393,8 @@ class EquijoinOperation(BaseOperation):
                     self.config.get("comparison_model", self.default_model),
                     left,
                     right,
+                    self.config.get("timeout", 120),
+                    self.config.get("max_retries_per_timeout", 2),
                 ): (left, right)
                 for left, right in blocked_pairs
             }

--- a/docetl/operations/filter.py
+++ b/docetl/operations/filter.py
@@ -135,6 +135,10 @@ class FilterOperation(BaseOperation):
                     messages,
                     self.config["output"]["schema"],
                     console=self.console,
+                    timeout_seconds=self.config.get("timeout", 120),
+                    max_retries_per_timeout=self.config.get(
+                        "max_retries_per_timeout", 2
+                    ),
                 ),
                 validation_fn=validation_fn,
                 val_rule=self.config.get("validate", []),

--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -154,6 +154,10 @@ class MapOperation(BaseOperation):
                         self.config["gleaning"]["validation_prompt"],
                         self.config["gleaning"]["num_rounds"],
                         self.console,
+                        timeout_seconds=self.config.get("timeout", 120),
+                        max_retries_per_timeout=self.config.get(
+                            "max_retries_per_timeout", 2
+                        ),
                     ),
                     validation_fn=validation_fn,
                     val_rule=self.config.get("validate", []),
@@ -170,6 +174,10 @@ class MapOperation(BaseOperation):
                         self.config["output"]["schema"],
                         tools=self.config.get("tools", None),
                         console=self.console,
+                        timeout_seconds=self.config.get("timeout", 120),
+                        max_retries_per_timeout=self.config.get(
+                            "max_retries_per_timeout", 2
+                        ),
                     ),
                     validation_fn=validation_fn,
                     val_rule=self.config.get("validate", []),
@@ -356,6 +364,8 @@ class ParallelMapOperation(BaseOperation):
                 local_output_schema,
                 tools=prompt_config.get("tools", None),
                 console=self.console,
+                timeout_seconds=self.config.get("timeout", 120),
+                max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
             )
             output = parse_llm_response(
                 response, tools=prompt_config.get("tools", None)

--- a/docetl/operations/reduce.py
+++ b/docetl/operations/reduce.py
@@ -691,6 +691,8 @@ class ReduceOperation(BaseOperation):
             self.config["output"]["schema"],
             scratchpad=scratchpad,
             console=self.console,
+            timeout_seconds=self.config.get("timeout", 120),
+            max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
         )
         folded_output = parse_llm_response(response)[0]
 
@@ -730,6 +732,8 @@ class ReduceOperation(BaseOperation):
             [{"role": "user", "content": merge_prompt}],
             self.config["output"]["schema"],
             console=self.console,
+            timeout_seconds=self.config.get("timeout", 120),
+            max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
         )
         merged_output = parse_llm_response(response)[0]
         merged_output.update(dict(zip(self.config["reduce_key"], key)))
@@ -822,6 +826,8 @@ class ReduceOperation(BaseOperation):
                 self.config["gleaning"]["validation_prompt"],
                 self.config["gleaning"]["num_rounds"],
                 console=self.console,
+                timeout_seconds=self.config.get("timeout", 120),
+                max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
             )
             item_cost += gleaning_cost
         else:
@@ -832,6 +838,8 @@ class ReduceOperation(BaseOperation):
                 self.config["output"]["schema"],
                 console=self.console,
                 scratchpad=scratchpad,
+                timeout_seconds=self.config.get("timeout", 120),
+                max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
             )
 
         item_cost += completion_cost(response)

--- a/docetl/operations/resolve.py
+++ b/docetl/operations/resolve.py
@@ -31,6 +31,8 @@ def compare_pair(
     item1: Dict,
     item2: Dict,
     blocking_keys: List[str] = [],
+    timeout_seconds: int = 120,
+    max_retries_per_timeout: int = 2,
 ) -> Tuple[bool, float]:
     """
     Compares two items using an LLM model to determine if they match.
@@ -58,6 +60,8 @@ def compare_pair(
         "compare",
         [{"role": "user", "content": prompt}],
         {"is_match": "bool"},
+        timeout_seconds=timeout_seconds,
+        max_retries_per_timeout=max_retries_per_timeout,
     )
     output = parse_llm_response(response)[0]
     return output["is_match"], completion_cost(response)
@@ -362,6 +366,10 @@ class ResolveOperation(BaseOperation):
                         input_data[pair[0]],
                         input_data[pair[1]],
                         blocking_keys,
+                        timeout_seconds=self.config.get("timeout", 120),
+                        max_retries_per_timeout=self.config.get(
+                            "max_retries_per_timeout", 2
+                        ),
                     ): pair
                     for pair in batch
                 }
@@ -400,6 +408,10 @@ class ResolveOperation(BaseOperation):
                     [{"role": "user", "content": resolution_prompt}],
                     self.config["output"]["schema"],
                     console=self.console,
+                    timeout_seconds=self.config.get("timeout", 120),
+                    max_retries_per_timeout=self.config.get(
+                        "max_retries_per_timeout", 2
+                    ),
                 )
                 reduction_output = parse_llm_response(reduction_response)[0]
                 reduction_cost = completion_cost(reduction_response)

--- a/docs/examples/ollama.md
+++ b/docs/examples/ollama.md
@@ -1,0 +1,140 @@
+# Medical Document Classification with Ollama
+
+This tutorial demonstrates how to use DocETL with [Ollama](https://github.com/ollama/ollama) models to classify medical documents into predefined categories. We'll use a simple map operation to process a set of medical records, ensuring that sensitive information remains private by using a locally-run model.
+
+## Setup
+
+!!! note "Prerequisites"
+
+    Before we begin, make sure you have Ollama installed and running on your local machine.
+
+You'll need to set the OLLAMA_API_BASE environment variable:
+
+```bash
+export OLLAMA_API_BASE=http://localhost:11434/
+```
+
+!!! info "API Details"
+
+    For more information on the Ollama REST API, refer to the [Ollama documentation](https://github.com/ollama/ollama?tab=readme-ov-file#rest-api).
+
+## Pipeline Configuration
+
+Let's create a pipeline that classifies medical documents into categories such as "Cardiology", "Neurology", "Oncology", etc.
+
+!!! example "Initial Pipeline Configuration"
+
+    ```yaml
+    datasets:
+      medical_records:
+        type: file
+        path: "medical_records.json"
+
+    default_model: ollama/llama3
+
+    operations:
+      - name: classify_medical_record
+        type: map
+        output:
+          schema:
+            categories: "list[str]"
+        prompt: |
+          Classify the following medical record into one or more of these categories: Cardiology, Neurology, Oncology, Pediatrics, Orthopedics.
+
+          Medical Record:
+          {{ input.text }}
+
+          Return your answer as a JSON list of strings, e.g., ["Cardiology", "Neurology"].
+
+    pipeline:
+      steps:
+        - name: medical_classification
+          input: medical_records
+          operations:
+            - classify_medical_record
+
+    output:
+      type: file
+      path: "classified_records.json"
+    ```
+
+## Running the Pipeline with a Sample
+
+To test our pipeline and estimate the required timeout, we'll first run it on a sample of documents.
+
+Modify the `classify_medical_record` operation in your configuration to include a `sample` parameter:
+
+```yaml
+operations:
+  - name: classify_medical_record
+    type: map
+    sample: 5
+    output:
+      schema:
+        categories: "list[str]"
+    prompt: |
+      Classify the following medical record into one or more of these categories: Cardiology, Neurology, Oncology, Pediatrics, Orthopedics.
+
+      Medical Record:
+      {{ input.text }}
+
+      Return your answer as a JSON list of strings, e.g., ["Cardiology", "Neurology"].
+```
+
+Now, run the pipeline with this sample configuration:
+
+```bash
+docetl run pipeline.yaml
+```
+
+## Adjusting the Timeout
+
+After running the sample, note the time it took to process 5 documents.
+
+!!! example "Timeout Calculation"
+
+    Let's say it took 100 seconds to process 5 documents. You can use this to estimate the time needed for your full dataset. For example, if you have 1000 documents in total, you might want to set the timeout to:
+
+    (100 seconds / 5 documents) * 1000 documents = 20,000 seconds
+
+Now, adjust your pipeline configuration to include this timeout and remove the sample parameter:
+
+```yaml
+operations:
+  - name: classify_medical_record
+    type: map
+    timeout: 20000
+    output:
+      schema:
+        categories: "list[str]"
+    prompt: |
+      Classify the following medical record into one or more of these categories: Cardiology, Neurology, Oncology, Pediatrics, Orthopedics.
+      Medical Record:
+      {{ input.text }}
+      Return your answer as a JSON list of strings, e.g., ["Cardiology", "Neurology"].
+```
+
+!!! note "Caching"
+
+    DocETL caches results (even between runs), so if the same document is processed again, the answer will be returned from the cache rather than processed again (significantly speeding up processing).
+
+## Running the Full Pipeline
+
+Now you can run the full pipeline with the adjusted timeout:
+
+```bash
+docetl run pipeline.yaml
+```
+
+This will process all your medical records, classifying them into the predefined categories.
+
+## Conclusion
+
+!!! success "Key Takeaways"
+
+    - This pipeline demonstrates how to use Ollama with DocETL for local processing of sensitive data.
+    - Ollama integrates into multi-operation pipelines, maintaining data privacy.
+    - Ollama is a local model, so it is much slower than leveraging an LLM API like OpenAI. Adjust the timeout accordingly.
+    - DocETL's sample and timeout parameters help optimize the pipeline for efficient use of Ollama's capabilities.
+
+For more information, e.g., for specific models, visit [https://ollama.com/](https://ollama.com/).

--- a/docs/operators/filter.md
+++ b/docs/operators/filter.md
@@ -89,6 +89,8 @@ This example demonstrates how the Filter operation distinguishes between high-im
 | `sample_size`                     | Number of samples to use for the operation        | Processes all data            |
 | `validate`                        | List of Python expressions to validate the output | None                          |
 | `num_retries_on_validate_failure` | Number of retry attempts on validation failure    | 0                             |
+| `timeout`                         | Timeout for each LLM call in seconds              | 120                           |
+| `max_retries_per_timeout`         | Maximum number of retries per timeout             | 2                             |
 
 !!! info "Validation"
 

--- a/docs/operators/map.md
+++ b/docs/operators/map.md
@@ -142,8 +142,12 @@ This example demonstrates how the Map operation can transform long, unstructured
 | `num_retries_on_validate_failure` | Number of retry attempts on validation failure                                                  | 0                             |
 | `gleaning`                        | Configuration for advanced validation and LLM-based refinement                                  | None                          |
 | `drop_keys`                       | List of keys to drop from the input before processing                                           | None                          |
+| `timeout`                         | Timeout for each LLM call in seconds                                                            | 120                           |
+| `max_retries_per_timeout`         | Maximum number of retries per timeout                                                           | 2                             |
 
 Note: If `drop_keys` is specified, `prompt` and `output` become optional parameters.
+
+| `timeout` | Timeout for each LLM call in seconds | 120 |
 
 !!! info "Validation and Gleaning"
 

--- a/docs/operators/parallel-map.md
+++ b/docs/operators/parallel-map.md
@@ -29,12 +29,14 @@ Each prompt configuration in the `prompts` list should contain:
 
 ### Optional Parameters
 
-| Parameter              | Description                                | Default                       |
-| ---------------------- | ------------------------------------------ | ----------------------------- |
-| `model`                | The default language model to use          | Falls back to `default_model` |
-| `optimize`             | Flag to enable operation optimization      | True                          |
-| `recursively_optimize` | Flag to enable recursive optimization      | false                         |
-| `sample_size`          | Number of samples to use for the operation | Processes all data            |
+| Parameter                 | Description                                | Default                       |
+| ------------------------- | ------------------------------------------ | ----------------------------- |
+| `model`                   | The default language model to use          | Falls back to `default_model` |
+| `optimize`                | Flag to enable operation optimization      | True                          |
+| `recursively_optimize`    | Flag to enable recursive optimization      | false                         |
+| `sample_size`             | Number of samples to use for the operation | Processes all data            |
+| `timeout`                 | Timeout for each LLM call in seconds       | 120                           |
+| `max_retries_per_timeout` | Maximum number of retries per timeout      | 2                             |
 
 ??? question "Why use Parallel Map instead of multiple Map operations?"
 

--- a/docs/operators/reduce.md
+++ b/docs/operators/reduce.md
@@ -49,18 +49,20 @@ This Reduce operation processes customer feedback grouped by department:
 
 ### Optional Parameters
 
-| Parameter            | Description                                                                     | Default                     |
-| -------------------- | ------------------------------------------------------------------------------- | --------------------------- |
-| `synthesize_resolve` | If false, won't synthesize a resolve operation between map and reduce           | true                        |
-| `model`              | The language model to use                                                       | Falls back to default_model |
-| `input`              | Specifies the schema or keys to subselect from each item                        | All keys from input items   |
-| `pass_through`       | If true, non-input keys from the first item in the group will be passed through | false                       |
-| `associative`        | If true, the reduce operation is associative (i.e., order doesn't matter)       | true                        |
-| `fold_prompt`        | A prompt template for incremental folding                                       | None                        |
-| `fold_batch_size`    | Number of items to process in each fold operation                               | None                        |
-| `value_sampling`     | A dictionary specifying the sampling strategy for large groups                  | None                        |
-| `verbose`            | If true, enables detailed logging of the reduce operation                       | false                       |
-| `persist_intermediates` | If true, persists the intermediate results for each group to the key `_{operation_name}_intermediates` | false |
+| Parameter                 | Description                                                                                            | Default                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------- |
+| `synthesize_resolve`      | If false, won't synthesize a resolve operation between map and reduce                                  | true                        |
+| `model`                   | The language model to use                                                                              | Falls back to default_model |
+| `input`                   | Specifies the schema or keys to subselect from each item                                               | All keys from input items   |
+| `pass_through`            | If true, non-input keys from the first item in the group will be passed through                        | false                       |
+| `associative`             | If true, the reduce operation is associative (i.e., order doesn't matter)                              | true                        |
+| `fold_prompt`             | A prompt template for incremental folding                                                              | None                        |
+| `fold_batch_size`         | Number of items to process in each fold operation                                                      | None                        |
+| `value_sampling`          | A dictionary specifying the sampling strategy for large groups                                         | None                        |
+| `verbose`                 | If true, enables detailed logging of the reduce operation                                              | false                       |
+| `persist_intermediates`   | If true, persists the intermediate results for each group to the key `_{operation_name}_intermediates` | false                       |
+| `timeout`                 | Timeout for each LLM call in seconds                                                                   | 120                         |
+| `max_retries_per_timeout` | Maximum number of retries per timeout                                                                  | 2                           |
 
 ## Advanced Features
 

--- a/docs/operators/resolve.md
+++ b/docs/operators/resolve.md
@@ -107,18 +107,20 @@ After determining eligible pairs for comparison, the Resolve operation uses a Un
 
 ## Optional Parameters
 
-| Parameter              | Description                                                                       | Default                       |
-| ---------------------- | --------------------------------------------------------------------------------- | ----------------------------- |
-| `embedding_model`      | The model to use for creating embeddings                                          | Falls back to `default_model` |
-| `resolution_model`     | The language model to use for reducing matched entries                            | Falls back to `default_model` |
-| `comparison_model`     | The language model to use for comparing potential matches                         | Falls back to `default_model` |
-| `blocking_keys`        | List of keys to use for initial blocking                                          | All keys in the input data    |
-| `blocking_threshold`   | Embedding similarity threshold for considering entries as potential matches       | None                          |
-| `blocking_conditions`  | List of conditions for initial blocking                                           | []                            |
-| `input`                | Specifies the schema or keys to subselect from each item to pass into the prompts | All keys from input items     |
-| `embedding_batch_size` | The number of entries to send to the embedding model at a time                    | 1000                          |
-| `compare_batch_size`   | The number of entity pairs processed in each batch during the comparison phase    | 100                           |
-| `limit_comparisons`    | Maximum number of comparisons to perform                                          | None                          |
+| Parameter                 | Description                                                                       | Default                       |
+| ------------------------- | --------------------------------------------------------------------------------- | ----------------------------- |
+| `embedding_model`         | The model to use for creating embeddings                                          | Falls back to `default_model` |
+| `resolution_model`        | The language model to use for reducing matched entries                            | Falls back to `default_model` |
+| `comparison_model`        | The language model to use for comparing potential matches                         | Falls back to `default_model` |
+| `blocking_keys`           | List of keys to use for initial blocking                                          | All keys in the input data    |
+| `blocking_threshold`      | Embedding similarity threshold for considering entries as potential matches       | None                          |
+| `blocking_conditions`     | List of conditions for initial blocking                                           | []                            |
+| `input`                   | Specifies the schema or keys to subselect from each item to pass into the prompts | All keys from input items     |
+| `embedding_batch_size`    | The number of entries to send to the embedding model at a time                    | 1000                          |
+| `compare_batch_size`      | The number of entity pairs processed in each batch during the comparison phase    | 100                           |
+| `limit_comparisons`       | Maximum number of comparisons to perform                                          | None                          |
+| `timeout`                 | Timeout for each LLM call in seconds                                              | 120                           |
+| `max_retries_per_timeout` | Maximum number of retries per timeout                                             | 2                             |
 
 ## Best Practices
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
   - Examples:
       - Reporting on Themes from Presidential Debates: examples/presidential-debate-themes.md
       - Mining Product Reviews for Polarizing Features: examples/mining-product-reviews.md
+      - Medical Document Classification with Ollama: examples/ollama.md
       # - Annotating Legal Documents: examples/annotating-legal-documents.md
       # - Characterizing Troll Behavior on Wikipedia: examples/characterizing-troll-behavior.md
   - API Reference:

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -54,7 +54,7 @@ def map_config():
         type="map",
         prompt="Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
         output={"schema": {"sentiment": "string"}},
-        model="ollama_chat/llama3",
+        model="ollama/llama3",
     )
 
 
@@ -66,7 +66,7 @@ def reduce_config():
         reduce_key="group",
         prompt="Summarize the following group of values: {{ inputs }} Provide a total and any other relevant statistics.",
         output={"schema": {"total": "number", "avg": "number"}},
-        model="ollama_chat/llama3",
+        model="ollama/llama3",
     )
 
 
@@ -95,7 +95,7 @@ def test_ollama_map_reduce_pipeline(
         output=PipelineOutput(
             type="file", path=temp_output_file, intermediate_dir=temp_intermediate_dir
         ),
-        default_model="ollama_chat/llama3",
+        default_model="ollama/llama3",
     )
 
     cost = pipeline.run()

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -15,6 +15,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Set the OLLAMA_API_BASE environment variable
+os.environ["OLLAMA_API_BASE"] = "http://localhost:11434/"
+
 
 @pytest.fixture
 def temp_input_file():


### PR DESCRIPTION
This PR introduces configurable timeouts for operations and adds comprehensive documentation for Ollama integration, enhancing our system's reliability and user guidance. This will close #23.

## Changes

1. Added support for configurable timeouts in operations
2. Implemented a new `max_retries_per_timeout` parameter (default: 2)
3. Created a new test in `test_map.py` to verify the timeout functionality
4. Added documentation for Ollama integration with timeout examples

## Details

### Timeout Implementation
- Operations now accept a `timeout` parameter in their configuration
- If a timeout occurs, the operation will retry up to `max_retries_per_timeout` times

### New Parameter
- `max_retries_per_timeout`: Controls the number of retry attempts after a timeout (default: 2)

### Testing
- Added a new test case in `test_map.py` to ensure proper functionality of the timeout feature

### Documentation
- Created new documentation for Ollama integration
- Included example of using timeouts with Ollama operations
- Provided guidance on estimating appropriate timeout values

## Usage Example

```yaml
operations:
  - name: classify_medical_record
    type: map
    timeout: 20000  # Example timeout for Ollama operation
    max_retries_per_timeout: 3
    # ... other configuration ...
```

## Benefits

- Improved handling of long-running operations, especially for Ollama integrations
- Enhanced system stability by preventing indefinite hangs
- Greater control over resource allocation and task management
- Clear guidance for users on integrating Ollama and managing timeouts