### PR TITLE
docs: add verbose param

### DIFF
--- a/docetl/utils.py
+++ b/docetl/utils.py
@@ -120,7 +120,11 @@ def extract_jinja_variables(template_string: str) -> List[str]:
 
 def completion_cost(response) -> float:
     try:
-        return lcc(response)
+        return (
+            response._completion_cost
+            if hasattr(response, "_completion_cost")
+            else lcc(response)
+        )
     except Exception:
         return 0.0
 

--- a/docs/operators/map.md
+++ b/docs/operators/map.md
@@ -149,6 +149,7 @@ This example demonstrates how the Map operation can transform long, unstructured
 | `timeout`                         | Timeout for each LLM call in seconds                                                            | 120                           |
 | `litellm_completion_kwargs` | Additional parameters to pass to LiteLLM completion calls. | {}                          |
 | `skip_on_error` | If true, skip the operation if the LLM returns an error. | False                          |
+| `bypass_cache` | If true, bypass the cache for this operation. | False                          |
 
 Note: If `drop_keys` is specified, `prompt` and `output` become optional parameters.
 

--- a/docs/operators/reduce.md
+++ b/docs/operators/reduce.md
@@ -65,6 +65,7 @@ This Reduce operation processes customer feedback grouped by department:
 | `timeout`                 | Timeout for each LLM call in seconds                                                                   | 120                         |
 | `max_retries_per_timeout` | Maximum number of retries per timeout                                                                  | 2                           |
 | `litellm_completion_kwargs` | Additional parameters to pass to LiteLLM completion calls. | {}                          |
+| `bypass_cache` | If true, bypass the cache for this operation. | False                          |
 
 ## Advanced Features
 

--- a/docs/operators/resolve.md
+++ b/docs/operators/resolve.md
@@ -128,6 +128,7 @@ After determining eligible pairs for comparison, the Resolve operation uses a Un
 | `max_retries_per_timeout` | Maximum number of retries per timeout                                             | 2                             |
 | `sample`                  | Number of samples to use for the operation                                                      |   None                        |
 | `litellm_completion_kwargs` | Additional parameters to pass to LiteLLM completion calls. | {}                          |
+| `bypass_cache` | If true, bypass the cache for this operation. | False                          |
 
 ## Best Practices
 

--- a/tests/basic/test_basic_map.py
+++ b/tests/basic/test_basic_map.py
@@ -358,4 +358,30 @@ def test_map_operation_with_max_tokens(simple_map_config, map_sample_data, api_w
     # Since we limited max_tokens to 10, each response should be relatively short
     # The sentiment field should contain just the sentiment value without much extra text
     assert all(len(result["sentiment"]) <= 20 for result in results)
+    
+def test_map_operation_with_verbose(simple_map_config, map_sample_data, api_wrapper):
+    # Add verbose configuration
+    map_config_with_verbose = {
+        **simple_map_config,
+        "verbose": True,
+        "bypass_cache": True
+    }
+
+    operation = MapOperation(api_wrapper, map_config_with_verbose, "gpt-4o-mini", 4)
+
+    # Execute the operation
+    results, cost = operation.execute(map_sample_data)
+
+    # Assert that we have results for all input items
+    assert len(results) == len(map_sample_data)
+
+    # Check that all results have a sentiment
+    assert all("sentiment" in result for result in results)
+
+    # Verify that all sentiments are valid
+    valid_sentiments = ["positive", "negative", "neutral"]
+    assert all(
+        any(vs in result["sentiment"] for vs in valid_sentiments) for result in results
+    )
+
 


### PR DESCRIPTION
This PR does 2 things:
- add verbose param to print LLM input and output
- add bypass_cache to docs