### PR TITLE
feat: add code operations to the ui (#169)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,7 @@
         "@agbishop/react-ansi-18": "^4.0.6",
         "@ai-sdk/openai": "^0.0.70",
         "@hookform/resolvers": "^3.9.0",
+        "@monaco-editor/react": "^4.6.0",
         "@next/third-parties": "^14.2.11",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.2",
@@ -1364,6 +1365,32 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -9251,6 +9278,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10800,6 +10834,12 @@
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "@agbishop/react-ansi-18": "^4.0.6",
     "@ai-sdk/openai": "^0.0.70",
     "@hookform/resolvers": "^3.9.0",
+    "@monaco-editor/react": "^4.6.0",
     "@next/third-parties": "^14.2.11",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.2",

--- a/website/src/app/types.ts
+++ b/website/src/app/types.ts
@@ -15,7 +15,10 @@ export type Operation = {
     | "unnest"
     | "split"
     | "gather"
-    | "sample";
+    | "sample"
+    | "code_map"
+    | "code_reduce"
+    | "code_filter";
   name: string;
   prompt?: string;
   output?: { schema: SchemaItem[] };

--- a/website/src/components/AIChatPanel.tsx
+++ b/website/src/components/AIChatPanel.tsx
@@ -106,7 +106,7 @@ const AIChatPanel: React.FC<AIChatPanelProps> = ({ onClose }) => {
 Core Capabilities:
 - DocETL enables users to create sophisticated data processing workflows with LLM calls, like crowdsourcing pipelines
 - Each pipeline processes documents through a sequence of operations
-- Operations can be LLM-based (map, reduce, resolve, filter) or utility-based (unnest, split, gather, sample)
+- Operations can be LLM-based (map, reduce, resolve, filter) or utility-based (unnest, split, gather, sample) or code-based (python for map, reduce, and filter)
 
 Operation Details:
 - Every LLM operation has:
@@ -116,6 +116,12 @@ Operation Details:
   - Map/Filter: Access current doc with '{{ input.keyname }}'
   - Reduce: Loop through docs with '{% for doc in inputs %}...{% endfor %}'
   - Resolve: Compare docs with '{{ input1 }}/{{ input2 }}' and canonicalize with '{{ inputs }}'
+- Code-based operations:
+  - Map: Define a transform function (def transform(doc: dict) -> dict), where the returned dict will have key-value pairs that will be added to the output document
+  - Filter: Define a transform function (def transform(doc: dict) -> bool), where the function should return true if the document should be included in the output
+  - Reduce: Define a transform function (def transform(docs: list[dict]) -> dict), where the returned dict will have key-value pairs that will *be* the output document (unless "pass_through" is set to true, then the first original doc for every group will also be returned)
+  - Only do imports of common libraries, inside the function definition
+  - Only suggest code-based operations if the task is one that is easily expressed in code, and LLMs or crowd workers are incapable of doing it correctly (e.g., word count, simple regex, etc.)
 
 Your Role:
 - Help users optimize pipelines and overcome challenges

--- a/website/src/components/Output.tsx
+++ b/website/src/components/Output.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { ColumnType } from "@/components/ResizableDataTable";
 import ResizableDataTable from "@/components/ResizableDataTable";
 import { usePipelineContext } from "@/contexts/PipelineContext";
-import { Loader2, Download, ChevronDown } from "lucide-react";
+import { Loader2, Download, ChevronDown, Circle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import BookmarkableText from "@/components/BookmarkableText";
@@ -18,6 +18,47 @@ import {
 import { useWebSocket } from "@/contexts/WebSocketContext";
 import AnsiRenderer from "./AnsiRenderer";
 import clsx from "clsx";
+
+const TinyPieChart: React.FC<{ percentage: number }> = ({ percentage }) => {
+  const size = 16;
+  const radius = 6;
+  const strokeWidth = 2;
+  const center = size / 2;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDasharray = `${
+    (percentage * circumference) / 100
+  } ${circumference}`;
+
+  return (
+    <div className="relative w-4 h-4 flex items-center justify-center">
+      <svg
+        className="w-4 h-4 -rotate-90"
+        viewBox={`0 0 ${size} ${size}`}
+        width={size}
+        height={size}
+      >
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          className="fill-none stroke-gray-200"
+          strokeWidth={strokeWidth}
+        />
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          className={clsx(
+            "fill-none transition-all duration-500 ease-out",
+            percentage > 100 ? "stroke-emerald-500" : "stroke-rose-500"
+          )}
+          strokeWidth={strokeWidth}
+          strokeDasharray={strokeDasharray}
+        />
+      </svg>
+    </div>
+  );
+};
 
 export const ConsoleContent: React.FC = () => {
   const { terminalOutput, setTerminalOutput, optimizerProgress } =
@@ -442,7 +483,7 @@ export const Output: React.FC = () => {
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger>
-                    <div className="flex items-center px-2 py-1 border border-gray-200 rounded-md">
+                    <div className="flex items-center px-2 py-1 border border-gray-200 rounded-md cursor-help">
                       <span
                         className={clsx(
                           "font-medium",
@@ -457,6 +498,14 @@ export const Output: React.FC = () => {
                       >
                         {selectivityFactor}×
                       </span>
+                      {selectivityFactor !== "N/A" &&
+                        Number(selectivityFactor) < 1 && (
+                          <div className="ml-1">
+                            <TinyPieChart
+                              percentage={Number(selectivityFactor) * 100}
+                            />
+                          </div>
+                        )}
                     </div>
                   </TooltipTrigger>
                   <TooltipContent>

--- a/website/src/components/PipelineGui.tsx
+++ b/website/src/components/PipelineGui.tsx
@@ -735,6 +735,41 @@ const PipelineGUI: React.FC = () => {
                 >
                   Sample
                 </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>Code Operations</DropdownMenuLabel>
+                <DropdownMenuItem
+                  onClick={() =>
+                    handleAddOperation(
+                      "non-LLM",
+                      "code_map",
+                      "Untitled Code Map"
+                    )
+                  }
+                >
+                  Code Map
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() =>
+                    handleAddOperation(
+                      "non-LLM",
+                      "code_reduce",
+                      "Untitled Code Reduce"
+                    )
+                  }
+                >
+                  Code Reduce
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() =>
+                    handleAddOperation(
+                      "non-LLM",
+                      "code_filter",
+                      "Untitled Code Filter"
+                    )
+                  }
+                >
+                  Code Filter
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
             <div className="flex space-x-2">

--- a/website/src/components/operations/args.tsx
+++ b/website/src/components/operations/args.tsx
@@ -471,9 +471,18 @@ export const CodeInput: React.FC<CodeInputProps> = React.memo(
             </Tooltip>
           </TooltipProvider>
         </div>
-        <div className="border">
+        <div
+          className="border"
+          style={{
+            resize: "vertical",
+            overflow: "auto",
+            minHeight: "200px",
+            height: "200px", // Set initial height explicitly
+            backgroundColor: "var(--background)", // Match editor background
+          }}
+        >
           <Editor
-            height="200px"
+            height="100%"
             defaultLanguage="python"
             value={code || getPlaceholder()}
             onChange={(value) => onChange(value || "")}


### PR DESCRIPTION
Closes #169. Attaching screenshots here.

A code map operation:
![Screenshot 2024-11-14 at 11 20 02 AM](https://github.com/user-attachments/assets/0f3c4b7e-5596-4969-9149-2c7e43859769)

Add operation dropdown
![Screenshot 2024-11-14 at 11 20 21 AM](https://github.com/user-attachments/assets/3bb5aa75-0407-418b-95b7-9bc8c7b62c72)

The PR also adds support for sorting columns in the output table.