### PR TITLE
(partial) fix: add exponential backoff for rate limit errors

### DIFF
--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -430,8 +430,8 @@ def call_llm(
         except RateLimitError:
             # TODO: this is a really hacky way to handle rate limits
             # we should implement a more robust retry mechanism
-            backoff_time = 0.1 * (2**rate_limited_attempt)  # Exponential backoff
-            max_backoff = 60  # Maximum backoff time of 60 seconds
+            backoff_time = 4 * (2**rate_limited_attempt)  # Exponential backoff
+            max_backoff = 120  # Maximum backoff time of 60 seconds
             sleep_time = min(backoff_time, max_backoff)
             console.log(
                 f"[yellow]Rate limit hit. Retrying in {sleep_time:.2f} seconds...[/yellow]"

--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -414,7 +414,9 @@ def call_llm(
     key = cache_key(model, op_type, messages, output_schema, scratchpad)
 
     max_retries = max_retries_per_timeout
-    for attempt in range(max_retries + 1):
+    attempt = 0
+    rate_limited_attempt = 0
+    while attempt <= max_retries:
         try:
             return timeout(timeout_seconds)(cached_call_llm)(
                 key,
@@ -426,20 +428,24 @@ def call_llm(
                 scratchpad,
             )
         except RateLimitError:
-            if attempt == max_retries - 1:
-                console.log(
-                    f"[bold red]LLM call timed out after {max_retries} retries[/bold red]"
-                )
-                # TODO: HITL
-                return {}
-            time.sleep(0.1)
+            # TODO: this is a really hacky way to handle rate limits
+            # we should implement a more robust retry mechanism
+            backoff_time = 0.1 * (2**rate_limited_attempt)  # Exponential backoff
+            max_backoff = 60  # Maximum backoff time of 60 seconds
+            sleep_time = min(backoff_time, max_backoff)
+            console.log(
+                f"[yellow]Rate limit hit. Retrying in {sleep_time:.2f} seconds...[/yellow]"
+            )
+            time.sleep(sleep_time)
+            rate_limited_attempt += 1
         except TimeoutError:
-            if attempt == max_retries - 1:
+            if attempt == max_retries:
                 console.log(
-                    f"[bold red]LLM call timed out after {max_retries} retries[/bold red]"
+                    f"[bold red]LLM call timed out after {max_retries + 1} attempts[/bold red]"
                 )
                 # TODO: HITL
                 return {}
+            attempt += 1
 
 
 class InvalidOutputError(Exception):

--- a/tests/test_azure_rl.py
+++ b/tests/test_azure_rl.py
@@ -1,0 +1,58 @@
+import pytest
+from docetl.operations.map import MapOperation
+import random
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+# @pytest.fixture
+def simple_map_config():
+    return {
+        "name": "simple_sentiment_analysis",
+        "type": "map",
+        "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
+        "output": {"schema": {"sentiment": "string"}},
+        "model": "azure/gpt-4o",
+    }
+
+
+# @pytest.fixture
+def sample_documents():
+    sentiments = ["positive", "negative", "neutral"]
+    documents = []
+    for _ in range(15):
+        sentiment = random.choice(sentiments)
+        if sentiment == "positive":
+            text = f"I absolutely love this product! It's amazing and works perfectly."
+        elif sentiment == "negative":
+            text = f"This is the worst experience I've ever had. Terrible service."
+        else:
+            text = f"The product works as expected. Nothing special to report."
+        documents.append({"text": text})
+    return documents
+
+
+def test_map_operation_over_15_documents():
+    # Set environment variables specific to this test
+    os.environ["AZURE_API_BASE"] = os.getenv("LOW_RES_AZURE_API_BASE")
+    os.environ["AZURE_API_VERSION"] = os.getenv("LOW_RES_AZURE_API_VERSION")
+    os.environ["AZURE_API_KEY"] = os.getenv("LOW_RES_AZURE_API_KEY")
+
+    smc = simple_map_config()
+    sd = sample_documents()
+
+    operation = MapOperation(smc, "azure/gpt-4o", 4)
+    results, cost = operation.execute(sd)
+
+    assert len(results) == 15
+    assert all("sentiment" in result for result in results)
+    assert all(
+        result["sentiment"] in ["positive", "negative", "neutral"] for result in results
+    )
+    assert cost > 0
+
+
+if __name__ == "__main__":
+    test_map_operation_over_15_documents()

--- a/tests/test_azure_rl.py
+++ b/tests/test_azure_rl.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-# @pytest.fixture
+@pytest.fixture
 def simple_map_config():
     return {
         "name": "simple_sentiment_analysis",
@@ -18,11 +18,11 @@ def simple_map_config():
     }
 
 
-# @pytest.fixture
+@pytest.fixture
 def sample_documents():
     sentiments = ["positive", "negative", "neutral"]
     documents = []
-    for _ in range(15):
+    for _ in range(8):
         sentiment = random.choice(sentiments)
         if sentiment == "positive":
             text = f"I absolutely love this product! It's amazing and works perfectly."
@@ -34,17 +34,14 @@ def sample_documents():
     return documents
 
 
-def test_map_operation_over_15_documents():
+def test_map_operation_over_15_documents(simple_map_config, sample_documents):
     # Set environment variables specific to this test
     os.environ["AZURE_API_BASE"] = os.getenv("LOW_RES_AZURE_API_BASE")
     os.environ["AZURE_API_VERSION"] = os.getenv("LOW_RES_AZURE_API_VERSION")
     os.environ["AZURE_API_KEY"] = os.getenv("LOW_RES_AZURE_API_KEY")
 
-    smc = simple_map_config()
-    sd = sample_documents()
-
-    operation = MapOperation(smc, "azure/gpt-4o", 4)
-    results, cost = operation.execute(sd)
+    operation = MapOperation(simple_map_config, "azure/gpt-4o", 4)
+    results, cost = operation.execute(sample_documents)
 
     assert len(results) == 15
     assert all("sentiment" in result for result in results)
@@ -52,7 +49,3 @@ def test_map_operation_over_15_documents():
         result["sentiment"] in ["positive", "negative", "neutral"] for result in results
     )
     assert cost > 0
-
-
-if __name__ == "__main__":
-    test_map_operation_over_15_documents()


### PR DESCRIPTION
This is a very hacky fix, but this PR adds exponential backoff logic for `call_llm` whenever there is a RateLimitError. It does it until the operation fully completes. It does not address #46, but at least it makes docetl usable...