### PR TITLE
hotfix: Import declaration conflicts with local declaration of 'Operation'.

### DIFF
--- a/website/src/components/operations/components.tsx
+++ b/website/src/components/operations/components.tsx
@@ -74,15 +74,6 @@ interface OtherKwargs {
   code?: string;
 }
 
-interface Operation {
-  type: string;
-  prompt?: string;
-  output?: {
-    schema?: SchemaItem[];
-  };
-  otherKwargs?: OtherKwargs;
-}
-
 interface OperationComponentProps {
   operation: Operation;
   isSchemaExpanded: boolean;


### PR DESCRIPTION
```typescript

Type error: Import declaration conflicts with local declaration of 'Operation'.

  1 | import React from "react";
> 2 | import { Operation, SchemaItem } from "'app/types"' (see below for file content);
    |          ^
  3 | import { OutputSchema, PromptInput, CodeInput } from "./args";
  4 | import { useMemo } from "react";
  5 | import { Input } from "'components/ui/input"' (see below for file content);
make: *** [Makefile:42: run-ui] Error 1
```