### PR TITLE
chore: add param to skip LLM calls when they fail

### DIFF
--- a/docetl/builder.py
+++ b/docetl/builder.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import yaml
 from docetl.utils import CapturedOutput
 from rich.console import Console
+from rich.panel import Panel
 from rich.status import Status
 from rich.traceback import install
 
@@ -205,11 +206,14 @@ class Optimizer:
         The output is color-coded and formatted for easy readability, with a header and
         separator lines to clearly delineate the configuration information.
         """
-        self.console.rule("[bold cyan]Optimizer Configuration[/bold cyan]")
-        self.console.log(f"[yellow]Sample Size:[/yellow] {self.sample_size_map}")
-        self.console.log(f"[yellow]Max Threads:[/yellow] {self.max_threads}")
-        self.console.log(f"[yellow]Model:[/yellow] {self.llm_client.model}")
-        self.console.log(f"[yellow]Timeout:[/yellow] {self.timeout} seconds")
+        self.console.print(Panel.fit(
+            "[bold cyan]Optimizer Configuration[/bold cyan]\n"
+            f"[yellow]Sample Size:[/yellow] {self.sample_size_map}\n"
+            f"[yellow]Max Threads:[/yellow] {self.max_threads}\n" 
+            f"[yellow]Model:[/yellow] {self.llm_client.model}\n"
+            f"[yellow]Timeout:[/yellow] {self.timeout} seconds",
+            title="Optimizer Configuration"
+        ))
 
     def compute_sample_size(
         self,
@@ -462,20 +466,25 @@ class Optimizer:
             self.console.log("[green]Finished loading optimized operations[/green]")
 
             # Print out the operations for each step
-            self.console.log("[bold blue]Operations for each step:[/bold blue]")
+            step_operations = []
             for step in self.config["pipeline"]["steps"]:
                 step_name = step.get("name")
                 operations = step.get("operations", [])
-                self.console.log(f"[cyan]Step: {step_name}[/cyan]")
+                step_info = f"[cyan]Step: {step_name}[/cyan]\n"
+                
                 for op in operations:
                     if isinstance(op, dict):
-                        # Handle the case where the operation is a dictionary (e.g., for equijoin)
                         op_name = list(op.keys())[0]
                         op_details = op[op_name]
-                        self.console.log(f"  - {op_name}: {op_details}")
+                        step_info += f"  - {op_name}: {op_details}\n"
                     else:
-                        self.console.log(f"  - {op}")
-                self.console.log("")  # Add a blank line between steps
+                        step_info += f"  - {op}\n"
+                step_operations.append(step_info)
+
+            self.console.print(Panel.fit(
+                "\n".join(step_operations),
+                title="[bold blue]Operations for each step"
+            ))
         else:
             self.console.log("[yellow]No optimized operations found[/yellow]")
 
@@ -846,10 +855,23 @@ class Optimizer:
                 optimized_operation_names.append(operation_name)
 
                 selectivity = len(output_data) / len(input_data)
-
                 self.selectivities[step.get("name")][operation_name] = selectivity
                 self.samples_taken[step.get("name")][operation_name] = sample_size
             else:
+                sample_info = []
+                if op_object.get("type") == "equijoin":
+                    sample_info.extend([
+                        f"[yellow]Sample size (left): {len(input_data['left'])}",
+                        f"[yellow]Sample size (right): {len(input_data['right'])}"
+                    ])
+                else:
+                    sample_info.append(f"[yellow]Sample size: {len(input_data)}")
+
+                self.console.print(Panel.fit(
+                    "\n".join(sample_info),
+                    title=f"[yellow]Optimizing {operation_name} (Type: {op_object['type']})"
+                ))
+
                 # Use rich console status to indicate optimization of the operation
                 with self.console.status(
                     f"[bold blue]Optimizing operation: {operation_name} (Type: {op_object['type']})[/bold blue]"
@@ -960,12 +982,16 @@ class Optimizer:
                     ]
 
                     # Print new operator configs
-                    self.console.log("[bold green]New op configurations:[/bold green]")
-                    for op_name, op_config in optimized_operations.items():
-                        if op_name in [o["name"] for o in optimized_ops]:
-                            self.console.log(
-                                f"[cyan]{op_name}:[/cyan] {json.dumps(op_config, indent=2)}"
-                            )
+                    if optimized_ops:
+                        config_content = "[bold green]New op configurations:[/bold green]\n"
+                        for op_name, op_config in optimized_operations.items():
+                            if op_name in [o["name"] for o in optimized_ops]:
+                                config_content += f"[cyan]{op_name}:[/cyan] {json.dumps(op_config, indent=2)}\n"
+                        
+                        self.console.print(Panel.fit(
+                            config_content,
+                            title="Optimized Operations"
+                        ))
 
                     # Save the optimized operations to disk
                     os.makedirs(self.optimized_ops_path, exist_ok=True)
@@ -1168,14 +1194,15 @@ class Optimizer:
         # Sort the sizes for a more readable output
         sorted_sizes = sorted(size_counts.items())
 
-        # Print the histogram
-        self.console.log("\n[bold]Histogram of Group Sizes:[/bold]")
+        # Replace the histogram logging with a panel
+        histogram_content = "[bold]Histogram of Group Sizes:[/bold]\n"
         max_bar_width, max_count = 2, max(size_counts.values())
         for size, count in sorted_sizes[:5]:
             normalized_count = int(count / max_count * max_bar_width)
             bar = "█" * normalized_count
-            self.console.log(f"{size:3d}: {bar} ({count})")
-        self.console.log("\n")
+            histogram_content += f"{size:3d}: {bar} ({count})\n"
+        
+        self.console.print(Panel.fit(histogram_content, title="Group Size Distribution"))
 
         return sample
 

--- a/docetl/operations/base.py
+++ b/docetl/operations/base.py
@@ -70,6 +70,7 @@ class BaseOperation(ABC, metaclass=BaseOperationMeta):
     class schema(BaseModel, extra="allow"):
         name: str
         type: str
+        skip_on_error: bool = False
 
     @classproperty
     def json_schema(cls):

--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -261,15 +261,27 @@ class MapOperation(BaseOperation):
                 with ThreadPoolExecutor(max_workers=self.max_batch_size) as executor:
                     futures = [executor.submit(_process_map_item, items_and_outputs[i][0], items_and_outputs[i][1]) for i in range(len(items_and_outputs))]
                     for i in range(len(futures)):
-                        result, item_cost = futures[i].result()
-                        if result is not None:
-                            all_results.append(result)
-                        total_cost += item_cost
+                        try:
+                            result, item_cost = futures[i].result()
+                            if result is not None:
+                                all_results.append(result)
+                            total_cost += item_cost
+                        except Exception as e:
+                            if self.config.get("skip_on_error", False):
+                               continue
+                            else:
+                                raise e
             else:
-                result, item_cost = _process_map_item(items_and_outputs[0][0], items_and_outputs[0][1])
-                if result is not None:
-                    all_results.append(result)
-                total_cost += item_cost
+                try:
+                    result, item_cost = _process_map_item(items_and_outputs[0][0], items_and_outputs[0][1])
+                    if result is not None:
+                        all_results.append(result)
+                    total_cost += item_cost
+                except Exception as e:
+                    if self.config.get("skip_on_error", False):
+                        pass
+                    else:
+                        raise e
 
             # Return items and cost
             return all_results, total_cost

--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -268,6 +268,7 @@ class MapOperation(BaseOperation):
                             total_cost += item_cost
                         except Exception as e:
                             if self.config.get("skip_on_error", False):
+                               self.console.log(f"[bold red]Error in map operation {self.config['name']}, skipping item:[/bold red] {e}")
                                continue
                             else:
                                 raise e
@@ -279,7 +280,7 @@ class MapOperation(BaseOperation):
                     total_cost += item_cost
                 except Exception as e:
                     if self.config.get("skip_on_error", False):
-                        pass
+                        self.console.log(f"[bold red]Error in map operation {self.config['name']}, skipping item:[/bold red] {e}")
                     else:
                         raise e
 

--- a/docetl/optimizers/map_optimizer/config_generators.py
+++ b/docetl/optimizers/map_optimizer/config_generators.py
@@ -251,11 +251,7 @@ class ConfigGenerator:
         Full input sample:
         {json.dumps(random.choice(input_data_sample), indent=2)[:1000]}
 
-        Determine if metadata is needed to perform the subtask.
-
-        Consider:
-        1. Does the input sample have any structural metadata that might be relevant to the subtask?
-        2. Is the sample chunk or full input missing any crucial information that could be in this metadata?
+        Determine if the beginning of the document has any metadata that might help with performing the subtask. For example, if there's a header, or a table of contents, or a table of information in the beginning of the document.
 
         Provide your response in the following format:
         """

--- a/docetl/optimizers/map_optimizer/optimizer.py
+++ b/docetl/optimizers/map_optimizer/optimizer.py
@@ -253,6 +253,12 @@ class MapOptimizer:
             The cost is the cost of the optimizer (from possibly synthesizing resolves).
 
         """
+        # Verify that the plan types are valid
+        for plan_type in plan_types:
+            if plan_type not in ["chunk", "proj_synthesis", "glean"]:
+                raise ValueError(f"Invalid plan type: {plan_type}. Valid plan types are: chunk, proj_synthesis, glean.")
+
+        
         input_data, output_data, model_input_context_length, no_change_runtime, validator_prompt, assessment, data_exceeds_limit = self._should_optimize_helper(op_config, input_data)
 
         # Check if improvement is needed based on the assessment

--- a/docetl/optimizers/map_optimizer/plan_generators.py
+++ b/docetl/optimizers/map_optimizer/plan_generators.py
@@ -81,6 +81,7 @@ class PlanGenerator:
         subprompt_output_schema = split_result.get("subprompt_output_schema", {})
         if not subprompt_output_schema:
             subprompt_output_schema = op_config["output"]["schema"]
+        split_subprompt = split_result["subprompt"]
 
         chunk_sizes = self.config_generator._generate_chunk_sizes(
             split_key, input_data, token_limit
@@ -98,7 +99,7 @@ class PlanGenerator:
             try:
                 metadata_info = self.config_generator._determine_metadata_needs(
                     op_config,
-                    split_result["subprompt"],
+                    split_subprompt,
                     avg_chunk_size,
                     split_key,
                     input_data,
@@ -112,7 +113,7 @@ class PlanGenerator:
                     # Retry once
                     return self.config_generator._determine_metadata_needs(
                         op_config,
-                        split_result["subprompt"],
+                        split_subprompt,
                         avg_chunk_size,
                         split_key,
                         input_data,
@@ -129,6 +130,7 @@ class PlanGenerator:
                 f"Metadata prompt and output schema: {metadata_info.get('metadata_prompt', 'N/A')}; {metadata_info.get('output_schema', 'N/A')}"
             )
             self.console.log(f"Reason: {metadata_info.get('reason', 'N/A')}")
+            split_subprompt = "Given the following metadata about the document:\n{{ input.metadata }}\n\n" + split_subprompt
 
         # Create header extraction prompt
         header_extraction_prompt, header_output_schema = (
@@ -187,7 +189,7 @@ class PlanGenerator:
 
         # Generate the info extraction prompt
         info_extraction_prompt = self.generate_info_extraction_prompt(
-            split_result["subprompt"],
+            split_subprompt,
             split_result["split_key"],
             sample_chunks[0],
             sample_chunks[1],
@@ -218,7 +220,7 @@ class PlanGenerator:
         map_op = self.operation_creator.create_map_operation(
             op_config,
             subprompt_output_schema,
-            split_result["subprompt"] ,
+            split_subprompt ,
         )
 
         # unnest_ops = self.operation_creator.create_unnest_operations(op_config)
@@ -745,10 +747,16 @@ class PlanGenerator:
 
         Input data sample:
         {json.dumps({k: v for k, v in input_data[0].items() if k in variables_in_prompt} if input_data else {}, indent=2)}
+        Think step by step to decompose the original task into a chain of subtasks, even if the steps are not explicitly outlined in the original task prompt. Break down the task into logical steps by:
+        1. Analyzing the original task and output schema carefully to identify the key components and dependencies
+        2. Breaking down the task into logical steps, where each step produces one or more output keys or helpful intermediate results
+        3. Considering what information each step needs from previous steps
+        4. Arranging the steps in a sequence that satisfies all dependencies
 
-        Decompose the original task into a chain of subtasks, where each subtask produces one or more keys of the output schema or synthesizes new intermediate keys.
-        Analyze dependencies between output keys and arrange subtasks in a logical order. You can create new intermediate keys that don't exist in the given output schema if they help break down the task into simpler steps. For example, the first chain step can generate a helpful intermediate result that subsequent steps can build upon.
+        Each subtask should produce one or more keys of the output schema or synthesize new intermediate keys. You can create new intermediate keys that don't exist in the given output schema if they help break down the task into simpler steps. For example, the first chain step can generate a helpful intermediate result that subsequent steps can build upon.
+
         To access the output of a previous subtask, use the syntax {{ input.key }}. Each prompt should be a Jinja2 template.
+
         Ensure that all keys in the original output schema are produced by the end of the chain, even if some subtasks create additional intermediate keys.
 
         Provide your response in the following format:

--- a/docetl/optimizers/map_optimizer/plan_generators.py
+++ b/docetl/optimizers/map_optimizer/plan_generators.py
@@ -755,7 +755,9 @@ class PlanGenerator:
 
         Each subtask should produce one or more keys of the output schema or synthesize new intermediate keys. You can create new intermediate keys that don't exist in the given output schema if they help break down the task into simpler steps. For example, the first chain step can generate a helpful intermediate result that subsequent steps can build upon.
 
-        To access the output of a previous subtask, use the syntax {{ input.key }}. Each prompt should be a Jinja2 template.
+        To access the output of a previous subtask, use the syntax {{{{ input.key }}}}. Each prompt should be a Jinja2 template.
+
+        Every variable you use in the prompt must be defined in the input data or the output of a previous subtask, and should be accessed like this: {{{{ input.key }}}}. You may need to reference the data for all the subtasks in the chain.
 
         Ensure that all keys in the original output schema are produced by the end of the chain, even if some subtasks create additional intermediate keys.
 

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -306,7 +306,7 @@ class DSLRunner(ConfigWrapper):
                 f"[green italic]💾 Output saved to {output_config['path']}[/green italic]"
             )
         else:
-            raise ValueError(f"Unsupported output type: {output_config['type']}")
+            raise ValueError(f"Unsupported output type: {output_config['type']}. Supported types: file")
 
     def execute_step(
         self, step: Dict, input_data: Optional[List[Dict]]

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 import hashlib
 from rich.console import Console
 from rich.prompt import Confirm
+from rich.panel import Panel
 
 from docetl.dataset import Dataset, create_parsing_tool_map
 from docetl.operations import get_operation, get_operations
@@ -133,26 +134,17 @@ class DSLRunner(ConfigWrapper):
     def syntax_check(self):
         """
         Perform a syntax check on all operations defined in the configuration.
-
-        This method validates each operation by attempting to instantiate it.
-        If any operation fails to instantiate, a ValueError is raised.
-
-        Raises:
-            ValueError: If any operation fails the syntax check.
         """
-        self.console.rule("[yellow]Syntax Check[/yellow]")
-        self.console.print(
-            "[yellow]Performing syntax check on all operations...[/yellow]"
-        )
-
+        syntax_content = "[yellow]Performing syntax check on all operations...[/yellow]\n\n"
+        
         # Just validate that it's a json file if specified
         self.get_output_path()
 
-        for operation_config in self.config["operations"]:
-            operation = operation_config["name"]
-            operation_type = operation_config["type"]
+        try:
+            for operation_config in self.config["operations"]:
+                operation = operation_config["name"]
+                operation_type = operation_config["type"]
 
-            try:
                 operation_class = get_operation(operation_type)
                 operation_class(
                     self,
@@ -161,12 +153,14 @@ class DSLRunner(ConfigWrapper):
                     self.max_threads,
                     self.console,
                 )
-            except Exception as e:
-                raise ValueError(
-                    f"Syntax check failed for operation '{operation}': {str(e)}"
-                )
+                syntax_content += f"[green]✓[/green] Operation '{operation}' ({operation_type})\n"
+        except Exception as e:
+            raise ValueError(
+                f"Syntax check failed for operation '{operation}': {str(e)}"
+            )
 
-        self.console.print("[green]Syntax check passed for all operations.[/green]")
+        syntax_content += "\n[green]Syntax check passed for all operations.[/green]"
+        self.console.print(Panel.fit(syntax_content, title="[yellow]Syntax Check[/yellow]"))
 
     def find_operation(self, op_name: str) -> Dict:
         for operation_config in self.config["operations"]:
@@ -186,7 +180,7 @@ class DSLRunner(ConfigWrapper):
         """
 
         # Fail early if we can't save the output...
-        self.get_output_path(require=True)
+        output_path = self.get_output_path(require=True)
 
         self.console.rule("[bold blue]Pipeline Execution[/bold blue]")
         start_time = time.time()
@@ -194,11 +188,15 @@ class DSLRunner(ConfigWrapper):
         output, total_cost = self.run(self.load())
         self.save(output)
 
-        self.console.rule("[bold green]Execution Summary[/bold green]")
-        self.console.print(f"[bold green]Total cost: [green]${total_cost:.2f}[/green]")
-        self.console.print(
-            f"[bold green]Total time: [green]{time.time() - start_time:.2f} seconds[/green]"
+        execution_time = time.time() - start_time
+        summary_content = (
+            "[bold]Pipeline Execution Complete[/bold]\n\n"
+            f"[bold green]Total cost:[/bold green] [green]${total_cost:.2f}[/green]\n"
+            f"[bold green]Total time:[/bold green] [green]{execution_time:.2f} seconds[/green]\n"
+            f"[bold green]Intermediate directory:[/bold green]\n[green]{self.intermediate_dir}[/green]\n"
+            f"[bold green]Saved output to:[/bold green]\n[green]{output_path}[/green]"
         )
+        self.console.print(Panel.fit(summary_content, title="[bold green]Execution Summary[/bold green]"))
 
         return total_cost
 
@@ -236,6 +234,7 @@ class DSLRunner(ConfigWrapper):
 
         # Save the self.step_op_hashes to a file if self.intermediate_dir exists
         if self.intermediate_dir:
+            os.makedirs(self.intermediate_dir, exist_ok=True)
             with open(
                 os.path.join(self.intermediate_dir, ".docetl_intermediate_config.json"),
                 "w",
@@ -256,8 +255,9 @@ class DSLRunner(ConfigWrapper):
         Raises:
             ValueError: If an unsupported dataset type is encountered.
         """
-        self.console.rule("[cyan]Loading Datasets[/cyan]")
+        dataset_content = ""
         datasets = {}
+        
         for name, dataset_config in self.config["datasets"].items():
             if dataset_config["type"] == "file":
                 datasets[name] = Dataset(
@@ -268,9 +268,11 @@ class DSLRunner(ConfigWrapper):
                     parsing=dataset_config.get("parsing", []),
                     user_defined_parsing_tool_map=self.parsing_tool_map,
                 )
-                self.console.print(f"Loaded dataset: [bold]{name}[/bold]")
+                dataset_content += f"[green]✓[/green] Loaded dataset: [bold]{name}[/bold]\n"
             else:
                 raise ValueError(f"Unsupported dataset type: {dataset_config['type']}")
+        
+        self.console.print(Panel.fit(dataset_content, title="[cyan]Loading Datasets[/cyan]"))
         return datasets
 
     def save(self, data: List[Dict]):
@@ -313,19 +315,10 @@ class DSLRunner(ConfigWrapper):
     ) -> Tuple[List[Dict], float]:
         """
         Execute a single step in the pipeline.
-
-        This method runs all operations defined for a step, updating the progress
-        and calculating the cost.
-
-        Args:
-            step (Dict): The step configuration.
-            input_data (Optional[List[Dict]]): Input data for the step.
-
-        Returns:
-            Tuple[List[Dict], float]: A tuple containing the output data and the total cost of the step.
         """
-        self.console.rule(f"[bold blue]Executing Step: {step['name']}[/bold blue]")
+        step_content = f"[bold blue]Step: {step['name']}[/bold blue]\n\n"
         total_cost = 0
+
         for operation in step["operations"]:
             if isinstance(operation, dict):
                 operation_name = list(operation.keys())[0]
@@ -334,15 +327,13 @@ class DSLRunner(ConfigWrapper):
                 operation_name = operation
                 operation_config = {}
 
-            # Load from checkpoint if it exists
+            # Load from checkpoint if exists
             attempted_input_data = self._load_from_checkpoint_if_exists(
                 step["name"], operation_name
             )
             if attempted_input_data is not None:
                 input_data = attempted_input_data
-                self.console.print(
-                    f"[green]✓ [italic]Loaded saved data for operation '{operation_name}' in step '{step['name']}'[/italic][/green]"
-                )
+                step_content += f"[green]✓[/green] [italic]Loaded saved data for operation '{operation_name}'[/italic]\n"
                 continue
 
             # Delete existing intermediate file before running operation
@@ -384,9 +375,7 @@ class DSLRunner(ConfigWrapper):
                 else:
                     input_data, cost = operation_instance.execute(input_data)
                 total_cost += cost
-                self.console.log(
-                    f"\tOperation [cyan]{operation_name}[/cyan] completed. Cost: [green]${cost:.2f}[/green]"
-                )
+                step_content += f"[green]✓[/green] Operation [cyan]{operation_name}[/cyan] completed (Cost: [green]${cost:.2f}[/green])\n"
 
             # Checkpoint after each operation
             if self.intermediate_dir:
@@ -413,6 +402,12 @@ class DSLRunner(ConfigWrapper):
                 with open(intermediate_config_path, "w") as f:
                     json.dump(existing_config, f, indent=2)
 
+                step_content += f"[green]✓[/green] [italic]Saved checkpoint for operation '{operation_name}'[/italic]\n"
+
+        self.console.print(Panel.fit(
+            step_content,
+            title=f"[bold blue]Step Execution: {step['name']}[/bold blue]"
+        ))
         return input_data, total_cost
 
     def _load_from_checkpoint_if_exists(

--- a/docs/operators/map.md
+++ b/docs/operators/map.md
@@ -148,6 +148,7 @@ This example demonstrates how the Map operation can transform long, unstructured
 | `max_retries_per_timeout`         | Maximum number of retries per timeout                                                           | 2                             |
 | `timeout`                         | Timeout for each LLM call in seconds                                                            | 120                           |
 | `litellm_completion_kwargs` | Additional parameters to pass to LiteLLM completion calls. | {}                          |
+| `skip_on_error` | If true, skip the operation if the LLM returns an error. | False                          |
 
 Note: If `drop_keys` is specified, `prompt` and `output` become optional parameters.
 


### PR DESCRIPTION
For our model cascades experiments (separate project), sometimes we run into errors like content warnings or repetitive words in prompt (400 error), which terminates the program. We should allow users to skip these.