### PR TITLE
Add Azure Document Intelligence Read Tool

### DIFF
--- a/docetl/api.py
+++ b/docetl/api.py
@@ -50,14 +50,22 @@ Usage:
 """
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import yaml
 from rich import print
 
 from docetl.builder import Optimizer
 from docetl.runner import DSLRunner
-from docetl.schemas import Dataset, EquijoinOp, FilterOp, GatherOp, MapOp, ParallelMapOp
+from docetl.schemas import (
+    Dataset,
+    EquijoinOp,
+    FilterOp,
+    GatherOp,
+    MapOp,
+    ParallelMapOp,
+    ParsingTool,
+)
 from docetl.schemas import Pipeline as PipelineModel
 from docetl.schemas import (
     PipelineOutput,
@@ -66,7 +74,6 @@ from docetl.schemas import (
     ResolveOp,
     SplitOp,
     UnnestOp,
-    ParsingTool,
 )
 
 

--- a/docetl/builder.py
+++ b/docetl/builder.py
@@ -8,11 +8,11 @@ from collections import Counter, defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
-from docetl.dataset import Dataset, create_parsing_tool_map
 from rich.console import Console
 from rich.status import Status
 from rich.traceback import install
 
+from docetl.dataset import Dataset, create_parsing_tool_map
 from docetl.operations import get_operation
 from docetl.operations.base import BaseOperation
 from docetl.operations.utils import flush_cache

--- a/docetl/dataset.py
+++ b/docetl/dataset.py
@@ -1,9 +1,9 @@
-from typing import List, Dict, Union, Optional, Any, Callable
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from docetl.parsing_tools import PARSING_TOOLS
 from docetl.schemas import ParsingTool
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 def process_item(

--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -16,7 +16,6 @@ from dotenv import load_dotenv
 from frozendict import frozendict
 from jinja2 import Template
 from litellm import completion, embedding, model_cost
-from pydantic import create_model
 from rich import print as rprint
 from rich.console import Console
 from rich.prompt import Prompt

--- a/docetl/parsing_tools.py
+++ b/docetl/parsing_tools.py
@@ -1,6 +1,7 @@
-import os
-from typing import Optional, List
 import io
+import os
+from typing import List, Optional
+
 from litellm import transcription
 
 
@@ -223,10 +224,11 @@ def azure_di_read(
     Raises:
         ValueError: If DOCUMENTINTELLIGENCE_API_KEY or DOCUMENTINTELLIGENCE_ENDPOINT environment variables are not set.
     """
-    from azure.core.credentials import AzureKeyCredential
+    import os
+
     from azure.ai.documentintelligence import DocumentIntelligenceClient
     from azure.ai.documentintelligence.models import AnalyzeDocumentRequest
-    import os
+    from azure.core.credentials import AzureKeyCredential
 
     key = os.getenv("DOCUMENTINTELLIGENCE_API_KEY")
     endpoint = os.getenv("DOCUMENTINTELLIGENCE_ENDPOINT")

--- a/docetl/parsing_tools.py
+++ b/docetl/parsing_tools.py
@@ -135,17 +135,17 @@ def docx_to_string(filename: str) -> List[str]:
     return ["\n".join([paragraph.text for paragraph in doc.paragraphs])]
 
 
-def pptx_to_string(filename: str, slide_per_document: bool = False) -> List[str]:
+def pptx_to_string(filename: str, doc_per_slide: bool = False) -> List[str]:
     """
     Extract text from a PowerPoint presentation.
 
     Args:
         filename (str): Path to the pptx file.
-        slide_per_document (bool): If True, return each slide as a separate
+        doc_per_slide (bool): If True, return each slide as a separate
             document. If False, return the entire presentation as one document.
 
     Returns:
-        List[str]: Extracted text from the presentation. If slide_per_document
+        List[str]: Extracted text from the presentation. If doc_per_slide
             is True, each string in the list represents a single slide.
             Otherwise, the list contains a single string with all slides'
             content.
@@ -161,15 +161,133 @@ def pptx_to_string(filename: str, slide_per_document: bool = False) -> List[str]
             if hasattr(shape, "text"):
                 slide_content.append(shape.text)
 
-        if slide_per_document:
+        if doc_per_slide:
             result.append("\n".join(slide_content))
         else:
             result.extend(slide_content)
 
-    if not slide_per_document:
+    if not doc_per_slide:
         result = ["\n".join(result)]
 
     return result
+
+
+def azure_di_read(
+    filename: str,
+    use_url: bool = False,
+    include_line_numbers: bool = False,
+    include_handwritten: bool = False,
+    include_font_styles: bool = False,
+    include_selection_marks: bool = False,
+    doc_per_page: bool = False,
+) -> List[str]:
+    """
+    Extract text from a document using Azure Form Recognizer.
+
+    Used this documentation: https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/how-to-guides/use-sdk-rest-api?view=doc-intel-4.0.0&tabs=windows&pivots=programming-language-python
+
+    Args:
+        filename (str): Path to the file to be analyzed or URL of the document if use_url is True.
+        use_url (bool, optional): If True, treat filename as a URL. Defaults to False.
+        include_line_numbers (bool, optional): If True, include line numbers in the output. Defaults to False.
+        include_handwritten (bool, optional): If True, include handwritten text in the output. Defaults to False.
+        include_font_styles (bool, optional): If True, include font style information in the output. Defaults to False.
+        include_selection_marks (bool, optional): If True, include selection marks in the output. Defaults to False.
+        doc_per_page (bool, optional): If True, return each page as a separate document. Defaults to False.
+
+    Returns:
+        List[str]: Extracted text from the document. If doc_per_page is True, each string in the list represents
+                   a single page. Otherwise, the list contains a single string with all pages' content.
+
+    Raises:
+        ValueError: If DOCUMENTINTELLIGENCE_API_KEY or DOCUMENTINTELLIGENCE_ENDPOINT environment variables are not set.
+    """
+    from azure.core.credentials import AzureKeyCredential
+    from azure.ai.documentintelligence import DocumentIntelligenceClient
+    from azure.ai.documentintelligence.models import AnalyzeDocumentRequest
+    import os
+
+    key = os.getenv("DOCUMENTINTELLIGENCE_API_KEY")
+    endpoint = os.getenv("DOCUMENTINTELLIGENCE_ENDPOINT")
+
+    if key is None:
+        raise ValueError("DOCUMENTINTELLIGENCE_API_KEY environment variable is not set")
+    if endpoint is None:
+        raise ValueError(
+            "DOCUMENTINTELLIGENCE_ENDPOINT environment variable is not set"
+        )
+
+    document_analysis_client = DocumentIntelligenceClient(
+        endpoint=endpoint, credential=AzureKeyCredential(key)
+    )
+
+    if use_url:
+        poller = document_analysis_client.begin_analyze_document(
+            "prebuilt-read", AnalyzeDocumentRequest(url_source=filename)
+        )
+    else:
+        with open(filename, "rb") as f:
+            poller = document_analysis_client.begin_analyze_document("prebuilt-read", f)
+
+    result = poller.result()
+
+    style_content = []
+    content = []
+
+    if result.styles:
+        for style in result.styles:
+            if style.is_handwritten and include_handwritten:
+                handwritten_text = ",".join(
+                    [
+                        result.content[span.offset : span.offset + span.length]
+                        for span in style.spans
+                    ]
+                )
+                style_content.append(f"Handwritten content: {handwritten_text}")
+
+            if style.font_style and include_font_styles:
+                styled_text = ",".join(
+                    [
+                        result.content[span.offset : span.offset + span.length]
+                        for span in style.spans
+                    ]
+                )
+                style_content.append(f"'{style.font_style}' font style: {styled_text}")
+
+    for page in result.pages:
+        page_content = []
+
+        if page.lines:
+            for line_idx, line in enumerate(page.lines):
+                if include_line_numbers:
+                    page_content.append(f" Line #{line_idx}: {line.content}")
+                else:
+                    page_content.append(f"{line.content}")
+
+        if page.selection_marks and include_selection_marks:
+            # TODO: figure this out
+            for selection_mark_idx, selection_mark in enumerate(page.selection_marks):
+                page_content.append(
+                    f"Selection mark #{selection_mark_idx}: State is '{selection_mark.state}' within bounding polygon "
+                    f"'{selection_mark.polygon}' and has a confidence of {selection_mark.confidence}"
+                )
+
+        content.append("\n".join(page_content))
+
+    if doc_per_page:
+        return style_content + content
+    else:
+        return [
+            "\n\n".join(
+                [
+                    "\n".join(style_content),
+                    "\n\n".join(
+                        f"Page {i+1}:\n{page_content}"
+                        for i, page_content in enumerate(content)
+                    ),
+                ]
+            )
+        ]
 
 
 # Define a dictionary mapping function names to their corresponding functions
@@ -179,4 +297,5 @@ PARSING_TOOLS = {
     "txt_to_string": txt_to_string,
     "docx_to_string": docx_to_string,
     "pptx_to_string": pptx_to_string,
+    "azure_di_read": azure_di_read,
 }

--- a/docetl/parsing_tools.py
+++ b/docetl/parsing_tools.py
@@ -182,9 +182,30 @@ def azure_di_read(
     doc_per_page: bool = False,
 ) -> List[str]:
     """
-    Extract text from a document using Azure Form Recognizer.
+    Note to developers: We used this documentation: https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/how-to-guides/use-sdk-rest-api?view=doc-intel-4.0.0&tabs=windows&pivots=programming-language-python
 
-    Used this documentation: https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/how-to-guides/use-sdk-rest-api?view=doc-intel-4.0.0&tabs=windows&pivots=programming-language-python
+    This function uses Azure Document Intelligence to extract text from documents.
+    To use this function, you need to set up an Azure Document Intelligence resource:
+
+    1. Create an Azure account if you don't have one: https://azure.microsoft.com/
+    2. Set up a Document Intelligence resource in the Azure portal:
+       https://portal.azure.com/#create/Microsoft.CognitiveServicesFormRecognizer
+    3. Once created, find the resource's endpoint and key in the Azure portal
+    4. Set these as environment variables:
+       - DOCUMENTINTELLIGENCE_API_KEY: Your Azure Document Intelligence API key
+       - DOCUMENTINTELLIGENCE_ENDPOINT: Your Azure Document Intelligence endpoint URL
+
+    The function will use these credentials to authenticate with the Azure service.
+    If the environment variables are not set, the function will raise a ValueError.
+
+    The Azure Document Intelligence client is then initialized with these credentials.
+    It sends the document (either as a file or URL) to Azure for analysis.
+    The service processes the document and returns structured information about its content.
+
+    This function then extracts the text content from the returned data,
+    applying any specified formatting options (like including line numbers or font styles).
+    The extracted text is returned as a list of strings, with each string
+    representing either a page (if doc_per_page is True) or the entire document.
 
     Args:
         filename (str): Path to the file to be analyzed or URL of the document if use_url is True.

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -6,10 +6,10 @@ from typing import Dict, List, Optional, Tuple
 from dotenv import load_dotenv
 from rich.console import Console
 
+from docetl.dataset import Dataset, create_parsing_tool_map
 from docetl.operations import get_operation
 from docetl.operations.utils import flush_cache
 from docetl.utils import load_config
-from docetl.dataset import Dataset, create_parsing_tool_map
 
 load_dotenv()
 

--- a/docs/examples/custom-parsing.md
+++ b/docs/examples/custom-parsing.md
@@ -238,6 +238,10 @@ DocETL provides several built-in parsing tools to handle common file formats and
     options:
         heading_level: 3
 
+::: docetl.parsing_tools.azure_di_read
+    options:
+        heading_level: 3
+
 ### Using Function Arguments with Parsing Tools
 
 When using parsing tools in your DocETL configuration, you can pass additional arguments to the parsing functions using the function_kwargs field. This allows you to customize the behavior of the parsing tools without modifying their implementation.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,6 +14,12 @@ Before installing DocETL, ensure you have Python 3.10 or later installed on your
 pip install docetl
 ```
 
+If you want to use the parsing tools, you need to install the `parsing` extra:
+
+```bash
+pip install docetl[parsing]
+```
+
 This command will install DocETL along with its dependencies as specified in the pyproject.toml file. To verify that DocETL has been installed correctly, you can run the following command in your terminal:
 
 ```bash

--- a/poetry.lock
+++ b/poetry.lock
@@ -221,7 +221,7 @@ tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 name = "azure-ai-documentintelligence"
 version = "1.0.0b4"
 description = "Microsoft Azure AI Document Intelligence Client Library for Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "azure_ai_documentintelligence-1.0.0b4-py3-none-any.whl", hash = "sha256:c3a90560b4029e232dbab1334ac2f3dda4cae7c1f60dad277fe21a876dd6bb9f"},
@@ -234,38 +234,10 @@ isodate = ">=0.6.1"
 typing-extensions = ">=4.6.0"
 
 [[package]]
-name = "azure-ai-formrecognizer"
-version = "3.3.3"
-description = "Microsoft Azure Form Recognizer Client Library for Python"
-optional = true
-python-versions = ">=3.8"
-files = [
-    {file = "azure-ai-formrecognizer-3.3.3.tar.gz", hash = "sha256:9fc09788bbb65866630fa870cca1933bfd7298b8055236530bcc0e40d81fcccf"},
-    {file = "azure_ai_formrecognizer-3.3.3-py3-none-any.whl", hash = "sha256:81fc1abda8bd898426ee3bbc1b9c6bd164514201ce282129a31d4664f9d1f3bc"},
-]
-
-[package.dependencies]
-azure-common = ">=1.1"
-azure-core = ">=1.23.0"
-msrest = ">=0.6.21"
-typing-extensions = ">=4.0.1"
-
-[[package]]
-name = "azure-common"
-version = "1.1.28"
-description = "Microsoft Azure Client Library for Python (Common)"
-optional = true
-python-versions = "*"
-files = [
-    {file = "azure-common-1.1.28.zip", hash = "sha256:4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3"},
-    {file = "azure_common-1.1.28-py2.py3-none-any.whl", hash = "sha256:5c12d3dcf4ec20599ca6b0d3e09e86e146353d443e7fcc050c9a19c1f9df20ad"},
-]
-
-[[package]]
 name = "azure-core"
 version = "1.31.0"
 description = "Microsoft Azure Core Library for Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "azure_core-1.31.0-py3-none-any.whl", hash = "sha256:22954de3777e0250029360ef31d80448ef1be13b80a459bff80ba7073379e2cd"},
@@ -924,7 +896,7 @@ files = [
 name = "isodate"
 version = "0.6.1"
 description = "An ISO 8601 date/time/duration parser and formatter"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
@@ -1551,27 +1523,6 @@ mkdocs-autorefs = ">=1.2"
 mkdocstrings = ">=0.26"
 
 [[package]]
-name = "msrest"
-version = "0.7.1"
-description = "AutoRest swagger generator Python client runtime."
-optional = true
-python-versions = ">=3.6"
-files = [
-    {file = "msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32"},
-    {file = "msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9"},
-]
-
-[package.dependencies]
-azure-core = ">=1.24.0"
-certifi = ">=2017.4.17"
-isodate = ">=0.6.0"
-requests = ">=2.16,<3.0"
-requests-oauthlib = ">=0.5.0"
-
-[package.extras]
-async = ["aiodns", "aiohttp (>=3.0)"]
-
-[[package]]
 name = "multidict"
 version = "6.1.0"
 description = "multidict implementation"
@@ -1788,22 +1739,6 @@ files = [
     {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
     {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
 ]
-
-[[package]]
-name = "oauthlib"
-version = "3.2.2"
-description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
-optional = true
-python-versions = ">=3.6"
-files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
-]
-
-[package.extras]
-rsa = ["cryptography (>=3.0.0)"]
-signals = ["blinker (>=1.4.0)"]
-signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "openai"
@@ -2542,24 +2477,6 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-description = "OAuthlib authentication support for Requests."
-optional = true
-python-versions = ">=3.4"
-files = [
-    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
-    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
-]
-
-[package.dependencies]
-oauthlib = ">=3.0.0"
-requests = ">=2.0.0"
-
-[package.extras]
-rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rich"
@@ -3340,9 +3257,9 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-parsing = ["azure-ai-formrecognizer", "openpyxl", "pydub", "python-docx", "python-pptx"]
+parsing = ["azure-ai-documentintelligence", "openpyxl", "pydub", "python-docx", "python-pptx"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4e2139c07778a822cef8e8319751bb0a155c13548e51e5cde4ece70b354ac5b6"
+content-hash = "71b11942f4d91ce82d420a95adf3e0e5ec1ee7cbdf626c257171d174b203ccf9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -218,6 +218,69 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "azure-ai-documentintelligence"
+version = "1.0.0b4"
+description = "Microsoft Azure AI Document Intelligence Client Library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "azure_ai_documentintelligence-1.0.0b4-py3-none-any.whl", hash = "sha256:c3a90560b4029e232dbab1334ac2f3dda4cae7c1f60dad277fe21a876dd6bb9f"},
+    {file = "azure_ai_documentintelligence-1.0.0b4.tar.gz", hash = "sha256:1aa36f0617b0c129fdc82b039b7084fd5b69af08e8e0cb500108b9f6efd61b36"},
+]
+
+[package.dependencies]
+azure-core = ">=1.30.0"
+isodate = ">=0.6.1"
+typing-extensions = ">=4.6.0"
+
+[[package]]
+name = "azure-ai-formrecognizer"
+version = "3.3.3"
+description = "Microsoft Azure Form Recognizer Client Library for Python"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "azure-ai-formrecognizer-3.3.3.tar.gz", hash = "sha256:9fc09788bbb65866630fa870cca1933bfd7298b8055236530bcc0e40d81fcccf"},
+    {file = "azure_ai_formrecognizer-3.3.3-py3-none-any.whl", hash = "sha256:81fc1abda8bd898426ee3bbc1b9c6bd164514201ce282129a31d4664f9d1f3bc"},
+]
+
+[package.dependencies]
+azure-common = ">=1.1"
+azure-core = ">=1.23.0"
+msrest = ">=0.6.21"
+typing-extensions = ">=4.0.1"
+
+[[package]]
+name = "azure-common"
+version = "1.1.28"
+description = "Microsoft Azure Client Library for Python (Common)"
+optional = true
+python-versions = "*"
+files = [
+    {file = "azure-common-1.1.28.zip", hash = "sha256:4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3"},
+    {file = "azure_common-1.1.28-py2.py3-none-any.whl", hash = "sha256:5c12d3dcf4ec20599ca6b0d3e09e86e146353d443e7fcc050c9a19c1f9df20ad"},
+]
+
+[[package]]
+name = "azure-core"
+version = "1.31.0"
+description = "Microsoft Azure Core Library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "azure_core-1.31.0-py3-none-any.whl", hash = "sha256:22954de3777e0250029360ef31d80448ef1be13b80a459bff80ba7073379e2cd"},
+    {file = "azure_core-1.31.0.tar.gz", hash = "sha256:656a0dd61e1869b1506b7c6a3b31d62f15984b1a573d6326f6aa2f3e4123284b"},
+]
+
+[package.dependencies]
+requests = ">=2.21.0"
+six = ">=1.11.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["aiohttp (>=3.0)"]
+
+[[package]]
 name = "babel"
 version = "2.16.0"
 description = "Internationalization utilities"
@@ -858,6 +921,20 @@ files = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.6.1"
+description = "An ISO 8601 date/time/duration parser and formatter"
+optional = false
+python-versions = "*"
+files = [
+    {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
+    {file = "isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"},
+]
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "jinja2"
 version = "3.1.4"
 description = "A very fast and expressive template engine."
@@ -1474,6 +1551,27 @@ mkdocs-autorefs = ">=1.2"
 mkdocstrings = ">=0.26"
 
 [[package]]
+name = "msrest"
+version = "0.7.1"
+description = "AutoRest swagger generator Python client runtime."
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32"},
+    {file = "msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9"},
+]
+
+[package.dependencies]
+azure-core = ">=1.24.0"
+certifi = ">=2017.4.17"
+isodate = ">=0.6.0"
+requests = ">=2.16,<3.0"
+requests-oauthlib = ">=0.5.0"
+
+[package.extras]
+async = ["aiodns", "aiohttp (>=3.0)"]
+
+[[package]]
 name = "multidict"
 version = "6.1.0"
 description = "multidict implementation"
@@ -1690,6 +1788,22 @@ files = [
     {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
     {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
 ]
+
+[[package]]
+name = "oauthlib"
+version = "3.2.2"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
+    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
+]
+
+[package.extras]
+rsa = ["cryptography (>=3.0.0)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "openai"
@@ -2428,6 +2542,24 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+description = "OAuthlib authentication support for Requests."
+optional = true
+python-versions = ">=3.4"
+files = [
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
+]
+
+[package.dependencies]
+oauthlib = ">=3.0.0"
+requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rich"
@@ -3208,9 +3340,9 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-parsing = ["openpyxl", "pydub", "python-docx", "python-pptx"]
+parsing = ["azure-ai-formrecognizer", "openpyxl", "pydub", "python-docx", "python-pptx"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8a6c32c6ced43a22fb24cc0449bee9bf1079c703dc0467d655a99ea53f60f00c"
+content-hash = "4e2139c07778a822cef8e8319751bb0a155c13548e51e5cde4ece70b354ac5b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,10 @@ openpyxl = { version = "^3.1.5", optional = true }
 python-docx = { version = "^1.1.2", optional = true }
 pydub = { version = "^0.25.1", optional = true }
 python-pptx = { version = "^1.0.2", optional = true }
+azure-ai-documentintelligence = { version = "^1.0.0b4", optional = true }
 
 [tool.poetry.extras]
-parsing = ["python-docx", "openpyxl", "pydub", "python-pptx"]
+parsing = ["python-docx", "openpyxl", "pydub", "python-pptx", "azure-ai-documentintelligence"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/tests/test_parsing_tools.py
+++ b/tests/test_parsing_tools.py
@@ -139,8 +139,8 @@ def test_pptx_to_string(temp_pptx_file):
     assert "This is the second slide" in result[0]
 
 
-def test_pptx_to_string_slide_per_document(temp_pptx_file):
-    result = parsing_tools.pptx_to_string(temp_pptx_file, slide_per_document=True)
+def test_pptx_to_string_doc_per_slide(temp_pptx_file):
+    result = parsing_tools.pptx_to_string(temp_pptx_file, doc_per_slide=True)
 
     assert isinstance(result, list)
     assert len(result) == 2
@@ -148,6 +148,45 @@ def test_pptx_to_string_slide_per_document(temp_pptx_file):
     assert "This is the first slide" in result[0]
     assert "Second Slide" in result[1]
     assert "This is the second slide" in result[1]
+
+
+@pytest.fixture
+def pdf_url():
+    return "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-REST-api-samples/master/curl/form-recognizer/rest-api/read.png"
+
+
+def test_azure_di_read(pdf_url):
+    # Test with default parameters
+    result = parsing_tools.azure_di_read(pdf_url, use_url=True)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    content = result[0]
+
+    # Check for expected content in the extracted text
+    assert "While healthcare is still in the early stages of its" in content
+    assert "seeing pharmaceutical and other life sciences organizations" in content
+    assert "Enhancing the patient" in content
+
+    # Test with include_line_numbers=True
+    result_line_numbers = parsing_tools.azure_di_read(
+        pdf_url, use_url=True, include_line_numbers=True
+    )
+    assert isinstance(result_line_numbers, list)
+    assert len(result_line_numbers) == 1
+    assert any("Line #" in line for line in result_line_numbers[0].split("\n"))
+
+
+def test_azure_di_read_invoice():
+    invoice_url = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-REST-api-samples/master/curl/form-recognizer/sample-invoice.pdf"
+    result = parsing_tools.azure_di_read(invoice_url, use_url=True)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    content = result[0]
+
+    # Check for expected content in the extracted text
+    assert "Contoso" in content
 
 
 # Clean up temporary files after all tests have passed


### PR DESCRIPTION
This PR introduces a new parsing tool, `azure_di_read`, which leverages Azure's Document Intelligence service to extract text from various document types, including PDFs, images, and scanned documents.

## Features

- Extracts text from documents using Azure Form Recognizer
- Supports both local files and URLs
- Configurable options for including line numbers, handwritten text, font styles, and selection marks
- Option to return each page as a separate document or combine all pages into a single output

## Usage

To use this new tool, users need to:

1. Set up Azure Document Intelligence service and obtain API credentials
2. Set environment variables for `DOCUMENTINTELLIGENCE_API_KEY` and `DOCUMENTINTELLIGENCE_ENDPOINT`
3. Configure the parsing tool in their DocETL pipeline configuration

Example configuration:

```yaml
datasets:
  documents:
    type: file
    source: local
    path: "document_paths.json"
    parsing:
      - input_key: document_path
        function: azure_di_read
        output_key: extracted_text
        function_kwargs:
          include_line_numbers: true
          include_handwritten: true
```

## Testing

A new test case has been added to verify the functionality of the `azure_di_read` tool.

## Documentation

The `azure_di_read` function is documented with a docstring, explaining its parameters and usage. Additional documentation has been added to the parsing tools section of the project documentation.

**Note that this requires the user to have set up Azure Document Intelligence. This is not great; we should explore an off-the-shelf OCR option** as discussed in #3 