### PR TITLE
chore, load envs from current directory

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -2,6 +2,9 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from server.app.routes import pipeline
+from dotenv import load_dotenv
+
+load_dotenv()
 
 app = FastAPI()
 os.environ["USE_FRONTEND"] = "true"


### PR DESCRIPTION
* fastapi uses the environment variables in. env under the current directory