### PR TITLE
feat: refactoring map optimizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ website/next-env.d.ts
 
 # experiments
 experiments/*.json
+
+metrics_vs_cost.png

--- a/docetl/api.py
+++ b/docetl/api.py
@@ -180,10 +180,12 @@ class Pipeline:
     def optimize(
         self,
         max_threads: Optional[int] = None,
-        model: str = "gpt-4o",
+        rewrite_agent_model: str = "gpt-4o",
+        judge_agent_model: str = "gpt-4o-mini",
         resume: bool = False,
         timeout: int = 60,
         litellm_kwargs: Dict[str, Any] = {},
+        save_path: Optional[str] = None,
     ) -> "Pipeline":
         """
         Optimize the pipeline using the Optimizer.
@@ -205,11 +207,13 @@ class Pipeline:
             max_threads=max_threads,
         )
         optimized_config, _ = runner.optimize(
-            model=model,
+            rewrite_agent_model=rewrite_agent_model,
+            judge_agent_model=judge_agent_model,
             resume=resume,
             timeout=timeout,
             litellm_kwargs=litellm_kwargs,
             return_pipeline=False,
+            save_path=save_path,
         )
 
         updated_pipeline = Pipeline(

--- a/docetl/api.py
+++ b/docetl/api.py
@@ -144,6 +144,7 @@ class Pipeline:
         parsing_tools: List[Union[ParsingTool, Callable]] = [],
         default_model: Optional[str] = None,
         rate_limits: Optional[Dict[str, int]] = None,
+        optimizer_config: Dict[str, Any] = {},
     ):
         self.name = name
         self.datasets = datasets
@@ -162,6 +163,7 @@ class Pipeline:
         ]
         self.default_model = default_model
         self.rate_limits = rate_limits
+        self.optimizer_config = optimizer_config
         self._load_env()
 
     def _load_env(self):
@@ -180,11 +182,7 @@ class Pipeline:
     def optimize(
         self,
         max_threads: Optional[int] = None,
-        rewrite_agent_model: str = "gpt-4o",
-        judge_agent_model: str = "gpt-4o-mini",
         resume: bool = False,
-        timeout: int = 60,
-        litellm_kwargs: Dict[str, Any] = {},
         save_path: Optional[str] = None,
     ) -> "Pipeline":
         """
@@ -207,11 +205,7 @@ class Pipeline:
             max_threads=max_threads,
         )
         optimized_config, _ = runner.optimize(
-            rewrite_agent_model=rewrite_agent_model,
-            judge_agent_model=judge_agent_model,
             resume=resume,
-            timeout=timeout,
-            litellm_kwargs=litellm_kwargs,
             return_pipeline=False,
             save_path=save_path,
         )
@@ -224,6 +218,7 @@ class Pipeline:
             output=self.output,
             default_model=self.default_model,
             parsing_tools=self.parsing_tools,
+            optimizer_config=self.optimizer_config,
         )
         updated_pipeline._update_from_dict(optimized_config)
         return updated_pipeline
@@ -292,6 +287,7 @@ class Pipeline:
                 if self.parsing_tools
                 else None
             ),
+            "optimizer_config": self.optimizer_config,
         }
         if self.rate_limits:
             d["rate_limits"] = self.rate_limits

--- a/docetl/apis/pd_accessors.py
+++ b/docetl/apis/pd_accessors.py
@@ -91,10 +91,7 @@ class SemanticAccessor:
         """
         self.runner.config.update(config)
 
-        builder = Optimizer(
-            self.runner,
-            model=self.runner.config["default_model"],
-        )
+        builder = Optimizer(self.runner)
         self.runner.optimizer = builder
 
     def _record_operation(

--- a/docetl/cli.py
+++ b/docetl/cli.py
@@ -19,12 +19,17 @@ def build(
     max_threads: Optional[int] = typer.Option(
         None, help="Maximum number of threads to use for running operations"
     ),
-    model: str = typer.Option("gpt-4o", help="Model to use for optimization"),
+    rewrite_agent_model: str = typer.Option(
+        "gpt-4o", help="Model to use for rewriting operations"
+    ),
+    judge_agent_model: str = typer.Option(
+        "gpt-4o-mini", help="Model to use for judging rewritten operations"
+    ),
     resume: bool = typer.Option(
         False, help="Resume optimization from a previous build that may have failed"
     ),
-    timeout: int = typer.Option(
-        60, help="Timeout for optimization operations in seconds"
+    save_path: Path = typer.Option(
+        None, help="Path to save the optimized pipeline configuration"
     ),
 ):
     """
@@ -36,7 +41,7 @@ def build(
         max_threads (Optional[int]): Maximum number of threads to use for running operations.
         model (str): Model to use for optimization. Defaults to "gpt-4o".
         resume (bool): Whether to resume optimization from a previous run. Defaults to False.
-        timeout (int): Timeout for optimization operations in seconds. Defaults to 60.
+        save_path (Path): Path to save the optimized pipeline configuration.
     """
     # Get the current working directory (where the user called the command)
     cwd = os.getcwd()
@@ -47,13 +52,14 @@ def build(
         load_dotenv(env_file)
 
     runner = DSLRunner.from_yaml(str(yaml_file), max_threads=max_threads)
+    runner.config["optimizer_rewrite_agent_model"] = rewrite_agent_model
+    runner.config["optimizer_judge_agent_model"] = judge_agent_model
     runner.optimize(
         save=True,
         return_pipeline=False,
-        model=model or runner.config.get("optimizer_model", "gpt-4o"),
         resume=resume,
-        timeout=timeout,
         litellm_kwargs=runner.config.get("optimizer_litellm_kwargs", {}),
+        save_path=save_path,
     )
 
 

--- a/docetl/cli.py
+++ b/docetl/cli.py
@@ -19,12 +19,6 @@ def build(
     max_threads: Optional[int] = typer.Option(
         None, help="Maximum number of threads to use for running operations"
     ),
-    rewrite_agent_model: str = typer.Option(
-        "gpt-4o", help="Model to use for rewriting operations"
-    ),
-    judge_agent_model: str = typer.Option(
-        "gpt-4o-mini", help="Model to use for judging rewritten operations"
-    ),
     resume: bool = typer.Option(
         False, help="Resume optimization from a previous build that may have failed"
     ),
@@ -52,13 +46,10 @@ def build(
         load_dotenv(env_file)
 
     runner = DSLRunner.from_yaml(str(yaml_file), max_threads=max_threads)
-    runner.config["optimizer_rewrite_agent_model"] = rewrite_agent_model
-    runner.config["optimizer_judge_agent_model"] = judge_agent_model
     runner.optimize(
         save=True,
         return_pipeline=False,
         resume=resume,
-        litellm_kwargs=runner.config.get("optimizer_litellm_kwargs", {}),
         save_path=save_path,
     )
 

--- a/docetl/containers.py
+++ b/docetl/containers.py
@@ -177,7 +177,14 @@ class OpContainer:
                                     is_filter=self.config["type"] == "filter",
                                 )
                                 optimized_ops, _, cost = map_optimizer.optimize(
-                                    self.config, input_data[0]
+                                    self.config,
+                                    input_data[0],
+                                    plan_types=self.runner.config.get(
+                                        "optimizer_config", {}
+                                    ).get(
+                                        "plan_types",
+                                        ["chunk", "proj_synthesis", "glean"],
+                                    ),
                                 )
                                 self.runner.total_cost += cost
                             elif self.config.get("type") == "reduce":

--- a/docetl/containers.py
+++ b/docetl/containers.py
@@ -181,7 +181,9 @@ class OpContainer:
                                     input_data[0],
                                     plan_types=self.runner.config.get(
                                         "optimizer_config", {}
-                                    ).get(
+                                    )
+                                    .get("map", {})
+                                    .get(
                                         "plan_types",
                                         ["chunk", "proj_synthesis", "glean"],
                                     ),

--- a/docetl/operations/__init__.py
+++ b/docetl/operations/__init__.py
@@ -11,6 +11,7 @@ from docetl.operations.split import SplitOperation
 from docetl.operations.sample import SampleOperation
 from docetl.operations.unnest import UnnestOperation
 from docetl.operations.scan import ScanOperation
+from docetl.operations.add_uuid import AddUuidOperation
 
 mapping = {
     "cluster": ClusterOperation,
@@ -26,7 +27,8 @@ mapping = {
     "split": SplitOperation,
     "sample": SampleOperation,
     "unnest": UnnestOperation,
-    "scan": ScanOperation
+    "scan": ScanOperation,
+    "add_uuid": AddUuidOperation
 }
 
 def get_operation(operation_type: str):

--- a/docetl/operations/add_uuid.py
+++ b/docetl/operations/add_uuid.py
@@ -1,0 +1,44 @@
+import uuid
+from typing import Any, Dict, List, Tuple
+
+from docetl.operations.base import BaseOperation
+
+
+class AddUuidOperation(BaseOperation):
+    """
+    A class that implements an operation to add a UUID to each document.
+
+    This class extends BaseOperation to:
+    1. Generate a unique UUID for each document
+    2. Add the UUID under a key formatted as {operation_name}_id
+    """
+
+    class schema(BaseOperation.schema):
+        type: str = "add_uuid"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = self.config["name"]
+
+    def syntax_check(self) -> None:
+        # No additional configuration needed beyond base requirements
+        pass
+
+    def execute(
+        self, input_data: List[Dict[str, Any]]
+    ) -> Tuple[List[Dict[str, Any]], float]:
+        results = []
+        cost = 0.0
+
+        # If there's an id key in the config, use that as the id key
+        if "id_key" in self.config:
+            id_key = self.config["id_key"]
+        else:
+            id_key = f"{self.name}_id"
+
+        for item in input_data:
+            result = item.copy()
+            result[id_key] = str(uuid.uuid4())
+            results.append(result)
+
+        return results, cost

--- a/docetl/operations/gather.py
+++ b/docetl/operations/gather.py
@@ -297,9 +297,14 @@ class GatherOperation(BaseOperation):
         current_chunk_headers = current_chunk.get(doc_header_key, [])
         highest_level = float("inf")  # Initialize with positive infinity
         for header_info in current_chunk_headers:
-            level = header_info.get("level")
-            if level is not None and level < highest_level:
-                highest_level = level
+            try:
+                level = header_info.get("level")
+                if level is not None and level < highest_level:
+                    highest_level = level
+            except Exception as e:
+                self.runner.console.log(f"[red]Error processing header: {e}[/red]")
+                self.runner.console.log(f"[red]Header: {header_info}[/red]")
+                return ""
 
         # If no headers found in the current chunk, set highest_level to None
         if highest_level == float("inf"):
@@ -307,14 +312,19 @@ class GatherOperation(BaseOperation):
 
         for chunk in chunks:
             for header_info in chunk.get(doc_header_key, []):
-                header = header_info["header"]
-                level = header_info["level"]
-                if header and level:
-                    current_hierarchy[level] = header
+                try:
+                    header = header_info["header"]
+                    level = header_info["level"]
+                    if header and level:
+                        current_hierarchy[level] = header
                     # Clear lower levels when a higher level header is found
                     for lower_level in range(level + 1, len(current_hierarchy) + 1):
                         if lower_level in current_hierarchy:
                             current_hierarchy[lower_level] = None
+                except Exception as e:
+                    self.runner.console.log(f"[red]Error processing header: {e}[/red]")
+                    self.runner.console.log(f"[red]Header: {header_info}[/red]")
+                    return ""
 
         rendered_headers = [
             f"{'#' * level} {header}"

--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -490,7 +490,8 @@ class ParallelMapOperation(BaseOperation):
         def process_prompt(item, prompt_config):
             prompt = strict_render(prompt_config["prompt"], {"input": item})
             local_output_schema = {
-                key: output_schema[key] for key in prompt_config["output_keys"]
+                key: output_schema.get(key, "string")
+                for key in prompt_config["output_keys"]
             }
             model = prompt_config.get("model", self.default_model)
             if not model:

--- a/docetl/optimizer.py
+++ b/docetl/optimizer.py
@@ -144,8 +144,7 @@ class Optimizer:
                 f"[yellow]Sample Size:[/yellow] {self.sample_size_map}\n"
                 f"[yellow]Max Threads:[/yellow] {self.max_threads}\n"
                 f"[yellow]Rewrite Agent Model:[/yellow] {self.llm_client.rewrite_agent_model}\n"
-                f"[yellow]Judge Agent Model:[/yellow] {self.llm_client.judge_agent_model}\n"
-                f"[yellow]Timeout:[/yellow] {self.timeout} seconds",
+                f"[yellow]Judge Agent Model:[/yellow] {self.llm_client.judge_agent_model}\n",
                 title="Optimizer Configuration",
             )
         )

--- a/docetl/optimizer.py
+++ b/docetl/optimizer.py
@@ -55,7 +55,8 @@ class Optimizer:
     def __init__(
         self,
         runner: "DSLRunner",
-        model: str = "gpt-4o",
+        rewrite_agent_model: str = "gpt-4o",
+        judge_agent_model: str = "gpt-4o-mini",
         litellm_kwargs: Dict[str, Any] = {},
         resume: bool = False,
         timeout: int = 60,
@@ -99,7 +100,9 @@ class Optimizer:
         self.status = runner.status
 
         self.optimized_config = copy.deepcopy(self.config)
-        self.llm_client = LLMClient(runner, model, **litellm_kwargs)
+        self.llm_client = LLMClient(
+            runner, rewrite_agent_model, judge_agent_model, **litellm_kwargs
+        )
         self.timeout = timeout
         self.resume = resume
         self.captured_output = CapturedOutput()
@@ -140,7 +143,8 @@ class Optimizer:
                 "[bold cyan]Optimizer Configuration[/bold cyan]\n"
                 f"[yellow]Sample Size:[/yellow] {self.sample_size_map}\n"
                 f"[yellow]Max Threads:[/yellow] {self.max_threads}\n"
-                f"[yellow]Model:[/yellow] {self.llm_client.model}\n"
+                f"[yellow]Rewrite Agent Model:[/yellow] {self.llm_client.rewrite_agent_model}\n"
+                f"[yellow]Judge Agent Model:[/yellow] {self.llm_client.judge_agent_model}\n"
                 f"[yellow]Timeout:[/yellow] {self.timeout} seconds",
                 title="Optimizer Configuration",
             )
@@ -338,7 +342,7 @@ class Optimizer:
         Analyzes whether an operation should be optimized by running it on a sample of input data
         and evaluating potential optimizations. Returns the optimization suggestion and relevant data.
         """
-        self.console.rule("[bold cyan]Beginning Pipeline Optimization[/bold cyan]")
+        self.console.rule("[bold cyan]Beginning Pipeline Assessment[/bold cyan]")
 
         self._insert_empty_resolve_operations()
 
@@ -408,7 +412,7 @@ class Optimizer:
         Optimizes the entire pipeline by walking the operation DAG and applying
         operation-specific optimizers where marked. Returns the total optimization cost.
         """
-        self.console.rule("[bold cyan]Beginning Pipeline Optimization[/bold cyan]")
+        self.console.rule("[bold cyan]Beginning Pipeline Rewrites[/bold cyan]")
 
         # If self.resume is True and there's a checkpoint, load it
         if self.resume:
@@ -606,7 +610,7 @@ class Optimizer:
         def clean_operation(op_container: OpContainer) -> Dict:
             """Remove internal fields from operation config"""
             op_config = op_container.config
-            clean_op = op_config.copy()
+            clean_op = copy.deepcopy(op_config)
 
             clean_op.pop("_intermediates", None)
 

--- a/docetl/optimizers/join_optimizer.py
+++ b/docetl/optimizers/join_optimizer.py
@@ -71,7 +71,7 @@ class JoinOptimizer:
             },
         ]
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             messages,
             "You are an expert in analyzing natural language prompts for data processing tasks.",
             {
@@ -121,7 +121,7 @@ class JoinOptimizer:
                 "content": f"{context_prefix}I want to do a reduce operation on these values, and I need to determine if there are semantic duplicates in the data, where the strings are different but they technically belong in the same group. Note that exact string duplicates should not be considered here.\n\nHere's a sample of the data (showing the '{reduce_key}' field(s)): {data_sample}\n\nBased on this {'context and ' if map_prompt else ''}sample, are there likely to be such semantic duplicates (not exact string matches) in the dataset? Respond with 'yes' only if you think there are semantic duplicates, or 'no' if you don't see evidence of semantic duplicates or if you only see exact string duplicates.",
             },
         ]
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             messages,
             "You are an expert data analyst. Analyze the given data sample and determine if there are likely to be semantic duplicate values that belong in the same group, even if the strings are different.",
             {
@@ -209,7 +209,9 @@ class JoinOptimizer:
             "required": ["duplicates_found", "explanation"],
         }
 
-        response = self.llm_client.generate(messages, system_prompt, response_schema)
+        response = self.llm_client.generate_rewrite(
+            messages, system_prompt, response_schema
+        )
 
         # Print the duplicates_found and explanation
         self.console.log(
@@ -258,7 +260,7 @@ class JoinOptimizer:
             }
         ]
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             messages,
             system_prompt,
             {
@@ -342,7 +344,7 @@ class JoinOptimizer:
             }
         ]
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             messages,
             system_prompt,
             {
@@ -813,7 +815,7 @@ class JoinOptimizer:
             }
         ]
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             messages,
             "You are an AI expert in data analysis and entity matching.",
             {
@@ -874,7 +876,7 @@ class JoinOptimizer:
             }
         ]
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             messages,
             "You are an AI expert in data analysis and decomposing complex data processing pipelines.",
             {
@@ -943,7 +945,7 @@ class JoinOptimizer:
             }
         ]
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             messages,
             "You are an expert in entity matching and database operations.",
             {
@@ -1312,7 +1314,7 @@ class JoinOptimizer:
 
         for attempt in range(self.agent_max_retries):  # Up to 3 attempts
             # Generate blocking rule using the LLM
-            response = self.llm_client.generate(
+            response = self.llm_client.generate_rewrite(
                 messages,
                 "You are an expert in entity resolution and Python programming. Your task is to generate one efficient blocking rule based on the given sample comparisons and data structure.",
                 {
@@ -1490,7 +1492,7 @@ Please provide 3-5 different containment-based blocking rules, based on the keys
             },
         ]
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             messages,
             "You are an expert in data matching and Python programming.",
             {
@@ -1570,7 +1572,7 @@ Please provide 3-5 different containment-based blocking rules, based on the keys
         ]
 
         for attempt in range(self.agent_max_retries):
-            response = self.llm_client.generate(
+            response = self.llm_client.generate_rewrite(
                 messages,
                 "You are an expert in entity resolution and Python programming. Your task is to generate one efficient blocking rule based on the given sample comparisons and data structure.",
                 {

--- a/docetl/optimizers/map_optimizer/config_generators.py
+++ b/docetl/optimizers/map_optimizer/config_generators.py
@@ -115,7 +115,7 @@ class ConfigGenerator:
             "additionalProperties": False,
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [
                 {"role": "user", "content": prompt},
             ],
@@ -268,7 +268,7 @@ class ConfigGenerator:
             "required": ["needs_metadata", "reason"],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [
                 {"role": "user", "content": prompt},
             ],
@@ -400,7 +400,7 @@ class ConfigGenerator:
             ],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [
                 {"role": "user", "content": prompt},
             ],

--- a/docetl/optimizers/map_optimizer/operation_creators.py
+++ b/docetl/optimizers/map_optimizer/operation_creators.py
@@ -13,6 +13,7 @@ class OperationCreator:
     ) -> Dict[str, Any]:
         output = op_config["output"]
         output["schema"] = op_output_schema
+
         parallel_map_op = {
             "type": "parallel_map",
             "name": f"{op_config['name']}_parallel_map",
@@ -194,13 +195,13 @@ class OperationCreator:
         combine_prompt: str,
         is_associative: bool,
         doc_id_key: str,
+        add_input: bool = True,
     ) -> Dict[str, Any]:
         name = f"subreduce_{op_config['name']}"
-        return {
+        config = {
             "type": "reduce",
             "name": name,
             "reduce_key": [doc_id_key],
-            "input": op_config["output"],  # subselect keys
             "prompt": combine_prompt,
             "model": (
                 op_config["model"]
@@ -213,3 +214,6 @@ class OperationCreator:
             "synthesize_resolve": False,
             "_intermediates": {"last_map_prompt": op_config["prompt"]},
         }
+        if add_input:
+            config["input"] = op_config["output"]  # subselect keys
+        return config

--- a/docetl/optimizers/map_optimizer/optimizer.py
+++ b/docetl/optimizers/map_optimizer/optimizer.py
@@ -379,8 +379,13 @@ class MapOptimizer:
         self.console.log(table)
         self.console.log("\n")
 
-        best_plan = candidate_plans[best_plan_name]
-        best_output = results[best_plan_name][2]
+        try:
+            best_plan = candidate_plans[best_plan_name]
+            best_output = results[best_plan_name][2]
+        except KeyError:
+            raise ValueError(
+                f"Best plan name {best_plan_name} not found in candidate plans. Candidate plan names: {candidate_plans.keys()}"
+            )
 
         self.console.log(
             f"[green]Current best plan: {best_plan_name} for operation {op_config['name']} "
@@ -464,8 +469,9 @@ class MapOptimizer:
 
                 if chunk_plans:
                     # Sample 2 random plans
+                    chunk_items = list(chunk_plans.items())
                     sample_plans = dict(
-                        random.sample(chunk_plans.items(), min(2, len(chunk_plans)))
+                        random.sample(chunk_items, min(2, len(chunk_items)))
                     )
                     sample_results = self._evaluate_plans(
                         sample_plans, op_config, evaluation_samples, validator_prompt
@@ -501,6 +507,7 @@ class MapOptimizer:
                         chunk_plans, op_config, evaluation_samples, validator_prompt
                     )
                     initial_results.update(chunk_results)
+                    candidate_plans.update(chunk_plans)
             else:
                 # Try all chunking plans since no improvement found yet
                 self.console.log(

--- a/docetl/optimizers/map_optimizer/optimizer.py
+++ b/docetl/optimizers/map_optimizer/optimizer.py
@@ -1,5 +1,6 @@
 import concurrent
 import copy
+import random
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -244,47 +245,12 @@ class MapOptimizer:
     ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], float]:
         """
         Optimize the given operation configuration for the input data.
-        This method analyzes the operation and input data, generates various
-        optimization plans, evaluates them, and returns the best plan along
-        with its output. A key part of this process is creating a custom
-        validator prompt for evaluation. The validator prompt is generated
-        based on the specific task, input data, and output data. It serves
-        as a critical tool for assessing the quality and correctness of
-        each optimization plan's output. This custom prompt ensures that
-        the evaluation is tailored to the unique requirements and nuances
-        of the given operation. The types of optimization plans include:
-
-        1. Improved Prompt Plan: Enhances the original prompt based on evaluation, aiming to improve output quality.
-
-        2. Chunk Size Plan: Splits input data into chunks of different sizes,
-           processes each chunk separately, and then combines the results. This
-           can improve performance for large inputs.
-
-        3. Gleaning Plans: Implements an iterative refinement process where the
-           output is validated and improved over multiple rounds, enhancing accuracy.
-
-        4. Chain Decomposition Plan: Breaks down complex operations into a series
-           of simpler sub-operations, potentially improving overall performance
-           and interpretability.
-
-        5. Parallel Map Plan: Decomposes the task into subtasks that can be
-           executed in parallel, potentially speeding up processing for
-           independent operations.
-
-        The method generates these plans, evaluates their performance using
-        a custom validator, and selects the best performing plan based on
-        output quality and execution time.
-
-        Args:
-            op_config (Dict[str, Any]): The configuration of the operation to optimize.
-            input_data (List[Dict[str, Any]]): The input data for the operation.
-
-        Returns:
-            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], float]: A tuple containing
-            the best optimization plan and its output. The plan is a list of
-            operation configurations that achieve the best performance.
-            The cost is the cost of the optimizer (from possibly synthesizing resolves).
-
+        Uses a staged evaluation approach:
+        1. For data exceeding limits: Try all plan types at once
+        2. For data within limits:
+            - First try gleaning/proj synthesis
+            - Compare with baseline
+            - Selectively try chunking plans based on initial results
         """
         # Verify that the plan types are valid
         for plan_type in plan_types:
@@ -303,7 +269,6 @@ class MapOptimizer:
             data_exceeds_limit,
         ) = self._should_optimize_helper(op_config, input_data)
 
-        # Check if improvement is needed based on the assessment
         if not self.config.get("optimizer_config", {}).get("force_decompose", False):
             if not data_exceeds_limit and not assessment.get("needs_improvement", True):
                 self.console.log(
@@ -315,78 +280,280 @@ class MapOptimizer:
                     self.plan_generator.subplan_optimizer_cost,
                 )
 
-        candidate_plans = {}
+        # Select consistent evaluation samples
+        num_evaluations = min(5, len(input_data))
+        evaluation_samples = select_evaluation_samples(input_data, num_evaluations)
 
-        # Generate improved prompt plan
-        if not data_exceeds_limit:
-            #     improved_prompt_plan = self.prompt_generator._get_improved_prompt(
-            #         op_config, assessment, input_data
-            #     )
-            #     candidate_plans["improved_instructions"] = improved_prompt_plan
-            candidate_plans["no_change"] = [op_config]
-
-        # Generate chunk size plans
-        self.console.post_optimizer_status(StageType.CANDIDATE_PLANS)
-        if "chunk" in plan_types:
-            self.console.log(
-                "[bold magenta]Generating chunking plans...[/bold magenta]"
+        if data_exceeds_limit:
+            # For data exceeding limits, try all plan types at once
+            return self._evaluate_all_plans(
+                op_config,
+                input_data,
+                evaluation_samples,
+                validator_prompt,
+                plan_types,
+                model_input_context_length,
+                data_exceeds_limit=True,
             )
-            chunk_size_plans = self.plan_generator._generate_chunk_size_plans(
-                op_config, input_data, validator_prompt, model_input_context_length
-            )
-            for pname, plan in chunk_size_plans.items():
-                candidate_plans[pname] = plan
 
-        # Generate gleaning plans
-        if not data_exceeds_limit and "glean" in plan_types:
+        # For data within limits, use staged evaluation
+        return self._staged_evaluation(
+            op_config,
+            input_data,
+            evaluation_samples,
+            validator_prompt,
+            plan_types,
+            no_change_runtime,
+            model_input_context_length,
+        )
+
+    def _select_best_plan(
+        self,
+        results: Dict[str, Tuple[float, float, List[Dict[str, Any]]]],
+        op_config: Dict[str, Any],
+        evaluation_samples: List[Dict[str, Any]],
+        validator_prompt: str,
+        candidate_plans: Dict[str, List[Dict[str, Any]]],
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], str, Dict[str, int]]:
+        """
+        Select the best plan from evaluation results using top-k comparison.
+
+        Returns:
+            Tuple of (best plan, best output, best plan name, pairwise rankings)
+        """
+        # Sort results by score in descending order
+        sorted_results = sorted(results.items(), key=lambda x: x[1][0], reverse=True)
+
+        # Take the top k plans
+        top_plans = sorted_results[: self.k_to_pairwise_compare]
+
+        # Check if there are no top plans
+        if len(top_plans) == 0:
+            raise ValueError(
+                "No valid plans were generated. Unable to proceed with optimization."
+            )
+
+        # Include any additional plans that are tied with the last plan
+        tail_score = (
+            top_plans[-1][1][0]
+            if len(top_plans) == self.k_to_pairwise_compare
+            else float("-inf")
+        )
+        filtered_results = dict(
+            top_plans
+            + [
+                item
+                for item in sorted_results[len(top_plans) :]
+                if item[1][0] == tail_score
+            ]
+        )
+
+        # Perform pairwise comparisons on filtered plans
+        if len(filtered_results) > 1:
+            pairwise_rankings = self.evaluator._pairwise_compare_plans(
+                filtered_results, validator_prompt, op_config, evaluation_samples
+            )
+            best_plan_name = max(pairwise_rankings, key=pairwise_rankings.get)
+        else:
+            pairwise_rankings = {k: 0 for k in results.keys()}
+            best_plan_name = next(iter(filtered_results))
+
+        # Display results table
+        self.console.log(
+            f"\n[bold]Plan Evaluation Results for {op_config['name']} ({op_config['type']}, {len(results)} plans, {len(evaluation_samples)} samples):[/bold]"
+        )
+        table = Table(show_header=True, header_style="bold magenta")
+        table.add_column("Plan", style="dim")
+        table.add_column("Score", justify="right", width=10)
+        table.add_column("Runtime", justify="right", width=10)
+        table.add_column("Pairwise Wins", justify="right", width=10)
+
+        for plan_name, (score, runtime, _) in sorted_results:
+            table.add_row(
+                plan_name,
+                f"{score:.2f}",
+                f"{runtime:.2f}s",
+                f"{pairwise_rankings.get(plan_name, 0)}",
+            )
+
+        self.console.log(table)
+        self.console.log("\n")
+
+        best_plan = candidate_plans[best_plan_name]
+        best_output = results[best_plan_name][2]
+
+        self.console.log(
+            f"[green]Current best plan: {best_plan_name} for operation {op_config['name']} "
+            f"(Score: {results[best_plan_name][0]:.2f}, "
+            f"Runtime: {results[best_plan_name][1]:.2f}s)[/green]"
+        )
+
+        return best_plan, best_output, best_plan_name, pairwise_rankings
+
+    def _staged_evaluation(
+        self,
+        op_config: Dict[str, Any],
+        input_data: List[Dict[str, Any]],
+        evaluation_samples: List[Dict[str, Any]],
+        validator_prompt: str,
+        plan_types: List[str],
+        no_change_runtime: float,
+        model_input_context_length: int,
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], float]:
+        """Stage 1: Try gleaning and proj synthesis plans first"""
+        candidate_plans = {"no_change": [op_config]}
+
+        # Generate initial plans (gleaning and proj synthesis)
+        if "glean" in plan_types:
             self.console.log(
                 "[bold magenta]Generating gleaning plans...[/bold magenta]"
             )
             gleaning_plans = self.plan_generator._generate_gleaning_plans(
                 op_config, validator_prompt
             )
-            for pname, plan in gleaning_plans.items():
-                candidate_plans[pname] = plan
+            candidate_plans.update(gleaning_plans)
 
-        # Generate chain decomposition plans
-        if not data_exceeds_limit and "proj_synthesis" in plan_types:
-            if not self.is_filter:
+        if "proj_synthesis" in plan_types and not self.is_filter:
+            self.console.log(
+                "[bold magenta]Generating independent projection synthesis plans...[/bold magenta]"
+            )
+            parallel_plans = self.plan_generator._generate_parallel_plans(
+                op_config, input_data
+            )
+            candidate_plans.update(parallel_plans)
+
+            self.console.log(
+                "[bold magenta]Generating chain projection synthesis plans...[/bold magenta]"
+            )
+            chain_plans = self.plan_generator._generate_chain_plans(
+                op_config, input_data
+            )
+            candidate_plans.update(chain_plans)
+
+        # Evaluate initial plans
+        initial_results = self._evaluate_plans(
+            candidate_plans,
+            op_config,
+            evaluation_samples,
+            validator_prompt,
+            no_change_runtime,
+        )
+
+        # Get best initial plan
+        best_plan, best_output, best_plan_name, pairwise_rankings = (
+            self._select_best_plan(
+                initial_results,
+                op_config,
+                evaluation_samples,
+                validator_prompt,
+                candidate_plans,
+            )
+        )
+        best_is_better_than_baseline = best_plan_name != "no_change"
+
+        # Stage 2: Decide whether/how to try chunking plans
+        if "chunk" in plan_types:
+            if best_is_better_than_baseline:
+                # Try 2 random chunking plans first
                 self.console.log(
-                    "[bold magenta]Generating chain projection synthesis plans...[/bold magenta]"
+                    "[bold magenta]Trying sample of chunking plans...[/bold magenta]"
                 )
-                chain_plans = self.plan_generator._generate_chain_plans(
-                    op_config, input_data
+                chunk_plans = self.plan_generator._generate_chunk_size_plans(
+                    op_config, input_data, validator_prompt, model_input_context_length
                 )
-                for pname, plan in chain_plans.items():
-                    candidate_plans[pname] = plan
 
-                # Generate parallel map plans
+                if chunk_plans:
+                    # Sample 2 random plans
+                    sample_plans = dict(
+                        random.sample(chunk_plans.items(), min(2, len(chunk_plans)))
+                    )
+                    sample_results = self._evaluate_plans(
+                        sample_plans, op_config, evaluation_samples, validator_prompt
+                    )
+
+                    # Do pairwise comparison between sampled plans and current best
+                    current_best = {best_plan_name: initial_results[best_plan_name]}
+                    current_best.update(sample_results)
+
+                    _, _, new_best_name, new_pairwise_rankings = self._select_best_plan(
+                        current_best,
+                        op_config,
+                        evaluation_samples,
+                        validator_prompt,
+                        {**{best_plan_name: best_plan}, **sample_plans},
+                    )
+
+                    if new_best_name == best_plan_name:
+                        self.console.log(
+                            "[yellow]Sample chunking plans did not improve results. Keeping current best plan.[/yellow]"
+                        )
+                        return (
+                            best_plan,
+                            best_output,
+                            self.plan_generator.subplan_optimizer_cost,
+                        )
+
+                    # If a sampled plan wins, evaluate all chunking plans
+                    self.console.log(
+                        "[bold magenta]Generating all chunking plans...[/bold magenta]"
+                    )
+                    chunk_results = self._evaluate_plans(
+                        chunk_plans, op_config, evaluation_samples, validator_prompt
+                    )
+                    initial_results.update(chunk_results)
+            else:
+                # Try all chunking plans since no improvement found yet
                 self.console.log(
-                    "[bold magenta]Generating independent projection synthesis plans...[/bold magenta]"
+                    "[bold magenta]Generating chunking plans...[/bold magenta]"
                 )
-                parallel_plans = self.plan_generator._generate_parallel_plans(
-                    op_config, input_data
+                chunk_plans = self.plan_generator._generate_chunk_size_plans(
+                    op_config, input_data, validator_prompt, model_input_context_length
                 )
-                for pname, plan in parallel_plans.items():
-                    candidate_plans[pname] = plan
+                chunk_results = self._evaluate_plans(
+                    chunk_plans, op_config, evaluation_samples, validator_prompt
+                )
+                initial_results.update(chunk_results)
+                candidate_plans.update(chunk_plans)
 
-        # Select consistent evaluation samples
-        num_evaluations = min(5, len(input_data))
-        evaluation_samples = select_evaluation_samples(input_data, num_evaluations)
+        # Final selection of best plan
+        best_plan, best_output, _, final_pairwise_rankings = self._select_best_plan(
+            initial_results,
+            op_config,
+            evaluation_samples,
+            validator_prompt,
+            candidate_plans,
+        )
 
-        results = {}
-        plans_list = list(candidate_plans.items())
-
-        # Capture candidate plans
+        # Capture evaluation results with pairwise rankings
+        ratings = {k: v[0] for k, v in initial_results.items()}
+        runtime = {k: v[1] for k, v in initial_results.items()}
+        sample_outputs = {k: v[2] for k, v in initial_results.items()}
         self.runner.optimizer.captured_output.save_optimizer_output(
-            stage_type=StageType.CANDIDATE_PLANS,
-            output=candidate_plans,
+            stage_type=StageType.EVALUATION_RESULTS,
+            output={
+                "input_data": evaluation_samples,
+                "all_plan_ratings": ratings,
+                "all_plan_runtimes": runtime,
+                "all_plan_sample_outputs": sample_outputs,
+                "all_plan_pairwise_rankings": final_pairwise_rankings,
+            },
         )
 
-        self.console.post_optimizer_status(StageType.EVALUATION_RESULTS)
-        self.console.log(
-            f"[bold magenta]Evaluating {len(plans_list)} plans...[/bold magenta]"
-        )
+        self.console.post_optimizer_status(StageType.END)
+        return best_plan, best_output, self.plan_generator.subplan_optimizer_cost
+
+    def _evaluate_plans(
+        self,
+        plans: Dict[str, List[Dict[str, Any]]],
+        op_config: Dict[str, Any],
+        evaluation_samples: List[Dict[str, Any]],
+        validator_prompt: str,
+        no_change_runtime: Optional[float] = None,
+    ) -> Dict[str, Tuple[float, float, List[Dict[str, Any]]]]:
+        """Helper method to evaluate a set of plans in parallel"""
+        results = {}
+        plans_list = list(plans.items())
+
         for i in range(0, len(plans_list), self._num_plans_to_evaluate_in_parallel):
             batch = plans_list[i : i + self._num_plans_to_evaluate_in_parallel]
             with ThreadPoolExecutor(
@@ -413,96 +580,95 @@ class MapOptimizer:
                             f"[yellow]Plan {plan_name} timed out and will be skipped.[/yellow]"
                         )
                     except Exception as e:
-                        # TODO: raise this error if the error is related to a Jinja error
                         self.console.log(
                             f"[red]Error in plan {plan_name}: {str(e)}[/red]"
                         )
-                        import traceback
 
-                        print(traceback.format_exc())
-
-        # Add no change plan
-        if not data_exceeds_limit:
+        if "no_change" in results and no_change_runtime is not None:
             results["no_change"] = (
                 results["no_change"][0],
                 no_change_runtime,
                 results["no_change"][2],
             )
 
-        # Create a table of scores sorted in descending order
-        scores = sorted(
-            [(score, runtime, plan) for plan, (score, runtime, _) in results.items()],
-            reverse=True,
-        )
+        return results
 
-        # Sort results by score in descending order
-        sorted_results = sorted(results.items(), key=lambda x: x[1][0], reverse=True)
+    def _evaluate_all_plans(
+        self,
+        op_config: Dict[str, Any],
+        input_data: List[Dict[str, Any]],
+        evaluation_samples: List[Dict[str, Any]],
+        validator_prompt: str,
+        plan_types: List[str],
+        model_input_context_length: int,
+        data_exceeds_limit: bool,
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], float]:
+        """
+        Evaluate all plans for a given operation configuration.
+        """
+        candidate_plans = {}
 
-        # Take the top 6 plans
-        top_plans = sorted_results[: self.k_to_pairwise_compare]
-
-        # Check if there are no top plans
-        if len(top_plans) == 0:
-            self.console.post_optimizer_status(StageType.END)
-            raise ValueError(
-                "Agent did not generate any plans. Unable to proceed with optimization. Try again."
-            )
-
-        # Include any additional plans that are tied with the last plan
-        tail_score = (
-            top_plans[-1][1][0]
-            if len(top_plans) == self.k_to_pairwise_compare
-            else float("-inf")
-        )
-        filtered_results = dict(
-            top_plans
-            + [
-                item
-                for item in sorted_results[len(top_plans) :]
-                if item[1][0] == tail_score
-            ]
-        )
-
-        # Perform pairwise comparisons on filtered plans
-        if len(filtered_results) > 1:
-            pairwise_rankings = self.evaluator._pairwise_compare_plans(
-                filtered_results, validator_prompt, op_config, evaluation_samples
-            )
-            best_plan_name = max(pairwise_rankings, key=pairwise_rankings.get)
-        else:
-            pairwise_rankings = {k: 0 for k in results.keys()}
-            best_plan_name = (
-                next(iter(filtered_results))
-                if filtered_results
-                else max(results, key=lambda x: results[x][0])
-            )
-
+        # Generate all plans
+        self.console.post_optimizer_status(StageType.CANDIDATE_PLANS)
         self.console.log(
-            f"\n[bold]Plan Evaluation Results for {op_config['name']} ({op_config['type']}, {len(scores)} plans, {num_evaluations} samples):[/bold]"
+            f"[bold magenta]Generating {len(plan_types)} plans...[/bold magenta]"
         )
-        table = Table(show_header=True, header_style="bold magenta")
-        table.add_column("Plan", style="dim")
-        table.add_column("Score", justify="right", width=10)
-        table.add_column("Runtime", justify="right", width=10)
-        table.add_column("Pairwise Wins", justify="right", width=10)
+        for plan_type in plan_types:
+            if plan_type == "chunk":
+                self.console.log(
+                    "[bold magenta]Generating chunking plans...[/bold magenta]"
+                )
+                chunk_size_plans = self.plan_generator._generate_chunk_size_plans(
+                    op_config, input_data, validator_prompt, model_input_context_length
+                )
+                candidate_plans.update(chunk_size_plans)
+            elif plan_type == "proj_synthesis":
+                if not self.is_filter:
+                    self.console.log(
+                        "[bold magenta]Generating independent projection synthesis plans...[/bold magenta]"
+                    )
+                    parallel_plans = self.plan_generator._generate_parallel_plans(
+                        op_config, input_data
+                    )
+                    candidate_plans.update(parallel_plans)
 
-        for score, runtime, plan in scores:
-            table.add_row(
-                plan,
-                f"{score:.2f}",
-                f"{runtime:.2f}s",
-                f"{pairwise_rankings.get(plan, 0)}",
-            )
+                    self.console.log(
+                        "[bold magenta]Generating chain projection synthesis plans...[/bold magenta]"
+                    )
+                    chain_plans = self.plan_generator._generate_chain_plans(
+                        op_config, input_data
+                    )
+                    candidate_plans.update(chain_plans)
+            elif plan_type == "glean":
+                self.console.log(
+                    "[bold magenta]Generating gleaning plans...[/bold magenta]"
+                )
+                gleaning_plans = self.plan_generator._generate_gleaning_plans(
+                    op_config, validator_prompt
+                )
+                candidate_plans.update(gleaning_plans)
 
-        self.console.log(table)
-        self.console.log("\n")
+        # Capture candidate plans
+        self.runner.optimizer.captured_output.save_optimizer_output(
+            stage_type=StageType.CANDIDATE_PLANS,
+            output=candidate_plans,
+        )
 
-        _, _, best_output = results[best_plan_name]
+        self.console.post_optimizer_status(StageType.EVALUATION_RESULTS)
         self.console.log(
-            f"[green]Choosing {best_plan_name} for operation {op_config['name']} (Score: {results[best_plan_name][0]:.2f}, Runtime: {results[best_plan_name][1]:.2f}s)[/green]"
+            f"[bold magenta]Evaluating {len(candidate_plans)} plans...[/bold magenta]"
         )
 
-        # Capture evaluation results
+        results = self._evaluate_plans(
+            candidate_plans, op_config, evaluation_samples, validator_prompt
+        )
+
+        # Select best plan using the centralized method
+        best_plan, best_output, _, pairwise_rankings = self._select_best_plan(
+            results, op_config, evaluation_samples, validator_prompt, candidate_plans
+        )
+
+        # Capture evaluation results with pairwise rankings
         ratings = {k: v[0] for k, v in results.items()}
         runtime = {k: v[1] for k, v in results.items()}
         sample_outputs = {k: v[2] for k, v in results.items()}
@@ -518,8 +684,4 @@ class MapOptimizer:
         )
 
         self.console.post_optimizer_status(StageType.END)
-        return (
-            candidate_plans[best_plan_name],
-            best_output,
-            self.plan_generator.subplan_optimizer_cost,
-        )
+        return best_plan, best_output, self.plan_generator.subplan_optimizer_cost

--- a/docetl/optimizers/map_optimizer/utils.py
+++ b/docetl/optimizers/map_optimizer/utils.py
@@ -37,7 +37,7 @@ def generate_and_validate_prompt(
 
     while attempt < max_retries:
         try:
-            response = llm_client.generate(
+            response = llm_client.generate_rewrite(
                 chat_history,
                 system_prompt,
                 parameters,

--- a/docetl/optimizers/reduce_optimizer.py
+++ b/docetl/optimizers/reduce_optimizer.py
@@ -297,7 +297,7 @@ class ReduceOptimizer:
             f"Reduce operation prompt:\n{truncated_messages[0]['content']}"
         )
 
-        preprocessing_response = self.llm_client.generate(
+        preprocessing_response = self.llm_client.generate_rewrite(
             model=self.config.get("model", self.default_model),
             messages=[{"role": "user", "content": preprocessing_prompt}],
             response_format={
@@ -686,7 +686,7 @@ class ReduceOptimizer:
             "required": ["should_decompose", "explanation"],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [{"role": "user", "content": prompt}],
             system_prompt,
             parameters,
@@ -756,7 +756,7 @@ class ReduceOptimizer:
             ],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [{"role": "user", "content": prompt}],
             system_prompt,
             parameters,
@@ -801,7 +801,7 @@ class ReduceOptimizer:
             "required": ["enable_sampling", "explanation"],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [{"role": "user", "content": prompt}],
             system_prompt,
             parameters,
@@ -854,7 +854,7 @@ class ReduceOptimizer:
             "required": ["method", "explanation"],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [{"role": "user", "content": prompt}],
             system_prompt,
             parameters,
@@ -893,7 +893,7 @@ class ReduceOptimizer:
                 "required": ["embedding_keys", "explanation"],
             }
 
-            response = self.llm_client.generate(
+            response = self.llm_client.generate_rewrite(
                 [{"role": "user", "content": prompt}],
                 system_prompt,
                 parameters,
@@ -939,7 +939,7 @@ class ReduceOptimizer:
                 "required": ["query_text", "explanation"],
             }
 
-            response = self.llm_client.generate(
+            response = self.llm_client.generate_rewrite(
                 [{"role": "user", "content": prompt}],
                 system_prompt,
                 parameters,
@@ -1003,7 +1003,7 @@ class ReduceOptimizer:
             "required": ["order_matters", "explanation"],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [{"role": "user", "content": prompt}],
             system_prompt,
             parameters,
@@ -1110,7 +1110,7 @@ class ReduceOptimizer:
             "required": ["validator_prompt"],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [{"role": "user", "content": prompt}],
             system_prompt,
             parameters,
@@ -1210,7 +1210,7 @@ class ReduceOptimizer:
 
                 futures.append(
                     executor.submit(
-                        self.llm_client.generate,
+                        self.llm_client.generate_judge,
                         [{"role": "user", "content": prompt}],
                         system_prompt,
                         parameters,
@@ -1595,7 +1595,7 @@ class ReduceOptimizer:
 
             Provide the fold prompt as a string.
             """
-            response = self.llm_client.generate(
+            response = self.llm_client.generate_rewrite(
                 [{"role": "user", "content": prompt}],
                 system_prompt,
                 parameters,
@@ -1906,7 +1906,7 @@ Remember, you must fold the new data into the existing output, do not start fres
             "required": ["merge_prompt"],
         }
 
-        response = self.llm_client.generate(
+        response = self.llm_client.generate_rewrite(
             [{"role": "user", "content": prompt}],
             system_prompt,
             parameters,

--- a/docetl/optimizers/utils.py
+++ b/docetl/optimizers/utils.py
@@ -28,6 +28,9 @@ class LLMClient:
         self.rewrite_agent_model = rewrite_agent_model
         self.judge_agent_model = judge_agent_model
         self.litellm_kwargs = litellm_kwargs
+        if "temperature" not in self.litellm_kwargs:
+            self.litellm_kwargs["temperature"] = 0.0
+
         self.total_cost = 0
         self.runner = runner
 
@@ -60,7 +63,6 @@ class LLMClient:
         while rate_limited_attempt < 6:
             try:
                 response = completion(
-                    temperature=0.0,
                     model=model,
                     messages=[
                         {

--- a/docetl/optimizers/utils.py
+++ b/docetl/optimizers/utils.py
@@ -1,6 +1,7 @@
+import time
 from typing import Any, Dict, List
 
-from litellm import completion
+from litellm import RateLimitError, completion
 
 from docetl.operations.utils import truncate_messages
 from docetl.utils import completion_cost
@@ -14,7 +15,9 @@ class LLMClient:
     and keeps track of the total cost of API calls.
     """
 
-    def __init__(self, runner, model: str = "gpt-4o", **litellm_kwargs):
+    def __init__(
+        self, runner, rewrite_agent_model: str, judge_agent_model: str, **litellm_kwargs
+    ):
         """
         Initialize the LLMClient.
 
@@ -22,18 +25,18 @@ class LLMClient:
             model (str, optional): The name of the LLM model to use. Defaults to "gpt-4o".
             **litellm_kwargs: Additional keyword arguments for the LLM model.
         """
-        if model == "gpt-4o":
-            model = "gpt-4o-2024-08-06"
-        self.model = model
+        self.rewrite_agent_model = rewrite_agent_model
+        self.judge_agent_model = judge_agent_model
         self.litellm_kwargs = litellm_kwargs
         self.total_cost = 0
         self.runner = runner
 
-    def generate(
+    def _generate(
         self,
         messages: List[Dict[str, str]],
         system_prompt: str,
         parameters: Dict[str, Any],
+        model: str,
     ) -> Any:
         """
         Generate a response using the LLM.
@@ -51,27 +54,62 @@ class LLMClient:
         """
         parameters["additionalProperties"] = False
 
-        messages = truncate_messages(messages, self.model, from_agent=True)
+        messages = truncate_messages(messages, model, from_agent=True)
 
-        response = completion(
-            model=self.model,
-            messages=[
-                {
-                    "role": "system",
-                    "content": system_prompt,
-                },
-                *messages,
-            ],
-            **self.litellm_kwargs,
-            response_format={
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "output",
-                    "strict": True,
-                    "schema": parameters,
-                },
-            },
+        rate_limited_attempt = 0
+        while rate_limited_attempt < 6:
+            try:
+                response = completion(
+                    temperature=0.0,
+                    model=model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": system_prompt,
+                        },
+                        *messages,
+                    ],
+                    **self.litellm_kwargs,
+                    response_format={
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "output",
+                            "strict": True,
+                            "schema": parameters,
+                        },
+                    },
+                )
+                cost = completion_cost(response)
+                self.total_cost += cost
+                return response
+            except RateLimitError:
+                backoff_time = 4 * (2**rate_limited_attempt)  # Exponential backoff
+                max_backoff = 120  # Maximum backoff time of 120 seconds
+                sleep_time = min(backoff_time, max_backoff)
+                self.runner.console.log(
+                    f"[yellow]Rate limit hit. Retrying in {sleep_time:.2f} seconds...[/yellow]"
+                )
+                time.sleep(sleep_time)
+                rate_limited_attempt += 1
+
+        raise Exception("Rate limit hit too many times")
+
+    def generate_rewrite(
+        self,
+        messages: List[Dict[str, str]],
+        system_prompt: str,
+        parameters: Dict[str, Any],
+    ) -> Any:
+        return self._generate(
+            messages, system_prompt, parameters, self.rewrite_agent_model
         )
-        cost = completion_cost(response)
-        self.total_cost += cost
-        return response
+
+    def generate_judge(
+        self,
+        messages: List[Dict[str, str]],
+        system_prompt: str,
+        parameters: Dict[str, Any],
+    ) -> Any:
+        return self._generate(
+            messages, system_prompt, parameters, self.judge_agent_model
+        )

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -624,13 +624,15 @@ class DSLRunner(ConfigWrapper):
         self.load()
 
         # Augment the kwargs with the runner's config if not already provided
-        if "optimizer_litellm_kwargs" not in kwargs:
-            kwargs["litellm_kwargs"] = self.config.get("optimizer_litellm_kwargs", {})
-        if "optimizer_model" not in kwargs:
-            kwargs["rewrite_agent_model"] = self.config.get("optimizer_model", "gpt-4o")
-            kwargs["judge_agent_model"] = self.config.get(
-                "optimizer_model", "gpt-4o-mini"
-            )
+        kwargs["litellm_kwargs"] = self.config.get("optimizer_config", {}).get(
+            "litellm_kwargs", {}
+        )
+        kwargs["rewrite_agent_model"] = self.config.get("optimizer_config", {}).get(
+            "rewrite_agent_model", "gpt-4o"
+        )
+        kwargs["judge_agent_model"] = self.config.get("optimizer_config", {}).get(
+            "judge_agent_model", "gpt-4o-mini"
+        )
 
         builder = Optimizer(self, **kwargs)
         self.optimizer = builder
@@ -650,16 +652,15 @@ class DSLRunner(ConfigWrapper):
         self.load()
 
         # Augment the kwargs with the runner's config if not already provided
-        if "optimizer_litellm_kwargs" not in kwargs:
-            kwargs["litellm_kwargs"] = self.config.get("optimizer_litellm_kwargs", {})
-        if "optimizer_rewrite_agent_model" not in kwargs:
-            kwargs["rewrite_agent_model"] = self.config.get(
-                "optimizer_rewrite_agent_model", "gpt-4o"
-            )
-        if "optimizer_judge_agent_model" not in kwargs:
-            kwargs["judge_agent_model"] = self.config.get(
-                "optimizer_judge_agent_model", "gpt-4o-mini"
-            )
+        kwargs["litellm_kwargs"] = self.config.get("optimizer_config", {}).get(
+            "litellm_kwargs", {}
+        )
+        kwargs["rewrite_agent_model"] = self.config.get("optimizer_config", {}).get(
+            "rewrite_agent_model", "gpt-4o"
+        )
+        kwargs["judge_agent_model"] = self.config.get("optimizer_config", {}).get(
+            "judge_agent_model", "gpt-4o-mini"
+        )
 
         save_path = kwargs.get("save_path", None)
         # Pop the save_path from kwargs

--- a/docs/optimization/example.md
+++ b/docs/optimization/example.md
@@ -43,6 +43,7 @@ default_model: gpt-4o-mini
 operations:
   - name: extract_medications
     type: map
+    optimize: true
     output:
       schema:
         medication: list[str]
@@ -56,6 +57,7 @@ operations:
 
   - name: summarize_prescriptions
     type: reduce
+    optimize: true
     reduce_key:
       - medication
     output:
@@ -182,11 +184,10 @@ This optimized pipeline now includes improved prompts, a resolve operation, and 
 ## Optimizer API
 
 ::: docetl.cli.build
-handler: python
-options:
-members: - build
-show_root_full_path: true
-show_root_toc_entry: true
-show_root_heading: true
-show_source: false
-show_name: true
+    options:
+        show_root_heading: true
+        heading_level: 3
+        show_if_no_docstring: false
+        docstring_options:
+            ignore_init_summary: false
+            trim_doctest_flags: true

--- a/poetry.lock
+++ b/poetry.lock
@@ -587,46 +587,6 @@ wmi = ["wmi (>=1.5.1)"]
 
 [[package]]
 name = "docling"
-version = "2.15.1"
-description = "SDK and CLI for parsing PDF, DOCX, HTML, and more, to a unified document representation for powering downstream workflows such as gen AI applications."
-optional = true
-python-versions = "<4.0,>=3.9"
-files = [
-    {file = "docling-2.15.1-py3-none-any.whl", hash = "sha256:409a49f19f019cd4d22a81888a1b0bcd7dee21c6657efd2c812cc83d5d201938"},
-    {file = "docling-2.15.1.tar.gz", hash = "sha256:578b4eb3c9833e95025aaa4174c0f3a1b9037c81a75fc616e49c16afbd217abf"},
-]
-
-[package.dependencies]
-beautifulsoup4 = ">=4.12.3,<5.0.0"
-certifi = ">=2024.7.4"
-deepsearch-glm = ">=1.0.0,<2.0.0"
-docling-core = {version = ">=2.13.1,<3.0.0", extras = ["chunking"]}
-docling-ibm-models = ">=3.1.0,<4.0.0"
-docling-parse = ">=3.0.0,<4.0.0"
-easyocr = ">=1.7,<2.0"
-filetype = ">=1.2.0,<2.0.0"
-huggingface_hub = ">=0.23,<1"
-lxml = ">=4.0.0,<6.0.0"
-marko = ">=2.1.2,<3.0.0"
-openpyxl = ">=3.1.5,<4.0.0"
-pandas = ">=2.1.4,<3.0.0"
-pydantic = ">=2.0.0,<3.0.0"
-pydantic-settings = ">=2.3.0,<3.0.0"
-pypdfium2 = ">=4.30.0,<5.0.0"
-python-docx = ">=1.1.2,<2.0.0"
-python-pptx = ">=1.0.2,<2.0.0"
-requests = ">=2.32.2,<3.0.0"
-rtree = ">=1.3.0,<2.0.0"
-scipy = ">=1.6.0,<2.0.0"
-typer = ">=0.12.5,<0.13.0"
-
-[package.extras]
-ocrmac = ["ocrmac (>=1.0.0,<2.0.0)"]
-rapidocr = ["onnxruntime (>=1.7.0,<1.20.0)", "onnxruntime (>=1.7.0,<2.0.0)", "rapidocr-onnxruntime (>=1.4.0,<2.0.0)"]
-tesserocr = ["tesserocr (>=2.7.1,<3.0.0)"]
-
-[[package]]
-name = "docling"
 version = "2.17.0"
 description = "SDK and CLI for parsing PDF, DOCX, HTML, and more, to a unified document representation for powering downstream workflows such as gen AI applications."
 optional = true
@@ -695,29 +655,6 @@ chunking = ["semchunk (>=2.2.0,<3.0.0)", "transformers (>=4.34.0,<5.0.0)"]
 
 [[package]]
 name = "docling-ibm-models"
-version = "3.1.0"
-description = "This package contains the AI models used by the Docling PDF conversion package"
-optional = true
-python-versions = "<4.0,>=3.9"
-files = [
-    {file = "docling_ibm_models-3.1.0-py3-none-any.whl", hash = "sha256:a381a45dff16fdb2246b99c15a2e3d6ba880c573d48a1d6477d3ffb36bab807f"},
-    {file = "docling_ibm_models-3.1.0.tar.gz", hash = "sha256:65d734ffa490edc4e2301d296b6e893afa536c63b7daae7bbda781bd15b3431e"},
-]
-
-[package.dependencies]
-huggingface_hub = ">=0.23,<1"
-jsonlines = ">=3.1.0,<4.0.0"
-numpy = ">=1.24.4,<3.0.0"
-opencv-python-headless = ">=4.6.0.66,<5.0.0.0"
-Pillow = ">=10.0.0,<11.0.0"
-safetensors = {version = ">=0.4.3,<1", extras = ["torch"]}
-torch = ">=2.2.2,<3.0.0"
-torchvision = ">=0,<1"
-tqdm = ">=4.64.0,<5.0.0"
-transformers = ">=4.42.0,<5.0.0"
-
-[[package]]
-name = "docling-ibm-models"
 version = "3.3.0"
 description = "This package contains the AI models used by the Docling PDF conversion package"
 optional = true
@@ -730,14 +667,20 @@ files = [
 [package.dependencies]
 huggingface_hub = ">=0.23,<1"
 jsonlines = ">=3.1.0,<4.0.0"
-numpy = {version = ">=1.24.4,<3.0.0", markers = "sys_platform != \"darwin\" or platform_machine != \"x86_64\""}
+numpy = [
+    {version = ">=1.24.4,<3.0.0", markers = "sys_platform != \"darwin\" or platform_machine != \"x86_64\""},
+    {version = ">=1.24.4,<2.0.0", markers = "sys_platform == \"darwin\" and platform_machine == \"x86_64\""},
+]
 opencv-python-headless = ">=4.6.0.66,<5.0.0.0"
 Pillow = ">=10.0.0,<11.0.0"
 safetensors = {version = ">=0.4.3,<1", extras = ["torch"]}
 torch = ">=2.2.2,<3.0.0"
 torchvision = ">=0,<1"
 tqdm = ">=4.64.0,<5.0.0"
-transformers = {version = ">=4.42.0,<5.0.0", markers = "sys_platform != \"darwin\" or platform_machine != \"x86_64\""}
+transformers = [
+    {version = ">=4.42.0,<5.0.0", markers = "sys_platform != \"darwin\" or platform_machine != \"x86_64\""},
+    {version = ">=4.42.0,<4.43.0", markers = "sys_platform == \"darwin\" and platform_machine == \"x86_64\""},
+]
 
 [[package]]
 name = "docling-parse"
@@ -1530,23 +1473,23 @@ requests = ">=2.20"
 
 [[package]]
 name = "litellm"
-version = "1.59.10"
+version = "1.61.8"
 description = "Library to easily interface with LLM API providers"
 optional = false
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 files = [
-    {file = "litellm-1.59.10-py3-none-any.whl", hash = "sha256:9e0109926de7c9f54238809f1a8c050575ccc599bc8c83806fac200513c3b979"},
-    {file = "litellm-1.59.10.tar.gz", hash = "sha256:b34c70cf8bfe459ac6cfc518976d47878532b752d248829839cfcd3bce4fe77c"},
+    {file = "litellm-1.61.8-py3-none-any.whl", hash = "sha256:da895efefb86b71d2213257d2b57ed38c42c48c590c474c65473cdc4791e8b32"},
+    {file = "litellm-1.61.8.tar.gz", hash = "sha256:efebcafeb014c76ca992a5a49f5f2c6c8a944723c6a91b0cc70442911c3a656f"},
 ]
 
 [package.dependencies]
 aiohttp = "*"
 click = "*"
-httpx = ">=0.23.0,<0.28.0"
+httpx = ">=0.23.0"
 importlib-metadata = ">=6.8.0"
 jinja2 = ">=3.1.2,<4.0.0"
 jsonschema = ">=4.22.0,<5.0.0"
-openai = ">=1.55.3"
+openai = ">=1.61.0"
 pydantic = ">=2.0.0,<3.0.0"
 python-dotenv = ">=0.2.0"
 tiktoken = ">=0.7.0"
@@ -2352,6 +2295,51 @@ files = [
 
 [[package]]
 name = "numpy"
+version = "1.26.4"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
+    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
+    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
+    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
+    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
+    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
+    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
+    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
+    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
+    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
+]
+
+[[package]]
+name = "numpy"
 version = "2.2.2"
 description = "Fundamental package for array computing in Python"
 optional = false
@@ -2599,13 +2587,13 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "openai"
-version = "1.60.2"
+version = "1.63.2"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "openai-1.60.2-py3-none-any.whl", hash = "sha256:993bd11b96900b9098179c728026f016b4982ded7ee30dfcf4555eab1171fff9"},
-    {file = "openai-1.60.2.tar.gz", hash = "sha256:a8f843e10f2855713007f491d96afb2694b11b5e02cb97c7d01a0be60bc5bb51"},
+    {file = "openai-1.63.2-py3-none-any.whl", hash = "sha256:1f38b27b5a40814c2b7d8759ec78110df58c4a614c25f182809ca52b080ff4d4"},
+    {file = "openai-1.63.2.tar.gz", hash = "sha256:aeabeec984a7d2957b4928ceaa339e2ead19c61cfcf35ae62b7c363368d26360"},
 ]
 
 [package.dependencies]
@@ -4752,6 +4740,123 @@ blobfile = ["blobfile (>=2)"]
 
 [[package]]
 name = "tokenizers"
+version = "0.19.1"
+description = ""
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tokenizers-0.19.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:952078130b3d101e05ecfc7fc3640282d74ed26bcf691400f872563fca15ac97"},
+    {file = "tokenizers-0.19.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:82c8b8063de6c0468f08e82c4e198763e7b97aabfe573fd4cf7b33930ca4df77"},
+    {file = "tokenizers-0.19.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f03727225feaf340ceeb7e00604825addef622d551cbd46b7b775ac834c1e1c4"},
+    {file = "tokenizers-0.19.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:453e4422efdfc9c6b6bf2eae00d5e323f263fff62b29a8c9cd526c5003f3f642"},
+    {file = "tokenizers-0.19.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:02e81bf089ebf0e7f4df34fa0207519f07e66d8491d963618252f2e0729e0b46"},
+    {file = "tokenizers-0.19.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b07c538ba956843833fee1190cf769c60dc62e1cf934ed50d77d5502194d63b1"},
+    {file = "tokenizers-0.19.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e28cab1582e0eec38b1f38c1c1fb2e56bce5dc180acb1724574fc5f47da2a4fe"},
+    {file = "tokenizers-0.19.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b01afb7193d47439f091cd8f070a1ced347ad0f9144952a30a41836902fe09e"},
+    {file = "tokenizers-0.19.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:7fb297edec6c6841ab2e4e8f357209519188e4a59b557ea4fafcf4691d1b4c98"},
+    {file = "tokenizers-0.19.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2e8a3dd055e515df7054378dc9d6fa8c8c34e1f32777fb9a01fea81496b3f9d3"},
+    {file = "tokenizers-0.19.1-cp310-none-win32.whl", hash = "sha256:7ff898780a155ea053f5d934925f3902be2ed1f4d916461e1a93019cc7250837"},
+    {file = "tokenizers-0.19.1-cp310-none-win_amd64.whl", hash = "sha256:bea6f9947e9419c2fda21ae6c32871e3d398cba549b93f4a65a2d369662d9403"},
+    {file = "tokenizers-0.19.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5c88d1481f1882c2e53e6bb06491e474e420d9ac7bdff172610c4f9ad3898059"},
+    {file = "tokenizers-0.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ddf672ed719b4ed82b51499100f5417d7d9f6fb05a65e232249268f35de5ed14"},
+    {file = "tokenizers-0.19.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:dadc509cc8a9fe460bd274c0e16ac4184d0958117cf026e0ea8b32b438171594"},
+    {file = "tokenizers-0.19.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dfedf31824ca4915b511b03441784ff640378191918264268e6923da48104acc"},
+    {file = "tokenizers-0.19.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac11016d0a04aa6487b1513a3a36e7bee7eec0e5d30057c9c0408067345c48d2"},
+    {file = "tokenizers-0.19.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76951121890fea8330d3a0df9a954b3f2a37e3ec20e5b0530e9a0044ca2e11fe"},
+    {file = "tokenizers-0.19.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b342d2ce8fc8d00f376af068e3274e2e8649562e3bc6ae4a67784ded6b99428d"},
+    {file = "tokenizers-0.19.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d16ff18907f4909dca9b076b9c2d899114dd6abceeb074eca0c93e2353f943aa"},
+    {file = "tokenizers-0.19.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:706a37cc5332f85f26efbe2bdc9ef8a9b372b77e4645331a405073e4b3a8c1c6"},
+    {file = "tokenizers-0.19.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:16baac68651701364b0289979ecec728546133e8e8fe38f66fe48ad07996b88b"},
+    {file = "tokenizers-0.19.1-cp311-none-win32.whl", hash = "sha256:9ed240c56b4403e22b9584ee37d87b8bfa14865134e3e1c3fb4b2c42fafd3256"},
+    {file = "tokenizers-0.19.1-cp311-none-win_amd64.whl", hash = "sha256:ad57d59341710b94a7d9dbea13f5c1e7d76fd8d9bcd944a7a6ab0b0da6e0cc66"},
+    {file = "tokenizers-0.19.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:621d670e1b1c281a1c9698ed89451395d318802ff88d1fc1accff0867a06f153"},
+    {file = "tokenizers-0.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d924204a3dbe50b75630bd16f821ebda6a5f729928df30f582fb5aade90c818a"},
+    {file = "tokenizers-0.19.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4f3fefdc0446b1a1e6d81cd4c07088ac015665d2e812f6dbba4a06267d1a2c95"},
+    {file = "tokenizers-0.19.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9620b78e0b2d52ef07b0d428323fb34e8ea1219c5eac98c2596311f20f1f9266"},
+    {file = "tokenizers-0.19.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04ce49e82d100594715ac1b2ce87d1a36e61891a91de774755f743babcd0dd52"},
+    {file = "tokenizers-0.19.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c5c2ff13d157afe413bf7e25789879dd463e5a4abfb529a2d8f8473d8042e28f"},
+    {file = "tokenizers-0.19.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3174c76efd9d08f836bfccaca7cfec3f4d1c0a4cf3acbc7236ad577cc423c840"},
+    {file = "tokenizers-0.19.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c9d5b6c0e7a1e979bec10ff960fae925e947aab95619a6fdb4c1d8ff3708ce3"},
+    {file = "tokenizers-0.19.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:a179856d1caee06577220ebcfa332af046d576fb73454b8f4d4b0ba8324423ea"},
+    {file = "tokenizers-0.19.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:952b80dac1a6492170f8c2429bd11fcaa14377e097d12a1dbe0ef2fb2241e16c"},
+    {file = "tokenizers-0.19.1-cp312-none-win32.whl", hash = "sha256:01d62812454c188306755c94755465505836fd616f75067abcae529c35edeb57"},
+    {file = "tokenizers-0.19.1-cp312-none-win_amd64.whl", hash = "sha256:b70bfbe3a82d3e3fb2a5e9b22a39f8d1740c96c68b6ace0086b39074f08ab89a"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-macosx_10_12_x86_64.whl", hash = "sha256:bb9dfe7dae85bc6119d705a76dc068c062b8b575abe3595e3c6276480e67e3f1"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:1f0360cbea28ea99944ac089c00de7b2e3e1c58f479fb8613b6d8d511ce98267"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:71e3ec71f0e78780851fef28c2a9babe20270404c921b756d7c532d280349214"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b82931fa619dbad979c0ee8e54dd5278acc418209cc897e42fac041f5366d626"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e8ff5b90eabdcdaa19af697885f70fe0b714ce16709cf43d4952f1f85299e73a"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e742d76ad84acbdb1a8e4694f915fe59ff6edc381c97d6dfdd054954e3478ad4"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d8c5d59d7b59885eab559d5bc082b2985555a54cda04dda4c65528d90ad252ad"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b2da5c32ed869bebd990c9420df49813709e953674c0722ff471a116d97b22d"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:638e43936cc8b2cbb9f9d8dde0fe5e7e30766a3318d2342999ae27f68fdc9bd6"},
+    {file = "tokenizers-0.19.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:78e769eb3b2c79687d9cb0f89ef77223e8e279b75c0a968e637ca7043a84463f"},
+    {file = "tokenizers-0.19.1-cp37-none-win32.whl", hash = "sha256:72791f9bb1ca78e3ae525d4782e85272c63faaef9940d92142aa3eb79f3407a3"},
+    {file = "tokenizers-0.19.1-cp37-none-win_amd64.whl", hash = "sha256:f3bbb7a0c5fcb692950b041ae11067ac54826204318922da754f908d95619fbc"},
+    {file = "tokenizers-0.19.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:07f9295349bbbcedae8cefdbcfa7f686aa420be8aca5d4f7d1ae6016c128c0c5"},
+    {file = "tokenizers-0.19.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:10a707cc6c4b6b183ec5dbfc5c34f3064e18cf62b4a938cb41699e33a99e03c1"},
+    {file = "tokenizers-0.19.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6309271f57b397aa0aff0cbbe632ca9d70430839ca3178bf0f06f825924eca22"},
+    {file = "tokenizers-0.19.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ad23d37d68cf00d54af184586d79b84075ada495e7c5c0f601f051b162112dc"},
+    {file = "tokenizers-0.19.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:427c4f0f3df9109314d4f75b8d1f65d9477033e67ffaec4bca53293d3aca286d"},
+    {file = "tokenizers-0.19.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e83a31c9cf181a0a3ef0abad2b5f6b43399faf5da7e696196ddd110d332519ee"},
+    {file = "tokenizers-0.19.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c27b99889bd58b7e301468c0838c5ed75e60c66df0d4db80c08f43462f82e0d3"},
+    {file = "tokenizers-0.19.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bac0b0eb952412b0b196ca7a40e7dce4ed6f6926489313414010f2e6b9ec2adf"},
+    {file = "tokenizers-0.19.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8a6298bde623725ca31c9035a04bf2ef63208d266acd2bed8c2cb7d2b7d53ce6"},
+    {file = "tokenizers-0.19.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:08a44864e42fa6d7d76d7be4bec62c9982f6f6248b4aa42f7302aa01e0abfd26"},
+    {file = "tokenizers-0.19.1-cp38-none-win32.whl", hash = "sha256:1de5bc8652252d9357a666e609cb1453d4f8e160eb1fb2830ee369dd658e8975"},
+    {file = "tokenizers-0.19.1-cp38-none-win_amd64.whl", hash = "sha256:0bcce02bf1ad9882345b34d5bd25ed4949a480cf0e656bbd468f4d8986f7a3f1"},
+    {file = "tokenizers-0.19.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:0b9394bd204842a2a1fd37fe29935353742be4a3460b6ccbaefa93f58a8df43d"},
+    {file = "tokenizers-0.19.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4692ab92f91b87769d950ca14dbb61f8a9ef36a62f94bad6c82cc84a51f76f6a"},
+    {file = "tokenizers-0.19.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6258c2ef6f06259f70a682491c78561d492e885adeaf9f64f5389f78aa49a051"},
+    {file = "tokenizers-0.19.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c85cf76561fbd01e0d9ea2d1cbe711a65400092bc52b5242b16cfd22e51f0c58"},
+    {file = "tokenizers-0.19.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:670b802d4d82bbbb832ddb0d41df7015b3e549714c0e77f9bed3e74d42400fbe"},
+    {file = "tokenizers-0.19.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:85aa3ab4b03d5e99fdd31660872249df5e855334b6c333e0bc13032ff4469c4a"},
+    {file = "tokenizers-0.19.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbf001afbbed111a79ca47d75941e9e5361297a87d186cbfc11ed45e30b5daba"},
+    {file = "tokenizers-0.19.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4c89aa46c269e4e70c4d4f9d6bc644fcc39bb409cb2a81227923404dd6f5227"},
+    {file = "tokenizers-0.19.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:39c1ec76ea1027438fafe16ecb0fb84795e62e9d643444c1090179e63808c69d"},
+    {file = "tokenizers-0.19.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c2a0d47a89b48d7daa241e004e71fb5a50533718897a4cd6235cb846d511a478"},
+    {file = "tokenizers-0.19.1-cp39-none-win32.whl", hash = "sha256:61b7fe8886f2e104d4caf9218b157b106207e0f2a4905c9c7ac98890688aabeb"},
+    {file = "tokenizers-0.19.1-cp39-none-win_amd64.whl", hash = "sha256:f97660f6c43efd3e0bfd3f2e3e5615bf215680bad6ee3d469df6454b8c6e8256"},
+    {file = "tokenizers-0.19.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3b11853f17b54c2fe47742c56d8a33bf49ce31caf531e87ac0d7d13d327c9334"},
+    {file = "tokenizers-0.19.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d26194ef6c13302f446d39972aaa36a1dda6450bc8949f5eb4c27f51191375bd"},
+    {file = "tokenizers-0.19.1-pp310-pypy310_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e8d1ed93beda54bbd6131a2cb363a576eac746d5c26ba5b7556bc6f964425594"},
+    {file = "tokenizers-0.19.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca407133536f19bdec44b3da117ef0d12e43f6d4b56ac4c765f37eca501c7bda"},
+    {file = "tokenizers-0.19.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce05fde79d2bc2e46ac08aacbc142bead21614d937aac950be88dc79f9db9022"},
+    {file = "tokenizers-0.19.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:35583cd46d16f07c054efd18b5d46af4a2f070a2dd0a47914e66f3ff5efb2b1e"},
+    {file = "tokenizers-0.19.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:43350270bfc16b06ad3f6f07eab21f089adb835544417afda0f83256a8bf8b75"},
+    {file = "tokenizers-0.19.1-pp37-pypy37_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b4399b59d1af5645bcee2072a463318114c39b8547437a7c2d6a186a1b5a0e2d"},
+    {file = "tokenizers-0.19.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6852c5b2a853b8b0ddc5993cd4f33bfffdca4fcc5d52f89dd4b8eada99379285"},
+    {file = "tokenizers-0.19.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcd266ae85c3d39df2f7e7d0e07f6c41a55e9a3123bb11f854412952deacd828"},
+    {file = "tokenizers-0.19.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecb2651956eea2aa0a2d099434134b1b68f1c31f9a5084d6d53f08ed43d45ff2"},
+    {file = "tokenizers-0.19.1-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:b279ab506ec4445166ac476fb4d3cc383accde1ea152998509a94d82547c8e2a"},
+    {file = "tokenizers-0.19.1-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:89183e55fb86e61d848ff83753f64cded119f5d6e1f553d14ffee3700d0a4a49"},
+    {file = "tokenizers-0.19.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2edbc75744235eea94d595a8b70fe279dd42f3296f76d5a86dde1d46e35f574"},
+    {file = "tokenizers-0.19.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:0e64bfde9a723274e9a71630c3e9494ed7b4c0f76a1faacf7fe294cd26f7ae7c"},
+    {file = "tokenizers-0.19.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0b5ca92bfa717759c052e345770792d02d1f43b06f9e790ca0a1db62838816f3"},
+    {file = "tokenizers-0.19.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f8a20266e695ec9d7a946a019c1d5ca4eddb6613d4f466888eee04f16eedb85"},
+    {file = "tokenizers-0.19.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63c38f45d8f2a2ec0f3a20073cccb335b9f99f73b3c69483cd52ebc75369d8a1"},
+    {file = "tokenizers-0.19.1-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:dd26e3afe8a7b61422df3176e06664503d3f5973b94f45d5c45987e1cb711876"},
+    {file = "tokenizers-0.19.1-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:eddd5783a4a6309ce23432353cdb36220e25cbb779bfa9122320666508b44b88"},
+    {file = "tokenizers-0.19.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:56ae39d4036b753994476a1b935584071093b55c7a72e3b8288e68c313ca26e7"},
+    {file = "tokenizers-0.19.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f9939ca7e58c2758c01b40324a59c034ce0cebad18e0d4563a9b1beab3018243"},
+    {file = "tokenizers-0.19.1-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6c330c0eb815d212893c67a032e9dc1b38a803eccb32f3e8172c19cc69fbb439"},
+    {file = "tokenizers-0.19.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec11802450a2487cdf0e634b750a04cbdc1c4d066b97d94ce7dd2cb51ebb325b"},
+    {file = "tokenizers-0.19.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2b718f316b596f36e1dae097a7d5b91fc5b85e90bf08b01ff139bd8953b25af"},
+    {file = "tokenizers-0.19.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:ed69af290c2b65169f0ba9034d1dc39a5db9459b32f1dd8b5f3f32a3fcf06eab"},
+    {file = "tokenizers-0.19.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f8a9c828277133af13f3859d1b6bf1c3cb6e9e1637df0e45312e6b7c2e622b1f"},
+    {file = "tokenizers-0.19.1.tar.gz", hash = "sha256:ee59e6680ed0fdbe6b724cf38bd70400a0c1dd623b07ac729087270caeac88e3"},
+]
+
+[package.dependencies]
+huggingface-hub = ">=0.16.4,<1.0"
+
+[package.extras]
+dev = ["tokenizers[testing]"]
+docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
+testing = ["black (==22.3)", "datasets", "numpy", "pytest", "requests", "ruff"]
+
+[[package]]
+name = "tokenizers"
 version = "0.21.0"
 description = ""
 optional = false
@@ -4937,6 +5042,74 @@ discord = ["requests"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]
+
+[[package]]
+name = "transformers"
+version = "4.42.4"
+description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
+optional = true
+python-versions = ">=3.8.0"
+files = [
+    {file = "transformers-4.42.4-py3-none-any.whl", hash = "sha256:6d59061392d0f1da312af29c962df9017ff3c0108c681a56d1bc981004d16d24"},
+    {file = "transformers-4.42.4.tar.gz", hash = "sha256:f956e25e24df851f650cb2c158b6f4352dfae9d702f04c113ed24fc36ce7ae2d"},
+]
+
+[package.dependencies]
+filelock = "*"
+huggingface-hub = ">=0.23.2,<1.0"
+numpy = ">=1.17,<2.0"
+packaging = ">=20.0"
+pyyaml = ">=5.1"
+regex = "!=2019.12.17"
+requests = "*"
+safetensors = ">=0.4.1"
+tokenizers = ">=0.19,<0.20"
+tqdm = ">=4.27"
+
+[package.extras]
+accelerate = ["accelerate (>=0.21.0)"]
+agents = ["Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "datasets (!=2.5.0)", "diffusers", "opencv-python", "sentencepiece (>=0.1.91,!=0.1.92)", "torch"]
+all = ["Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "av (==9.2.0)", "codecarbon (==1.2.0)", "decord (==0.6.0)", "flax (>=0.4.1,<=0.7.0)", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "onnxconverter-common", "optax (>=0.0.8,<=0.1.4)", "optuna", "phonemizer", "protobuf", "pyctcdecode (>=0.4.0)", "ray[tune] (>=2.7.0)", "scipy (<1.13.0)", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "tensorflow (>2.9,<2.16)", "tensorflow-text (<2.16)", "tf2onnx", "timm (<=0.9.16)", "tokenizers (>=0.19,<0.20)", "torch", "torchaudio", "torchvision"]
+audio = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)"]
+benchmark = ["optimum-benchmark (>=0.2.0)"]
+codecarbon = ["codecarbon (==1.2.0)"]
+deepspeed = ["accelerate (>=0.21.0)", "deepspeed (>=0.9.3)"]
+deepspeed-testing = ["GitPython (<3.1.19)", "accelerate (>=0.21.0)", "beautifulsoup4", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "deepspeed (>=0.9.3)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "nltk", "optuna", "parameterized", "protobuf", "psutil", "pydantic", "pytest (>=7.2.0,<8.0.0)", "pytest-rich", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.4.4)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "sentencepiece (>=0.1.91,!=0.1.92)", "tensorboard", "timeout-decorator"]
+dev = ["GitPython (<3.1.19)", "Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "av (==9.2.0)", "beautifulsoup4", "codecarbon (==1.2.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "decord (==0.6.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "flax (>=0.4.1,<=0.7.0)", "fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "isort (>=5.5.4)", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "nltk", "onnxconverter-common", "optax (>=0.0.8,<=0.1.4)", "optuna", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pydantic", "pytest (>=7.2.0,<8.0.0)", "pytest-rich", "pytest-timeout", "pytest-xdist", "ray[tune] (>=2.7.0)", "rhoknp (>=1.1.0,<1.3.1)", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.4.4)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "scipy (<1.13.0)", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "sudachidict-core (>=20220729)", "sudachipy (>=0.6.6)", "tensorboard", "tensorflow (>2.9,<2.16)", "tensorflow-text (<2.16)", "tf2onnx", "timeout-decorator", "timm (<=0.9.16)", "tokenizers (>=0.19,<0.20)", "torch", "torchaudio", "torchvision", "unidic (>=1.0.2)", "unidic-lite (>=1.0.7)", "urllib3 (<2.0.0)"]
+dev-tensorflow = ["GitPython (<3.1.19)", "Pillow (>=10.0.1,<=15.0)", "beautifulsoup4", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "isort (>=5.5.4)", "kenlm", "keras-nlp (>=0.3.1)", "librosa", "nltk", "onnxconverter-common", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pydantic", "pytest (>=7.2.0,<8.0.0)", "pytest-rich", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.4.4)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "sentencepiece (>=0.1.91,!=0.1.92)", "tensorboard", "tensorflow (>2.9,<2.16)", "tensorflow-text (<2.16)", "tf2onnx", "timeout-decorator", "tokenizers (>=0.19,<0.20)", "urllib3 (<2.0.0)"]
+dev-torch = ["GitPython (<3.1.19)", "Pillow (>=10.0.1,<=15.0)", "accelerate (>=0.21.0)", "beautifulsoup4", "codecarbon (==1.2.0)", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "isort (>=5.5.4)", "kenlm", "librosa", "nltk", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "optuna", "parameterized", "phonemizer", "protobuf", "psutil", "pyctcdecode (>=0.4.0)", "pydantic", "pytest (>=7.2.0,<8.0.0)", "pytest-rich", "pytest-timeout", "pytest-xdist", "ray[tune] (>=2.7.0)", "rhoknp (>=1.1.0,<1.3.1)", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.4.4)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "scikit-learn", "sentencepiece (>=0.1.91,!=0.1.92)", "sigopt", "sudachidict-core (>=20220729)", "sudachipy (>=0.6.6)", "tensorboard", "timeout-decorator", "timm (<=0.9.16)", "tokenizers (>=0.19,<0.20)", "torch", "torchaudio", "torchvision", "unidic (>=1.0.2)", "unidic-lite (>=1.0.7)", "urllib3 (<2.0.0)"]
+flax = ["flax (>=0.4.1,<=0.7.0)", "jax (>=0.4.1,<=0.4.13)", "jaxlib (>=0.4.1,<=0.4.13)", "optax (>=0.0.8,<=0.1.4)", "scipy (<1.13.0)"]
+flax-speech = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)"]
+ftfy = ["ftfy"]
+integrations = ["optuna", "ray[tune] (>=2.7.0)", "sigopt"]
+ja = ["fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "rhoknp (>=1.1.0,<1.3.1)", "sudachidict-core (>=20220729)", "sudachipy (>=0.6.6)", "unidic (>=1.0.2)", "unidic-lite (>=1.0.7)"]
+modelcreation = ["cookiecutter (==1.7.3)"]
+natten = ["natten (>=0.14.6,<0.15.0)"]
+onnx = ["onnxconverter-common", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "tf2onnx"]
+onnxruntime = ["onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)"]
+optuna = ["optuna"]
+quality = ["GitPython (<3.1.19)", "datasets (!=2.5.0)", "isort (>=5.5.4)", "ruff (==0.4.4)", "urllib3 (<2.0.0)"]
+ray = ["ray[tune] (>=2.7.0)"]
+retrieval = ["datasets (!=2.5.0)", "faiss-cpu"]
+ruff = ["ruff (==0.4.4)"]
+sagemaker = ["sagemaker (>=2.31.0)"]
+sentencepiece = ["protobuf", "sentencepiece (>=0.1.91,!=0.1.92)"]
+serving = ["fastapi", "pydantic", "starlette", "uvicorn"]
+sigopt = ["sigopt"]
+sklearn = ["scikit-learn"]
+speech = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)", "torchaudio"]
+testing = ["GitPython (<3.1.19)", "beautifulsoup4", "cookiecutter (==1.7.3)", "datasets (!=2.5.0)", "dill (<0.3.5)", "evaluate (>=0.2.0)", "faiss-cpu", "nltk", "parameterized", "psutil", "pydantic", "pytest (>=7.2.0,<8.0.0)", "pytest-rich", "pytest-timeout", "pytest-xdist", "rjieba", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "ruff (==0.4.4)", "sacrebleu (>=1.4.12,<2.0.0)", "sacremoses", "sentencepiece (>=0.1.91,!=0.1.92)", "tensorboard", "timeout-decorator"]
+tf = ["keras-nlp (>=0.3.1)", "onnxconverter-common", "tensorflow (>2.9,<2.16)", "tensorflow-text (<2.16)", "tf2onnx"]
+tf-cpu = ["keras (>2.9,<2.16)", "keras-nlp (>=0.3.1)", "onnxconverter-common", "tensorflow-cpu (>2.9,<2.16)", "tensorflow-probability (<0.24)", "tensorflow-text (<2.16)", "tf2onnx"]
+tf-speech = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)"]
+timm = ["timm (<=0.9.16)"]
+tokenizers = ["tokenizers (>=0.19,<0.20)"]
+torch = ["accelerate (>=0.21.0)", "torch"]
+torch-speech = ["kenlm", "librosa", "phonemizer", "pyctcdecode (>=0.4.0)", "torchaudio"]
+torch-vision = ["Pillow (>=10.0.1,<=15.0)", "torchvision"]
+torchhub = ["filelock", "huggingface-hub (>=0.23.2,<1.0)", "importlib-metadata", "numpy (>=1.17,<2.0)", "packaging (>=20.0)", "protobuf", "regex (!=2019.12.17)", "requests", "sentencepiece (>=0.1.91,!=0.1.92)", "tokenizers (>=0.19,<0.20)", "torch", "tqdm (>=4.27)"]
+video = ["av (==9.2.0)", "decord (==0.6.0)"]
+vision = ["Pillow (>=10.0.1,<=15.0)"]
 
 [[package]]
 name = "transformers"

--- a/server/app/routes/pipeline.py
+++ b/server/app/routes/pipeline.py
@@ -58,8 +58,6 @@ async def run_optimization(task_id: str, yaml_config: str, step_name: str, op_na
             runner.should_optimize,
             step_name,
             op_name,
-            model=runner.config.get("optimizer_model", "gpt-4o"),
-            litellm_kwargs=runner.config.get("optimizer_litellm_kwargs", {})
         )
         
         # Update task result

--- a/server/app/routes/pipeline.py
+++ b/server/app/routes/pipeline.py
@@ -181,8 +181,12 @@ async def websocket_run_pipeline(websocket: WebSocket, client_id: str):
         if config.get("optimize", False):
             logging.info(f"Optimizing pipeline with model {config.get('optimizer_model', 'gpt-4o')}")
             
+            # Set the runner config to the optimizer config
+            runner.config["optimizer_config"]["rewrite_agent_model"] = config.get("optimizer_model", "gpt-4o")
+            runner.config["optimizer_config"]["judge_agent_model"] = config.get("optimizer_model", "gpt-4o-mini")
+            
             async def run_pipeline():
-                return await asyncio.to_thread(runner.optimize, return_pipeline=False, model=config.get("optimizer_model", "gpt-4o"))
+                return await asyncio.to_thread(runner.optimize, return_pipeline=False)
 
         else:
             async def run_pipeline():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -225,10 +225,14 @@ def test_pipeline_optimization(
             type="file", path=temp_output_file, intermediate_dir=temp_intermediate_dir
         ),
         default_model="gpt-4o-mini",
+        optimizer_config={
+            "rewrite_agent_model": "gpt-4o-mini",
+            "judge_agent_model": "gpt-4o-mini",
+        },
     )
 
     optimized_pipeline = pipeline.optimize(
-        max_threads=4, model="gpt-4o-mini", timeout=10
+        max_threads=4, timeout=10
     )
 
     assert isinstance(optimized_pipeline, Pipeline)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -232,7 +232,7 @@ def test_pipeline_optimization(
     )
 
     optimized_pipeline = pipeline.optimize(
-        max_threads=4, timeout=10
+        max_threads=64
     )
 
     assert isinstance(optimized_pipeline, Pipeline)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -226,7 +226,7 @@ def test_pipeline_optimization(
         ),
         default_model="gpt-4o-mini",
         optimizer_config={
-            "rewrite_agent_model": "gpt-4o-mini",
+            "rewrite_agent_model": "gpt-4o",
             "judge_agent_model": "gpt-4o-mini",
         },
     )

--- a/tests/test_pandas_accessors.py
+++ b/tests/test_pandas_accessors.py
@@ -336,12 +336,12 @@ def test_config_setting():
     df = pd.DataFrame({"text": ["test"]})
     
     # Set custom config
-    df.semantic.set_config(default_model="gpt-4")
-    assert df.semantic.runner.config["default_model"] == "gpt-4"
+    df.semantic.set_config(default_model="gpt-4o-mini", optimizer_config={"rewrite_agent_model": "gpt-4o", "judge_agent_model": "gpt-4o-mini"})
+    assert df.semantic.runner.config["default_model"] == "gpt-4o-mini"
     
     # Update config
-    df.semantic.set_config(max_threads=4)
-    assert df.semantic.runner.config["max_threads"] == 4
+    df.semantic.set_config(max_threads=64)
+    assert df.semantic.runner.config["max_threads"] == 64
 
 def test_error_handling(sample_df):
     """Test error handling for invalid inputs."""

--- a/website/src/app/playground/page.tsx
+++ b/website/src/app/playground/page.tsx
@@ -299,6 +299,7 @@ const CodeEditorPipelineApp: React.FC = () => {
     setSampleSize,
     setDefaultModel,
     setSystemPrompt,
+    setOutput,
   } = usePipelineContext();
 
   useEffect(() => {
@@ -860,6 +861,7 @@ const CodeEditorPipelineApp: React.FC = () => {
           setSystemPrompt={setSystemPrompt}
           currentFile={currentFile}
           files={files}
+          setOutput={setOutput}
         />
       </div>
     </BookmarkProvider>

--- a/website/src/components/PipelineGui.tsx
+++ b/website/src/components/PipelineGui.tsx
@@ -426,6 +426,7 @@ const PipelineGUI: React.FC = () => {
     setSystemPrompt,
     currentFile,
     files,
+    setOutput,
   });
 
   useEffect(() => {

--- a/website/src/components/TutorialsDialog.tsx
+++ b/website/src/components/TutorialsDialog.tsx
@@ -13,7 +13,7 @@ import { useDatasetUpload } from "@/hooks/useDatasetUpload";
 import { useRestorePipeline } from "@/hooks/useRestorePipeline";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import type { File as FileType, Operation } from "@/app/types";
+import type { File as FileType, Operation, OutputType } from "@/app/types";
 
 interface Tutorial {
   id: string;
@@ -265,6 +265,7 @@ interface TutorialsDialogProps {
   }) => void;
   currentFile: FileType | null;
   files: FileType[];
+  setOutput: (output: OutputType | null) => void;
 }
 
 export function TutorialsDialog({
@@ -282,6 +283,7 @@ export function TutorialsDialog({
   setSystemPrompt,
   currentFile,
   files,
+  setOutput,
 }: TutorialsDialogProps) {
   const { toast } = useToast();
   const { uploadLocalDataset } = useDatasetUpload({
@@ -299,6 +301,7 @@ export function TutorialsDialog({
     setSystemPrompt,
     currentFile,
     files,
+    setOutput,
   });
 
   // Add state to track the uploaded dataset path


### PR DESCRIPTION
This PR makes a number of changes to the map optimizer to follow the rewrite directives better, as well as support other optimizer models.

- Separates judge model and rewrite agent model (closes #306 )
- Allows user to configure what types of rewrites they want to consider for map operations
- Tries projection synthesis rewrites before chunking, to speed up rewrites


Example config:

```yaml
optimizer_config:
  sample_sizes:
    map: 2
  judge_agent_model: gemini/gemini-2.0-flash
  rewrite_agent_model: gpt-4o-mini
```