### PR TITLE
Fix Resolve and Map progress bars

### DIFF
--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -236,7 +236,6 @@ class MapOperation(BaseOperation):
                         }
                     results.append(result)
                 total_cost += item_cost
-                pbar.update(i)
 
         if self.status:
             self.status.start()

--- a/docetl/operations/resolve.py
+++ b/docetl/operations/resolve.py
@@ -449,8 +449,6 @@ class ResolveOperation(BaseOperation):
                     if is_match_result:
                         merge_clusters(pair[0], pair[1])
 
-                    pbar.update(i)
-
         total_cost += pair_costs
 
         # Collect final clusters


### PR DESCRIPTION
The `RichLoopBar` in `Map` and `Resolve` gets updated beyond the number of expected items. `for i in pbar` should suffice for updating it, `pbar.update(i)` can be removed.