### PR TITLE
fix: manually try to parse ollama outputs, even if it is not valid json

### DIFF
--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -814,6 +814,8 @@ def parse_llm_response(
                     output_dict = json.loads(tool_call.function.arguments)
                     if "ollama" in response.model:
                         for key, value in output_dict.items():
+                            if isinstance(value, str):
+                                continue
                             try:
                                 output_dict[key] = ast.literal_eval(value)
                             except:
@@ -823,7 +825,7 @@ def parse_llm_response(
                                     else:
                                         output_dict[key] = value
                                 except:
-                                    output_dict[key] = value
+                                    pass
                     outputs.append(output_dict)
                 except json.JSONDecodeError:
                     return [{}]

--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -18,6 +18,7 @@ from diskcache import Cache
 import tiktoken
 from rich import print as rprint
 from pydantic import BaseModel, create_model
+import ast
 
 from docetl.utils import count_tokens
 
@@ -810,7 +811,20 @@ def parse_llm_response(
             outputs = []
             for tool_call in tool_calls:
                 try:
-                    outputs.append(json.loads(tool_call.function.arguments))
+                    output_dict = json.loads(tool_call.function.arguments)
+                    if "ollama" in response.model:
+                        for key, value in output_dict.items():
+                            try:
+                                output_dict[key] = ast.literal_eval(value)
+                            except:
+                                try:
+                                    if value.startswith("["):
+                                        output_dict[key] = ast.literal_eval(value + "]")
+                                    else:
+                                        output_dict[key] = value
+                                except:
+                                    output_dict[key] = value
+                    outputs.append(output_dict)
                 except json.JSONDecodeError:
                     return [{}]
             return outputs


### PR DESCRIPTION
This PR checks if the model is an ollama model and calls `ast.literal_eval` on the outputs if they are strings.

Note that this is totally a hack to solve the issue that the models are not good at coming up with structured outputs.