### PR TITLE
Fix cache naming

### DIFF
--- a/docetl/operations/utils.py
+++ b/docetl/operations/utils.py
@@ -31,10 +31,10 @@ aeval = Interpreter()
 
 load_dotenv()
 # litellm.set_verbose = True
-DOCETL_HOME_DIR = os.environ.get("DOCETL_HOME_DIR", os.path.expanduser("~"))+"/.docetl"
+DOCETL_HOME_DIR = os.environ.get("DOCETL_HOME_DIR", os.path.expanduser("~"))+"/.cache/docetl"
 
-CACHE_DIR = os.path.join(DOCETL_HOME_DIR, "cache")
-LLM_CACHE_DIR = os.path.join(DOCETL_HOME_DIR, "llm_cache")
+CACHE_DIR = os.path.join(DOCETL_HOME_DIR, "general")
+LLM_CACHE_DIR = os.path.join(DOCETL_HOME_DIR, "llm")
 cache = Cache(LLM_CACHE_DIR)
 cache.close()
 

--- a/docs/concepts/operators.md
+++ b/docs/concepts/operators.md
@@ -10,7 +10,7 @@ Operators in DocETL are designed for semantically processing unstructured data. 
 
 !!! tip "Caching in DocETL"
 
-    DocETL employs caching for all LLM calls and partially-optimized plans. The cache is stored in the `.docetl/cache` and `.docetl/llm_cache` directories within your home directory. This caching mechanism helps to improve performance and reduce redundant API calls when running similar operations or reprocessing data.
+    DocETL employs caching for all LLM calls and partially-optimized plans. The cache is stored in the `.cache/docetl/general` and `.cache/docetl/llm` directories within your home directory. This caching mechanism helps to improve performance and reduce redundant API calls when running similar operations or reprocessing data.
 
 ## Common Attributes
 


### PR DESCRIPTION
Fixes #95 by updating cache naming for more conventional naming structure as well as the documentation in operators.md. 
Expected risk: minimal seems like all usages of the cache just call the instance in utils.py