### PR TITLE
Add Operation Hash and Caching Functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ tests:
 tests-basic:
 	poetry run pytest tests/basic
 	poetry run pytest tests/test_api.py
+	poetry run pytest tests/test_runner_caching.py
 
 lint:
 	poetry run ruff check docetl/* --fix

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -76,11 +76,13 @@ class DSLRunner:
         self.step_op_hashes = defaultdict(dict)
         for step in self.config["pipeline"]["steps"]:
             for idx, op in enumerate(step["operations"]):
+                op_name = op if isinstance(op, str) else list(op.keys())[0]
+
                 all_ops_until_and_including_current = [
                     op_map[prev_op] for prev_op in step["operations"][:idx]
-                ] + [op_map[op]]
+                ] + [op_map[op_name]]
                 all_ops_str = json.dumps(all_ops_until_and_including_current)
-                self.step_op_hashes[step["name"]][op] = hashlib.sha256(
+                self.step_op_hashes[step["name"]][op_name] = hashlib.sha256(
                     all_ops_str.encode()
                 ).hexdigest()
 

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -166,11 +166,13 @@ class DSLRunner:
             self.datasets[self.config["pipeline"]["steps"][-1]["name"]].load()
         )
 
-        # Save the self.step_op_hashes to a file
-        with open(
-            os.path.join(self.intermediate_dir, ".docetl_intermediate_config.json"), "w"
-        ) as f:
-            json.dump(self.step_op_hashes, f)
+        # Save the self.step_op_hashes to a file if self.intermediate_dir exists
+        if self.intermediate_dir:
+            with open(
+                os.path.join(self.intermediate_dir, ".docetl_intermediate_config.json"),
+                "w",
+            ) as f:
+                json.dump(self.step_op_hashes, f)
 
         self.console.rule("[bold green]Execution Summary[/bold green]")
         self.console.print(f"[bold green]Total cost: [green]${total_cost:.2f}[/green]")

--- a/tests/test_runner_caching.py
+++ b/tests/test_runner_caching.py
@@ -1,0 +1,119 @@
+import time
+import pytest
+import json
+import tempfile
+import os
+from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
+
+
+@pytest.fixture
+def temp_input_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as tmp:
+        json.dump(
+            [
+                {"text": "This is a test sentence."},
+                {"text": "Another test sentence."},
+            ],
+            tmp,
+        )
+    yield tmp.name
+    os.unlink(tmp.name)
+
+
+@pytest.fixture
+def temp_output_file():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as tmp:
+        pass
+    yield tmp.name
+    os.unlink(tmp.name)
+
+
+@pytest.fixture
+def temp_intermediate_dir():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield tmpdirname
+
+
+def create_pipeline(input_file, output_file, intermediate_dir, operation_prompt):
+    return Pipeline(
+        name="test_pipeline",
+        datasets={"test_input": Dataset(type="file", path=input_file)},
+        operations=[
+            MapOp(
+                name="test_operation",
+                type="map",
+                prompt=operation_prompt,
+                output={"schema": {"result": "string"}},
+            )
+        ],
+        steps=[
+            PipelineStep(
+                name="test_step", input="test_input", operations=["test_operation"]
+            ),
+        ],
+        output=PipelineOutput(
+            type="file", path=output_file, intermediate_dir=intermediate_dir
+        ),
+        default_model="gpt-4o-mini",
+    )
+
+
+def test_pipeline_rerun_on_operation_change(
+    temp_input_file, temp_output_file, temp_intermediate_dir
+):
+    # Initial run
+    initial_prompt = "Analyze the sentiment of the following text: '{{ input.text }}'"
+    pipeline = create_pipeline(
+        temp_input_file, temp_output_file, temp_intermediate_dir, initial_prompt
+    )
+    initial_cost = pipeline.run()
+
+    # Check that intermediate files were created
+    assert os.path.exists(
+        os.path.join(temp_intermediate_dir, "test_step", "test_operation.json")
+    )
+
+    # Run without modifying the operation
+    unmodified_cost = pipeline.run()
+
+    # Check that the pipeline was not rerun (cost should be zero)
+    assert unmodified_cost == 0
+
+    # Record the start time
+    start_time = time.time()
+
+    # Run again without changes
+    _ = pipeline.run()
+
+    # Record the end time
+    end_time = time.time()
+
+    # Calculate and store the runtime
+    unmodified_runtime = end_time - start_time
+
+    # Modify the operation
+    modified_prompt = "Count the words in the following text: '{{ input.text }}'"
+    modified_pipeline = create_pipeline(
+        temp_input_file, temp_output_file, temp_intermediate_dir, modified_prompt
+    )
+
+    # Record the start time
+    start_time = time.time()
+
+    _ = modified_pipeline.run()
+
+    # Record the end time
+    end_time = time.time()
+
+    # Calculate and store the runtime
+    modified_runtime = end_time - start_time
+
+    # Check that the intermediate files were updated
+    with open(
+        os.path.join(temp_intermediate_dir, "test_step", "test_operation.json"), "r"
+    ) as f:
+        intermediate_data = json.load(f)
+    assert any("word" in str(item).lower() for item in intermediate_data)
+
+    # Check that the runtime is faster when not modifying
+    assert unmodified_runtime < modified_runtime


### PR DESCRIPTION
Closes #49 

## Summary
This PR introduces a new caching mechanism based on operation hashes, allowing for more efficient pipeline execution by skipping previously completed operations when their configurations haven't changed.

## Changes
- Added `step_op_hashes` to `DSLRunner` to store hashes of operation configurations
- Implemented hashing logic for each step _and_ operation in the pipeline
- Modified `execute_step` to check for existing cached results before running operations
- Added `_load_from_checkpoint_if_exists` method to load cached data if available
- Updated `_save_checkpoint` to save operation hashes along with data
- Added logic to save and load `.docetl_intermediate_config.json` for persistent caching

## Implementation Details
- Operation hashes are calculated using SHA256 on the JSON representation of operation configurations (up until and including an operation)
- Hashes are stored in a nested dictionary structure: `{step_name: {operation_name: hash}}`
- Before executing an operation, the runner checks if a cached result exists with a matching hash
- If a match is found, the cached data is loaded instead of re-running the operation
- After each operation, results are cached along with their corresponding hash