### PR TITLE
Intermediates fix

### DIFF
--- a/website/src/app/api/writePipelineConfig/route.ts
+++ b/website/src/app/api/writePipelineConfig/route.ts
@@ -46,9 +46,12 @@ export async function POST(request: Request) {
 
     // Save the YAML file in the user's home directory
     const homeDir = os.homedir();
-    const pipelineDir = path.join(homeDir, ".docetl", "pipelines", "configs");
-    await fs.mkdir(pipelineDir, { recursive: true });
-    const filePath = path.join(pipelineDir, `${name}.yaml`);
+    const pipelineDir = path.join(homeDir, ".docetl", "pipelines");
+    const configDir = path.join(pipelineDir, "configs");
+    const nameDir = path.join(pipelineDir, name, "intermediates");
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.mkdir(nameDir, { recursive: true });
+    const filePath = path.join(configDir, `${name}.yaml`);
     await fs.writeFile(filePath, yamlString, "utf8");
 
     return NextResponse.json({ filePath, inputPath, outputPath });


### PR DESCRIPTION
I suspect the bug around running pipelines is due to the fact that Intermediates were not created

A renaming of the default pipeline to `DEBATE_ANALYSIS2` should validate 

Feel free to close if I am mistaken