### PR TITLE
feat: add _file_path to each document when uploading the dataset

### DIFF
--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -540,11 +540,20 @@ class ParallelMapOperation(BaseOperation):
                     raise ValueError(
                         f"PDF URL key '{self.config['pdf_url_key']}' not found in input data"
                     )
+                # Download content
+                if pdf_url.startswith("http"):
+                    file_data = requests.get(pdf_url).content
+                else:
+                    with open(pdf_url, "rb") as f:
+                        file_data = f.read()
+                encoded_file = base64.b64encode(file_data).decode("utf-8")
+                base64_url = f"data:application/pdf;base64,{encoded_file}"
+
                 messages[0]["content"] = [
-                    {"type": "image_url", "image_url": {"url": pdf_url}},
+                    {"type": "image_url", "image_url": {"url": base64_url}},
                     {"type": "text", "text": prompt},
                 ]
-
+                
             local_output_schema = {
                 key: output_schema.get(key, "string")
                 for key in prompt_config["output_keys"]

--- a/website/src/components/FileExplorer.tsx
+++ b/website/src/components/FileExplorer.tsx
@@ -430,9 +430,21 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({
         onFileUpload(originalFile);
       });
 
+      // Add the path to the result documents
+      const resultFiles = result.documents.map(
+        (doc: Record<string, string>) => {
+          const originalFile = savedDocs.files.find(
+            (f: Record<string, string>) => f.name === doc.filename
+          );
+          // Add the path to the result document
+          doc._file_path = originalFile?.path;
+          return doc;
+        }
+      );
+
       // Create and upload the JSON result file
       const jsonFile = new File(
-        [JSON.stringify(result.documents, null, 2)],
+        [JSON.stringify(resultFiles, null, 2)],
         `docs_${timestamp}.json`,
         { type: "application/json" }
       );


### PR DESCRIPTION
In DocWrangler, now every upload of a PDF should stores the full path of a file (in the _file_path key), and it can be referenced in the pdf_url_key in map and filter operations if users want to use claude or gemini.