### PR TITLE
Add support for LiteLLM proxy

### DIFF
--- a/docetl/api.py
+++ b/docetl/api.py
@@ -117,6 +117,7 @@ class Pipeline(PipelineModel):
             steps=self.steps,
             output=self.output,
             default_model=self.default_model,
+            proxy_url=self.proxy_url,
             parsing_tools=self.parsing_tools,
         )
         updated_pipeline._update_from_dict(optimized_config)
@@ -176,6 +177,7 @@ class Pipeline(PipelineModel):
                 "output": self.output.dict(),
             },
             "default_model": self.default_model,
+            "proxy_url": self.proxy_url,
             "parsing_tools": (
                 [tool.dict() for tool in self.parsing_tools]
                 if self.parsing_tools

--- a/docetl/operations/base.py
+++ b/docetl/operations/base.py
@@ -3,6 +3,7 @@ The BaseOperation class is an abstract base class for all operations in the doce
 """
 
 from abc import ABC, abstractmethod
+from openai import Client
 from typing import Dict, List, Optional, Tuple
 
 from rich.console import Console
@@ -17,6 +18,7 @@ class BaseOperation(ABC):
         max_threads: int,
         console: Optional[Console] = None,
         status: Optional[Status] = None,
+        client: Optional[Client] = None,
         **kwargs,
     ):
         """
@@ -36,6 +38,7 @@ class BaseOperation(ABC):
         self.console = console or Console()
         self.manually_fix_errors = self.config.get("manually_fix_errors", False)
         self.status = status
+        self.client = client
         self.num_retries_on_validate_failure = self.config.get(
             "num_retries_on_validate_failure", 0
         )

--- a/docetl/operations/filter.py
+++ b/docetl/operations/filter.py
@@ -146,6 +146,7 @@ class FilterOperation(BaseOperation):
                     max_retries_per_timeout=self.config.get(
                         "max_retries_per_timeout", 2
                     ),
+                    client=self.client,
                 ),
                 validation_fn=validation_fn,
                 val_rule=self.config.get("validate", []),

--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -174,6 +174,7 @@ class MapOperation(BaseOperation):
                         max_retries_per_timeout=self.config.get(
                             "max_retries_per_timeout", 2
                         ),
+                        client=self.client,
                     ),
                     validation_fn=validation_fn,
                     val_rule=self.config.get("validate", []),
@@ -194,6 +195,7 @@ class MapOperation(BaseOperation):
                         max_retries_per_timeout=self.config.get(
                             "max_retries_per_timeout", 2
                         ),
+                        client=self.client,
                     ),
                     validation_fn=validation_fn,
                     val_rule=self.config.get("validate", []),
@@ -377,6 +379,7 @@ class ParallelMapOperation(BaseOperation):
                 console=self.console,
                 timeout_seconds=self.config.get("timeout", 120),
                 max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
+                client=self.client,
             )
             output = parse_llm_response(
                 response,

--- a/docetl/operations/reduce.py
+++ b/docetl/operations/reduce.py
@@ -375,7 +375,9 @@ class ReduceOperation(BaseOperation):
         if sample_size >= len(group_list):
             return group_list, 0
 
-        clusters, cost = cluster_documents(group_list, value_sampling, sample_size)
+        clusters, cost = cluster_documents(
+            group_list, value_sampling, sample_size, self.client
+        )
 
         sampled_items = []
         idx_added_already = set()
@@ -413,9 +415,13 @@ class ReduceOperation(BaseOperation):
             reduce_key=dict(zip(self.config["reduce_key"], key))
         )
 
-        embeddings, cost = get_embeddings_for_clustering(group_list, value_sampling)
+        embeddings, cost = get_embeddings_for_clustering(
+            group_list, value_sampling, client=self.client
+        )
 
-        query_response = gen_embedding(embedding_model, [query_text])
+        query_response = gen_embedding(
+            embedding_model, [query_text], client=self.client
+        )
         query_embedding = query_response["data"][0]["embedding"]
         cost += completion_cost(query_response)
 
@@ -692,6 +698,7 @@ class ReduceOperation(BaseOperation):
             console=self.console,
             timeout_seconds=self.config.get("timeout", 120),
             max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
+            client=self.client,
         )
         folded_output = parse_llm_response(
             response,
@@ -737,6 +744,7 @@ class ReduceOperation(BaseOperation):
             console=self.console,
             timeout_seconds=self.config.get("timeout", 120),
             max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
+            client=self.client,
         )
         merged_output = parse_llm_response(response, self.config["output"]["schema"])[0]
         merged_output.update(dict(zip(self.config["reduce_key"], key)))
@@ -831,6 +839,7 @@ class ReduceOperation(BaseOperation):
                 console=self.console,
                 timeout_seconds=self.config.get("timeout", 120),
                 max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
+                client=self.client,
             )
             item_cost += gleaning_cost
         else:
@@ -843,6 +852,7 @@ class ReduceOperation(BaseOperation):
                 scratchpad=scratchpad,
                 timeout_seconds=self.config.get("timeout", 120),
                 max_retries_per_timeout=self.config.get("max_retries_per_timeout", 2),
+                client=self.client,
             )
 
         item_cost += completion_cost(response)

--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -517,9 +517,9 @@ def call_llm_with_cache(
                 "function": {
                     "name": "send_output",
                     "description": "Send structured output back to the user",
-                    # "strict": True,
+                    "strict": True,
                     "parameters": parameters,
-                    # "additionalProperties": False,
+                    "additionalProperties": False,
                 },
             }
         ]

--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -517,9 +517,9 @@ def call_llm_with_cache(
                 "function": {
                     "name": "send_output",
                     "description": "Send structured output back to the user",
-                    "strict": True,
+                    # "strict": True,
                     "parameters": parameters,
-                    "additionalProperties": False,
+                    # "additionalProperties": False,
                 },
             }
         ]
@@ -560,7 +560,7 @@ Remember: The scratchpad should contain information necessary for processing fut
     # Truncate messages if they exceed the model's context length
     messages = truncate_messages(messages, model)
 
-    completion_func = completion if client is None else client.completions.create
+    completion_func = completion if client is None else client.chat.completions.create
 
     if response_format is None:
         response = completion_func(

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -4,6 +4,7 @@ import time
 from typing import Dict, List, Optional, Tuple
 
 from dotenv import load_dotenv
+from openai import Client
 from rich.console import Console
 
 from docetl.dataset import Dataset, create_parsing_tool_map
@@ -64,6 +65,13 @@ class DSLRunner:
             raise ValueError(
                 "No output path specified in the configuration. Please provide an output path ending with '.json' in the configuration."
             )
+        
+        proxy_url = self.config.get("proxy_url")
+        self.client = (
+            Client(base_url=proxy_url, api_key=os.getenv("DOCETL_PROXY_API_KEY"))
+            if self.proxy_url
+            else None
+        )
 
         self.syntax_check()
 
@@ -250,6 +258,7 @@ class DSLRunner:
                     self.max_threads,
                     self.console,
                     self.status,
+                    self.client,
                 )
                 if op_object["type"] == "equijoin":
                     left_data = self.datasets[op_object["left"]].load()

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -68,11 +68,10 @@ class DSLRunner:
 
         proxy_url = self.config.get("proxy_url")
         self.client = (
-            Client(base_url=proxy_url, api_key=os.getenv("DOCETL_PROXY_API_KEY"))
+            Client(base_url=proxy_url, api_key=os.getenv("DOCETL_PROXY_API_KEY", "EMPTY"))
             if proxy_url
             else None
         )
-
         self.syntax_check()
 
     @classmethod

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -65,11 +65,11 @@ class DSLRunner:
             raise ValueError(
                 "No output path specified in the configuration. Please provide an output path ending with '.json' in the configuration."
             )
-        
+
         proxy_url = self.config.get("proxy_url")
         self.client = (
             Client(base_url=proxy_url, api_key=os.getenv("DOCETL_PROXY_API_KEY"))
-            if self.proxy_url
+            if proxy_url
             else None
         )
 

--- a/docetl/schemas.py
+++ b/docetl/schemas.py
@@ -372,6 +372,7 @@ class Pipeline(BaseModel):
     output: PipelineOutput
     parsing_tools: List[ParsingTool] = []
     default_model: Optional[str] = None
+    proxy_url: Optional[str] = None
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,112 @@
+import shutil
+import pytest
+import json
+import tempfile
+import os
+from docetl.api import (
+    Pipeline,
+    Dataset,
+    MapOp,
+    ReduceOp,
+    PipelineStep,
+    PipelineOutput,
+)
+from dotenv import load_dotenv
+
+load_dotenv()
+
+LITELLM_MODEL = "my-ollama-model"
+PROXY_URL = "http://0.0.0.0:4000"
+
+
+@pytest.fixture
+def temp_input_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as tmp:
+        json.dump(
+            [
+                {"text": "This is a test", "group": "A"},
+                {"text": "Another test", "group": "B"},
+            ],
+            tmp,
+        )
+    yield tmp.name
+    os.unlink(tmp.name)
+
+
+@pytest.fixture
+def temp_output_file():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as tmp:
+        pass
+    yield tmp.name
+    os.unlink(tmp.name)
+
+
+@pytest.fixture
+def temp_intermediate_dir():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield tmpdirname
+
+
+@pytest.fixture
+def map_config():
+    return MapOp(
+        name="sentiment_analysis",
+        type="map",
+        prompt="Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
+        output={"schema": {"sentiment": "string"}},
+    )
+
+
+@pytest.fixture
+def reduce_config():
+    return ReduceOp(
+        name="group_summary",
+        type="reduce",
+        reduce_key="group",
+        prompt="Summarize the following group of values: {{ inputs }} Provide a total and any other relevant statistics.",
+        output={"schema": {"total": "number", "avg": "number"}},
+    )
+
+
+@pytest.fixture(autouse=True)
+def remove_openai_api_key():
+    openai_api_key = os.environ.pop("OPENAI_API_KEY", None)
+    yield
+    if openai_api_key:
+        os.environ["OPENAI_API_KEY"] = openai_api_key
+
+
+def test_proxy_map_reduce_pipeline(
+    map_config, reduce_config, temp_input_file, temp_output_file, temp_intermediate_dir
+):
+    pipeline = Pipeline(
+        name="test_proxy_pipeline",
+        datasets={"test_input": Dataset(type="file", path=temp_input_file)},
+        operations=[map_config, reduce_config],
+        steps=[
+            PipelineStep(
+                name="pipeline",
+                input="test_input",
+                operations=["sentiment_analysis", "group_summary"],
+            ),
+        ],
+        output=PipelineOutput(
+            type="file", path=temp_output_file, intermediate_dir=temp_intermediate_dir
+        ),
+        default_model=LITELLM_MODEL,
+        proxy_url=PROXY_URL,
+    )
+
+    cost = pipeline.run()
+
+    assert isinstance(cost, float)
+    assert cost == 0
+
+    # Verify output file exists and contains data
+    assert os.path.exists(temp_output_file)
+    with open(temp_output_file, "r") as f:
+        output_data = json.load(f)
+    assert len(output_data) > 0
+
+    # Clean up
+    shutil.rmtree(temp_intermediate_dir)


### PR DESCRIPTION
Find corresponding issue here: https://github.com/ucbepic/docetl/issues/35

- Proposes to simplify accessing model through a (LiteLLM) proxy by adding an optional top level configuration option `proxy_url` to to configuration files
- API key to proxy can be set with environment variable `DOCETL_PROXY_API_KEY`
- If `proxy_url` is not set all completion / embedding calls are still made through the LiteLLM Python SDK.

Test more or less copy pasted from the Ollama one, we could potentially generalize a bit there.

NB my original intention was to use this to have DocETL use vLLM hosted models. That's still not working because of incompatibility with some of the nested parameters of keyword `function` (`strict` and `additionalProperties`) of `client.chat.completions.create`. Regardless, this should be a useful addition in itself

I'll wait for comments on my general setup before solving the merge conflicts.