### PR TITLE
hotfix: an error occurred when running make run-ui

### DIFF
--- a/website/src/components/BookmarkableText.tsx
+++ b/website/src/components/BookmarkableText.tsx
@@ -31,6 +31,7 @@ import { useToast } from "@/hooks/use-toast";
 interface BookmarkableTextProps {
   children: React.ReactNode;
   source: string;
+  className?: string;
 }
 
 const formSchema = z.object({
@@ -42,6 +43,7 @@ const formSchema = z.object({
 const BookmarkableText: React.FC<BookmarkableTextProps> = ({
   children,
   source,
+  className = "overflow-y-auto"
 }) => {
   const [buttonPosition, setButtonPosition] = useState({ x: 0, y: 0 });
   const [showButton, setShowButton] = useState(false);
@@ -137,7 +139,7 @@ const BookmarkableText: React.FC<BookmarkableTextProps> = ({
       ref={textRef}
       onMouseUp={handleMultiElementSelection}
       onTouchEnd={handleMultiElementSelection}
-      className="overflow-y-auto"
+      className={className}
     >
       {children}
       {showButton && (

--- a/website/src/components/ResizableDataTable.tsx
+++ b/website/src/components/ResizableDataTable.tsx
@@ -219,6 +219,8 @@ function ResizableDataTable<T extends DataType>({
     getPaginationRowModel: getPaginationRowModel(),
     onColumnSizingChange: (newColumnSizing) => {
       setColumnSizing(newColumnSizing);
+      setIsResizing(true);  
+      debouncedSetIsResizing(false);  
       saveSettings();
     },
     onColumnVisibilityChange: setColumnVisibility,
@@ -236,9 +238,7 @@ function ResizableDataTable<T extends DataType>({
       pagination: {
         pageSize: 5,
       },
-    },
-    onColumnSizingStart: () => setIsResizing(true),
-    onColumnSizingEnd: () => debouncedSetIsResizing(false),
+    }
   });
 
   return (


### PR DESCRIPTION
## ENV:

```bash
$ node --version
v18.20.4

$ npm --version
10.7.0

```

## Err Info:
```bash
./src/components/Output.tsx:254:43
Type error: Type '{ children: Element; source: string; className: string; }' is not assignable to type 'IntrinsicAttributes & BookmarkableTextProps'.
  Property 'className' does not exist on type 'IntrinsicAttributes & BookmarkableTextProps'.

  252 |         </div>
  253 |       ) : outputs.length > 0 ? (
> 254 |         <BookmarkableText source="output" className="h-full">
      |                                           ^
  255 |           <ResizableDataTable
  256 |             data={outputs}
  257 |             columns={columns}
```

```bash
./src/components/ResizableDataTable.tsx:240:5
Type error: Object literal may only specify known properties, and 'onColumnSizingStart' does not exist in type 'TableOptions<T>'.

  238 |       },
  239 |     },
> 240 |     onColumnSizingStart: () => setIsResizing(true),
      |     ^
  241 |     onColumnSizingEnd: () => debouncedSetIsResizing(false),
  242 |   });
  243 |
```