### PR TITLE
Parsers can now return any number of fields, and can access the whole item

### DIFF
--- a/docs/operators/split.md
+++ b/docs/operators/split.md
@@ -42,7 +42,7 @@ Note that chunks will not overlap in content.
 - `method`: The method to use for splitting. Options are "delimiter" and "token_count".
 - `method_kwargs`: A dictionary of keyword arguments for the splitting method.
   - For "delimiter" method: `delimiter` (string) to use for splitting.
-  - For "token_count" method: `token_count` (integer) specifying the maximum number of tokens per chunk.
+  - For "token_count" method: `num_tokens` (integer) specifying the maximum number of tokens per chunk.
 
 ### Optional Parameters in `method_kwargs
 
@@ -107,8 +107,8 @@ Let's walk through a complete example of using Split, Map, and Reduce operations
   split_key: transcript
   method: token_count
   method_kwargs:
-    token_count: 500
-  model: gpt-4o-mini
+    num_tokens: 500
+    model: gpt-4o-mini
 ```
 
 ### Step 2: Map Operation (Identify Frustration Indicators)


### PR DESCRIPTION
Closes https://github.com/ucbepic/docetl/issues/72

This should be backwards compatible with existing yaml. It also supports the following extended yaml format:

```
datasets:
  name:
    type: file
    source: local
    path: "file.json"
    parsing:
      - function: function_name
        param_name1: value1
        param_name2: value2
        ...
        param_nameN: valueN
```

`input_key` and `output_key` are supported for all previously existing parsers (and are just normal parameters to them), but might not be supported by any particular new parser. In fact, the llama-index based ones do not support an `output_key`, but instead places the output in the two fields `text` and `metadata`.

For the existing functions that do take `input_key` and `output_key`, they are both optional and both have default value `"text"`.