### PR TITLE
New api

### DIFF
--- a/docetl/cli.py
+++ b/docetl/cli.py
@@ -83,7 +83,7 @@ def run(
         load_dotenv(env_file)
 
     runner = DSLRunner.from_yaml(str(yaml_file), max_threads=max_threads)
-    runner.run()
+    runner.load_run_save()
 
 
 @app.command()


### PR DESCRIPTION
Kinda/partially solves https://github.com/ucbepic/docetl/issues/107 

This supports the following python API:

```
config = yaml.safe_load("""
datasets:
  input:
    type: file
    source: local
    path: "input.json"

operations:
- name: test
  type: unnest
  unnest_key: concepts
  expand_fields:
    - concept

pipeline:
  steps:
    - name: test
      input: input
      operations:
        - test
  output:
    type: file
    path: "output.json"
    intermediate_dir: "output"
""")


pipeline = docetl.DSLRunner(config)
input = pipeline.load()
output, cost = pipeline.run(input)
pipeline.save(output)
```

* `config` is your pipeline config parsed into dictionaries and list
* `input` can be just a dictionary of `{datasetname: [item, item, ...]}` where `item` is  dictionary with item data.
* `output` is just  `[item, item, ...]`

Left to implement is possibility to override intermediate dir outside of the `config`.