### PR TITLE
fix: default to gpt 4o tokenizer

### DIFF
--- a/docetl/optimizers/join_optimizer.py
+++ b/docetl/optimizers/join_optimizer.py
@@ -1294,7 +1294,7 @@ class JoinOptimizer:
                         "Here are up to 3 examples of incorrectly filtered pairs:\n"
                     )
                     for i, j in filtered_pairs[:3]:
-                        feedback += f"Item 1: {json.dumps({key: input_data[i][key] for key in blocking_keys})}\Item 2: {json.dumps({key: input_data[j][key] for key in blocking_keys})}\n"
+                        feedback += f"Item 1: {json.dumps({key: input_data[i][key] for key in blocking_keys})}\nItem 2: {json.dumps({key: input_data[j][key] for key in blocking_keys})}\n"
                         feedback += "These pairs are known matches but were filtered out by the rule.\n"
                     feedback += "Please generate a new rule that doesn't filter out these matches."
 

--- a/docetl/utils.py
+++ b/docetl/utils.py
@@ -78,8 +78,9 @@ def count_tokens(text: str, model: str) -> int:
     """
     Count the number of tokens in a string using the specified model.
     """
+    model_name = model.replace("azure/", "")
     try:
-        encoder = tiktoken.encoding_for_model(model)
+        encoder = tiktoken.encoding_for_model(model_name)
         return len(encoder.encode(text))
     except Exception:
         # Use gpt-4o-mini to count tokens for other models

--- a/docetl/utils.py
+++ b/docetl/utils.py
@@ -78,8 +78,13 @@ def count_tokens(text: str, model: str) -> int:
     """
     Count the number of tokens in a string using the specified model.
     """
-    encoder = tiktoken.encoding_for_model(model)
-    return len(encoder.encode(text))
+    try:
+        encoder = tiktoken.encoding_for_model(model)
+        return len(encoder.encode(text))
+    except Exception:
+        # Use gpt-4o-mini to count tokens for other models
+        encoder = tiktoken.encoding_for_model("gpt-4o")
+        return len(encoder.encode(text))
 
 
 def truncate_sample_data(


### PR DESCRIPTION
Fixes #56 -- where pipelines fail if using an azure gpt model, since `azure/` is not a prefix one can search for in the tiktoken encoding map.