### PR TITLE
feat: add flag to stream map operation outputs to disk

### DIFF
--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -41,7 +41,7 @@ class MapOperation(BaseOperation):
         batch_prompt: Optional[str] = None
         litellm_completion_kwargs: Dict[str, Any] = {}
         pdf_url_key: Optional[str] = None
-        flush_partial_result: bool = True
+        flush_partial_result: bool = False
 
         @field_validator("drop_keys")
         def validate_drop_keys(cls, v):
@@ -374,14 +374,20 @@ class MapOperation(BaseOperation):
                 if result_list:
                     if "drop_keys" in self.config:
                         result_list = [
-                            {k: v for k, v in result.items() if k not in self.config["drop_keys"]}
+                            {
+                                k: v
+                                for k, v in result.items()
+                                if k not in self.config["drop_keys"]
+                            }
                             for result in result_list
                         ]
                     results.extend(result_list)
                     # --- BEGIN: Flush partial checkpoint ---
                     if self.config.get("flush_partial_results", False):
                         op_name = self.config["name"]
-                        self.runner._flush_partial_results(op_name, batch_index, result_list)
+                        self.runner._flush_partial_results(
+                            op_name, batch_index, result_list
+                        )
                     # --- END: Flush partial checkpoint ---
                 total_cost += item_cost
 

--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -41,6 +41,7 @@ class MapOperation(BaseOperation):
         batch_prompt: Optional[str] = None
         litellm_completion_kwargs: Dict[str, Any] = {}
         pdf_url_key: Optional[str] = None
+        flush_partial_result: bool = True
 
         @field_validator("drop_keys")
         def validate_drop_keys(cls, v):
@@ -368,19 +369,20 @@ class MapOperation(BaseOperation):
                 desc=f"Processing {self.config['name']} (map) on all documents",
                 console=self.console,
             )
-            for i in pbar:
-                result_list, item_cost = futures[i].result()
+            for batch_index in pbar:
+                result_list, item_cost = futures[batch_index].result()
                 if result_list:
                     if "drop_keys" in self.config:
                         result_list = [
-                            {
-                                k: v
-                                for k, v in result.items()
-                                if k not in self.config["drop_keys"]
-                            }
+                            {k: v for k, v in result.items() if k not in self.config["drop_keys"]}
                             for result in result_list
                         ]
                     results.extend(result_list)
+                    # --- BEGIN: Flush partial checkpoint ---
+                    if self.config.get("flush_partial_results", False):
+                        op_name = self.config["name"]
+                        self.runner._flush_partial_results(op_name, batch_index, result_list)
+                    # --- END: Flush partial checkpoint ---
                 total_cost += item_cost
 
         if self.status:

--- a/docetl/runner.py
+++ b/docetl/runner.py
@@ -755,3 +755,34 @@ class DSLRunner(ConfigWrapper):
             return output_data, operation_instance
         else:
             return output_data
+
+    def _flush_partial_results(
+        self, operation_name: str, batch_index: int, data: List[Dict]
+    ) -> None:
+        """
+        Save partial (batch-level) results from an operation to a directory named
+        '<operation_name>_batches' inside the intermediate directory.
+
+        Args:
+            operation_name (str): The name of the operation, e.g. 'extract_medications'.
+            batch_index (int): Zero-based index of the batch.
+            data (List[Dict]): Batch results to write to disk.
+        """
+        if not self.intermediate_dir:
+            return
+
+        op_batches_dir = os.path.join(
+            self.intermediate_dir, f"{operation_name}_batches"
+        )
+        os.makedirs(op_batches_dir, exist_ok=True)
+
+        # File name: 'batch_0.json', 'batch_1.json', etc.
+        checkpoint_path = os.path.join(op_batches_dir, f"batch_{batch_index}.json")
+
+        with open(checkpoint_path, "w") as f:
+            json.dump(data, f)
+
+        self.console.log(
+            f"[green]✓[/green] [italic]Partial checkpoint saved for '{operation_name}', "
+            f"batch {batch_index} at '{checkpoint_path}'[/italic]"
+        )

--- a/docs/operators/map.md
+++ b/docs/operators/map.md
@@ -142,6 +142,7 @@ This example demonstrates how the Map operation can transform long, unstructured
 | `sample`                     | Number of samples to use for the operation                                                      | Processes all data            |
 | `tools`                           | List of tool definitions for LLM use                                                            | None                          |
 | `validate`                        | List of Python expressions to validate the output                                               | None                          |
+| `flush_partial_results`           | Write results of individual batches of map operation to disk for faster inspection              | True
 | `num_retries_on_validate_failure` | Number of retry attempts on validation failure                                                  | 0                             |
 | `gleaning`                        | Configuration for advanced validation and LLM-based refinement                                  | None                          |
 | `drop_keys`                       | List of keys to drop from the input before processing                                           | None                          |

--- a/docs/operators/map.md
+++ b/docs/operators/map.md
@@ -142,7 +142,7 @@ This example demonstrates how the Map operation can transform long, unstructured
 | `sample`                     | Number of samples to use for the operation                                                      | Processes all data            |
 | `tools`                           | List of tool definitions for LLM use                                                            | None                          |
 | `validate`                        | List of Python expressions to validate the output                                               | None                          |
-| `flush_partial_results`           | Write results of individual batches of map operation to disk for faster inspection              | True
+| `flush_partial_results`           | Write results of individual batches of map operation to disk for faster inspection              | False  |
 | `num_retries_on_validate_failure` | Number of retry attempts on validation failure                                                  | 0                             |
 | `gleaning`                        | Configuration for advanced validation and LLM-based refinement                                  | None                          |
 | `drop_keys`                       | List of keys to drop from the input before processing                                           | None                          |

--- a/tests/basic/test_basic_map.py
+++ b/tests/basic/test_basic_map.py
@@ -385,14 +385,14 @@ def test_map_operation_with_verbose(simple_map_config, map_sample_data, api_wrap
     )
 
 def test_map_operation_partial_checkpoint(
-    tmp_path, map_config_with_batching, default_model, max_threads, map_sample_data, api_wrapper
+    tmp_path, simple_map_config, default_model, max_threads, map_sample_data, api_wrapper
 ):
     """
     Test that MapOperation flushes partial results to disk when checkpoint_partial is enabled.
     
     This test:
     - Sets the intermediate_dir to a temporary directory.
-    - Enables checkpoint_partial in the operation config.
+    - Enables flush_partial_results in the operation config.
     - Executes the map operation.
     - Verifies that a subfolder named '<operation_name>_batches' is created.
     - Verifies that at least one partial checkpoint file (e.g. batch_0.json) is present and contains valid JSON.
@@ -405,19 +405,22 @@ def test_map_operation_partial_checkpoint(
     intermediate_dir.mkdir()
 
     # Enable partial checkpointing in the config.
-    map_config_with_batching["flush_partial_results"] = True
-    map_config_with_batching.setdefault("bypass_cache", True)
+    map_config = {
+        **simple_map_config,
+        "flush_partial_results": True,
+        "bypass_cache": True
+    }
 
     # Set the runner's intermediate_dir.
     # In our tests, 'api_wrapper' acts as the runner.
     api_wrapper.intermediate_dir = str(intermediate_dir)
 
     # Create and run the MapOperation.
-    operation = MapOperation(api_wrapper, map_config_with_batching, default_model, max_threads)
+    operation = MapOperation(api_wrapper, map_config, default_model, max_threads)
     results, cost = operation.execute(map_sample_data)
 
     # Determine the expected batch folder based on the operation name.
-    op_name = map_config_with_batching["name"]  # e.g. "extract_medications"
+    op_name = map_config["name"]
     batch_folder = intermediate_dir / f"{op_name}_batches"
     assert batch_folder.exists(), f"Partial checkpoint folder {batch_folder} does not exist"
 
@@ -425,12 +428,9 @@ def test_map_operation_partial_checkpoint(
     batch_files = sorted(batch_folder.glob("batch_*.json"))
     assert batch_files, "No partial checkpoint files were created"
 
-    # Optionally, check the first batch file contains valid, non-empty JSON data.
+    # Check the first batch file contains valid, non-empty JSON data.
     with open(batch_files[0], "r") as f:
         data = json.load(f)
     if map_sample_data:  # Only check if there was input
         assert isinstance(data, list), "Data in checkpoint file is not a list"
         assert data, "Partial checkpoint file is empty"
-
-    # Optionally, print the log for visual confirmation (comment out for CI)
-    # print(f"Partial checkpoint files created: {[os.path.basename(f) for f in batch_files]}")

--- a/tests/basic/test_basic_map.py
+++ b/tests/basic/test_basic_map.py
@@ -433,4 +433,4 @@ def test_map_operation_partial_checkpoint(
         assert data, "Partial checkpoint file is empty"
 
     # Optionally, print the log for visual confirmation (comment out for CI)
-    print(f"Partial checkpoint files created: {[os.path.basename(f) for f in batch_files]}")
+    # print(f"Partial checkpoint files created: {[os.path.basename(f) for f in batch_files]}")


### PR DESCRIPTION
Addresses #321 with a new flag for just for the map operation. To keep the change minimal for a single PR, there is nothing here that also reuses the already processed batches.

I implemented a method in the runner that could be an opt-in for other Ops too. Unsure though how generic it is.