### PR TITLE
feat: add basic llm call observability to the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ DocETL is the ideal choice when you're looking to maximize correctness and outpu
 - You're working with long documents that don't fit into a single prompt
 - You have validation criteria and want tasks to automatically retry when validation fails
 
+### Community Projects
+
+- [Conversation Generator](https://github.com/PassionFruits-net/docetl-conversation)
+- [Text-to-speech](https://github.com/PassionFruits-net/docetl-speaker)
+- [YouTube Transcript Topic Extraction](https://github.com/rajib76/docetl_examples)
+
+### Educational Resources
+
+- [UI/UX Thoughts](https://x.com/sh_reya/status/1846235904664273201)
+- [Using Gleaning to Improve Output Quality](https://x.com/sh_reya/status/1843354256335876262)
+- [Deep Dive on Resolve Operator](https://x.com/sh_reya/status/1840796824636121288)
+
+
 ## Getting Started
 
 There are two main ways to use DocETL:
@@ -161,15 +174,3 @@ make tests-basic  # Runs basic test suite (costs < $0.01 with OpenAI)
 ```
 
 For detailed documentation and tutorials, visit our [documentation](https://ucbepic.github.io/docetl).
-
-## Community Projects
-
-- [Conversation Generator](https://github.com/PassionFruits-net/docetl-conversation)
-- [Text-to-speech](https://github.com/PassionFruits-net/docetl-speaker)
-- [YouTube Transcript Topic Extraction](https://github.com/rajib76/docetl_examples)
-
-## Educational Resources
-
-- [UI/UX Thoughts](https://x.com/sh_reya/status/1846235904664273201)
-- [Using Gleaning to Improve Output Quality](https://x.com/sh_reya/status/1843354256335876262)
-- [Deep Dive on Resolve Operator](https://x.com/sh_reya/status/1840796824636121288)

--- a/docetl/operations/reduce.py
+++ b/docetl/operations/reduce.py
@@ -394,11 +394,13 @@ class ReduceOperation(BaseOperation):
             ):
                 # If the fold batch size is greater than or equal to the number of items in the group,
                 # we can just run a single fold operation
-                result, prompts, cost = self._batch_reduce(key, group_list)
+                result, prompt, cost = self._batch_reduce(key, group_list)
+                prompts = [prompt]
             elif "fold_prompt" in self.config:
                 result, prompts, cost = self._incremental_reduce(key, group_list)
             else:
-                result, prompts, cost = self._batch_reduce(key, group_list)
+                result, prompt, cost = self._batch_reduce(key, group_list)
+                prompts = [prompt]
 
             total_cost += cost
 

--- a/docetl/operations/resolve.py
+++ b/docetl/operations/resolve.py
@@ -5,7 +5,9 @@ The `ResolveOperation` class is a subclass of `BaseOperation` that performs a re
 import random
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Dict, List, Tuple, Optional
+from typing import Any, Dict, List, Tuple, Optional, Union
+import json
+from datetime import datetime
 
 import jinja2
 from jinja2 import Template
@@ -45,6 +47,7 @@ class ResolveOperation(BaseOperation):
         optimize: Optional[bool] = None
         timeout: Optional[int] = None
         litellm_completion_kwargs: Dict[str, Any] = Field(default_factory=dict)
+        enable_observability: bool = False
 
     def compare_pair(
         self,
@@ -55,7 +58,7 @@ class ResolveOperation(BaseOperation):
         blocking_keys: List[str] = [],
         timeout_seconds: int = 120,
         max_retries_per_timeout: int = 2,
-    ) -> Tuple[bool, float]:
+    ) -> Tuple[bool, float, str]:
         """
         Compares two items using an LLM model to determine if they match.
 
@@ -66,7 +69,7 @@ class ResolveOperation(BaseOperation):
             item2 (Dict): The second item to compare.
 
         Returns:
-            Tuple[bool, float]: A tuple containing a boolean indicating whether the items match and the cost of the comparison.
+            Tuple[bool, float, str]: A tuple containing a boolean indicating whether the items match, the cost of the comparison, and the prompt.
         """
         if blocking_keys:
             if all(
@@ -75,7 +78,7 @@ class ResolveOperation(BaseOperation):
                 and str(item1[key]).lower() == str(item2[key]).lower()
                 for key in blocking_keys
             ):
-                return True, 0
+                return True, 0, ""
 
         prompt_template = Template(comparison_prompt)
         prompt = prompt_template.render(input1=item1, input2=item2)
@@ -93,7 +96,8 @@ class ResolveOperation(BaseOperation):
             response.response,
             {"is_match": "bool"},
         )[0]
-        return output["is_match"], response.total_cost
+
+        return output["is_match"], response.total_cost, prompt
 
     def syntax_check(self) -> None:
         """
@@ -502,10 +506,20 @@ class ResolveOperation(BaseOperation):
 
                 for future in as_completed(future_to_pair):
                     pair = future_to_pair[future]
-                    is_match_result, cost = future.result()
+                    is_match_result, cost, prompt = future.result()
                     pair_costs += cost
                     if is_match_result:
                         merge_clusters(pair[0], pair[1])
+                        
+                    if self.config.get("enable_observability", False):
+                        observability_key = f"_observability_{self.config['name']}"
+                        for idx in (pair[0], pair[1]):
+                            if observability_key not in input_data[idx]:
+                                input_data[idx][observability_key] = {
+                                    "comparison_prompts": [],
+                                    "resolution_prompt": None
+                                }
+                            input_data[idx][observability_key]["comparison_prompts"].append(prompt)
 
                     pbar.update(last_processed//batch_size)
         total_cost += pair_costs
@@ -548,6 +562,16 @@ class ResolveOperation(BaseOperation):
                     litellm_completion_kwargs=self.config.get("litellm_completion_kwargs", {}),
                 )
                 reduction_cost = reduction_response.total_cost
+
+                if self.config.get("enable_observability", False):
+                    for item in [input_data[i] for i in cluster]:
+                        observability_key = f"_observability_{self.config['name']}"
+                        if observability_key not in item:
+                            item[observability_key] = {
+                                "comparison_prompts": [],
+                                "resolution_prompt": None
+                            }
+                        item[observability_key]["resolution_prompt"] = resolution_prompt
 
                 if reduction_response.validated:
                     reduction_output = self.runner.api.parse_llm_response(

--- a/docetl/optimizers/join_optimizer.py
+++ b/docetl/optimizers/join_optimizer.py
@@ -1119,7 +1119,7 @@ class JoinOptimizer:
                 for i, j in pairs
             ]
             for future, (i, j) in zip(futures, pairs):
-                is_match, cost = future.result()
+                is_match, cost, _ = future.result()
                 comparisons.append((i, j, is_match))
                 total_cost += cost
 

--- a/website/src/app/api/utils.ts
+++ b/website/src/app/api/utils.ts
@@ -124,6 +124,7 @@ export function generatePipelineConfig(
 
       return {
         ...newOp,
+        enable_observability: true,
         output: {
           schema: op.output.schema.reduce(
             (acc: Record<string, string>, item: SchemaItem) => {

--- a/website/src/components/Output.tsx
+++ b/website/src/components/Output.tsx
@@ -310,6 +310,7 @@ export const Output: React.FC = () => {
                 : []
             }
             startingRowHeight={180}
+            currentOperation={opName}
           />
         </BookmarkableText>
       ) : (

--- a/website/src/components/ResizableDataTable.tsx
+++ b/website/src/components/ResizableDataTable.tsx
@@ -457,6 +457,8 @@ const ColumnHeader = React.memo(
                       ? " items"
                       : stats.type === "string-words"
                       ? " words"
+                      : stats.type === "string-chars"
+                      ? " chars"
                       : ""}
                   </span>
                   <span>avg: {Math.round(stats.avg)}</span>
@@ -466,6 +468,8 @@ const ColumnHeader = React.memo(
                       ? " items"
                       : stats.type === "string-words"
                       ? " words"
+                      : stats.type === "string-chars"
+                      ? " chars"
                       : ""}
                   </span>
                 </>
@@ -798,11 +802,6 @@ const SearchableCell = React.memo(
 );
 SearchableCell.displayName = "SearchableCell";
 
-const isObservabilityColumn = (columnId: string | undefined): boolean => {
-  if (!columnId) return false;
-  return columnId.startsWith("_observability_");
-};
-
 interface ObservabilityIndicatorProps {
   row: Record<string, unknown>;
   currentOperation: string;
@@ -961,8 +960,8 @@ function ResizableDataTable<T extends DataType>({
     data,
     columns: sortedColumns
       .filter((col) => {
-        const columnId = col.id as string | undefined;
-        return !isObservabilityColumn(columnId);
+        const columnId = col.accessorKey || col.id;
+        return !columnId?.startsWith("_observability_");
       })
       .map((col) => ({
         ...col,

--- a/website/src/components/ResizableDataTable.tsx
+++ b/website/src/components/ResizableDataTable.tsx
@@ -831,7 +831,7 @@ const ObservabilityIndicator = React.memo(
         >
           <div className="space-y-4">
             <h3 className="text-lg font-semibold border-b pb-2">
-              LLM Call for {currentOperation}
+              LLM Call(s) for {currentOperation}
             </h3>
             <div className="space-y-2">
               {observabilityEntries.map(([key, value]) => (

--- a/website/src/components/ResizableDataTable.tsx
+++ b/website/src/components/ResizableDataTable.tsx
@@ -31,7 +31,13 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, ChevronRight, ChevronDown, Search } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  Search,
+  Eye,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -43,6 +49,11 @@ import ReactMarkdown from "react-markdown";
 import debounce from "lodash/debounce";
 import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer } from "recharts";
 import { Input } from "@/components/ui/input";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 
 export type DataType = Record<string, unknown>;
 export type ColumnType<T extends DataType> = ColumnDef<T> & {
@@ -537,6 +548,7 @@ interface ResizableDataTableProps<T extends DataType> {
   columns: ColumnType<T>[];
   boldedColumns: string[];
   startingRowHeight?: number;
+  currentOperation: string;
 }
 
 interface MarkdownCellProps {
@@ -786,11 +798,66 @@ const SearchableCell = React.memo(
 );
 SearchableCell.displayName = "SearchableCell";
 
+const isObservabilityColumn = (columnId: string | undefined): boolean => {
+  if (!columnId) return false;
+  return columnId.startsWith("_observability_");
+};
+
+interface ObservabilityIndicatorProps {
+  row: Record<string, unknown>;
+  currentOperation: string;
+}
+
+const ObservabilityIndicator = React.memo(
+  ({ row, currentOperation }: ObservabilityIndicatorProps) => {
+    // Only show observability data for the current operation
+    const observabilityEntries = Object.entries(row).filter(
+      ([key]) => key === `_observability_${currentOperation}`
+    );
+
+    if (observabilityEntries.length === 0) return null;
+
+    return (
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <div className="cursor-help">
+            <Eye className="h-4 w-4 text-muted-foreground hover:text-primary" />
+          </div>
+        </HoverCardTrigger>
+        <HoverCardContent
+          className="w-[800px] max-h-[600px] overflow-auto"
+          side="right"
+          align="start"
+        >
+          <div className="space-y-4">
+            <h3 className="text-lg font-semibold border-b pb-2">
+              LLM Call for {currentOperation}
+            </h3>
+            <div className="space-y-2">
+              {observabilityEntries.map(([key, value]) => (
+                <div key={key} className="flex flex-col gap-1">
+                  <div className="text-sm text-muted-foreground">
+                    {typeof value === "object"
+                      ? JSON.stringify(value, null, 2)
+                      : String(value)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </HoverCardContent>
+      </HoverCard>
+    );
+  }
+);
+ObservabilityIndicator.displayName = "ObservabilityIndicator";
+
 function ResizableDataTable<T extends DataType>({
   data,
   columns,
   boldedColumns,
   startingRowHeight = 60,
+  currentOperation,
 }: ResizableDataTableProps<T>) {
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => {
     const savedSettings = localStorage.getItem(TABLE_SETTINGS_KEY);
@@ -892,34 +959,39 @@ function ResizableDataTable<T extends DataType>({
 
   const table = useReactTable({
     data,
-    columns: sortedColumns.map((col) => ({
-      ...col,
-      enableSorting: true,
-      filterFn: fuzzyFilter,
-      sortingFn: (rowA: Row<T>, rowB: Row<T>) => {
-        const accessor = col.accessorKey;
-        if (!accessor) return 0;
+    columns: sortedColumns
+      .filter((col) => {
+        const columnId = col.id as string | undefined;
+        return !isObservabilityColumn(columnId);
+      })
+      .map((col) => ({
+        ...col,
+        enableSorting: true,
+        filterFn: fuzzyFilter,
+        sortingFn: (rowA: Row<T>, rowB: Row<T>) => {
+          const accessor = col.accessorKey;
+          if (!accessor) return 0;
 
-        const a = rowA.getValue(accessor);
-        const b = rowB.getValue(accessor);
+          const a = rowA.getValue(accessor);
+          const b = rowB.getValue(accessor);
 
-        // Handle null/undefined values
-        if (a == null) return -1;
-        if (b == null) return 1;
+          // Handle null/undefined values
+          if (a == null) return -1;
+          if (b == null) return 1;
 
-        // Sort based on type
-        if (typeof a === "number" && typeof b === "number") {
-          return a - b;
-        }
+          // Sort based on type
+          if (typeof a === "number" && typeof b === "number") {
+            return a - b;
+          }
 
-        if (Array.isArray(a) && Array.isArray(b)) {
-          return a.length - b.length;
-        }
+          if (Array.isArray(a) && Array.isArray(b)) {
+            return a.length - b.length;
+          }
 
-        // For strings, do alphabetical comparison
-        return String(a).localeCompare(String(b));
-      },
-    })),
+          // For strings, do alphabetical comparison
+          return String(a).localeCompare(String(b));
+        },
+      })),
     columnResizeMode: "onChange" as ColumnResizeMode,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -1065,7 +1137,7 @@ function ResizableDataTable<T extends DataType>({
       <div style={{ width: "100%", overflow: "auto" }}>
         <Table
           style={{
-            width: table.getTotalSize() + 100, // Add extra space for resizing
+            width: table.getTotalSize() + 100,
             minWidth: "100%",
           }}
         >
@@ -1126,9 +1198,15 @@ function ResizableDataTable<T extends DataType>({
                       textAlign: "center",
                     }}
                   >
-                    <span style={{ fontSize: "0.75rem", color: "#888" }}>
-                      {row.index + 1}
-                    </span>
+                    <div className="flex flex-col items-center gap-1">
+                      <span style={{ fontSize: "0.75rem", color: "#888" }}>
+                        {row.index + 1}
+                      </span>
+                      <ObservabilityIndicator
+                        row={row.original}
+                        currentOperation={currentOperation}
+                      />
+                    </div>
                   </TableCell>
                   {row.getVisibleCells().map((cell) => (
                     <TableCell


### PR DESCRIPTION
Now, each row in the output table has an "eye" icon:

![image](https://github.com/user-attachments/assets/bc5559b1-d2fb-4044-8359-c68b386793a9)

I've accommodated map, parallel map, filter, reduce, resolve. Need to test non-map operations in the UI.