### PR TITLE
fix: enable gleaning llm calls to work

### DIFF
--- a/docetl/operations/base.py
+++ b/docetl/operations/base.py
@@ -30,6 +30,7 @@ class BaseOperation(ABC):
             status (Optional[Status]): Rich status for displaying progress. Defaults to None.
         """
         assert "name" in config, "Operation must have a name"
+        assert "type" in config, "Operation must have a type"
         self.config = config
         self.default_model = default_model
         self.max_threads = max_threads

--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -733,7 +733,7 @@ def call_llm_with_gleaning(
     cost = 0.0
 
     # Parse the response
-    parsed_response = parse_llm_response(response, output_schema, messages=messages)
+    parsed_response = parse_llm_response(response, output_schema)
     output = parsed_response[0]
 
     messages = (

--- a/tests/basic/test_basic_map.py
+++ b/tests/basic/test_basic_map.py
@@ -174,7 +174,7 @@ def test_map_operation_with_timeout(simple_map_config, simple_sample_data):
         operation.execute(simple_sample_data)
 
 
-def test_map_operation_with_gleaning(simple_map_config, simple_sample_data):
+def test_map_operation_with_gleaning(simple_map_config, map_sample_data):
     # Add gleaning configuration to the map configuration
     map_config_with_gleaning = {
         **simple_map_config,
@@ -187,17 +187,19 @@ def test_map_operation_with_gleaning(simple_map_config, simple_sample_data):
     operation = MapOperation(map_config_with_gleaning, "gpt-4o-mini", 4)
 
     # Execute the operation
-    results, cost = operation.execute(simple_sample_data)
+    results, cost = operation.execute(map_sample_data)
 
     # Assert that we have results for all input items
-    assert len(results) == len(simple_sample_data)
+    assert len(results) == len(map_sample_data)
 
     # Check that all results have a sentiment
     assert all("sentiment" in result for result in results)
 
     # Verify that all sentiments are valid
     valid_sentiments = ["positive", "negative", "neutral"]
-    assert all(result["sentiment"] in valid_sentiments for result in results)
+    assert all(
+        any(vs in result["sentiment"] for vs in valid_sentiments) for result in results
+    )
 
     # Assert that the operation had a cost
     assert cost > 0

--- a/tests/basic/test_basic_map.py
+++ b/tests/basic/test_basic_map.py
@@ -172,3 +172,32 @@ def test_map_operation_with_timeout(simple_map_config, simple_sample_data):
     # Execute the operation and expect empty results
     with pytest.raises(docetl.operations.utils.InvalidOutputError):
         operation.execute(simple_sample_data)
+
+
+def test_map_operation_with_gleaning(simple_map_config, simple_sample_data):
+    # Add gleaning configuration to the map configuration
+    map_config_with_gleaning = {
+        **simple_map_config,
+        "gleaning": {
+            "num_rounds": 1,
+            "validation_prompt": "Review the sentiment analysis. Is it accurate? If not, suggest improvements.",
+        },
+    }
+
+    operation = MapOperation(map_config_with_gleaning, "gpt-4o-mini", 4)
+
+    # Execute the operation
+    results, cost = operation.execute(simple_sample_data)
+
+    # Assert that we have results for all input items
+    assert len(results) == len(simple_sample_data)
+
+    # Check that all results have a sentiment
+    assert all("sentiment" in result for result in results)
+
+    # Verify that all sentiments are valid
+    valid_sentiments = ["positive", "negative", "neutral"]
+    assert all(result["sentiment"] in valid_sentiments for result in results)
+
+    # Assert that the operation had a cost
+    assert cost > 0


### PR DESCRIPTION
The `gleaning` feature wasn't working, so this PR removes an extraneous argument to a function call as a fix. Also adds a test.