### PR TITLE
feat: add TPM rate limits & pipeline settings to DocWrangler

### DIFF
--- a/docetl/config_wrapper.py
+++ b/docetl/config_wrapper.py
@@ -1,9 +1,11 @@
 import datetime
 import math
 import os
+import time
 from typing import Dict, Optional
 
 import pyrate_limiter
+from pyrate_limiter import LimiterDelayException, BucketFullException
 from rich.console import Console
 
 from docetl.console import get_console
@@ -67,10 +69,25 @@ class ConfigWrapper(object):
             os.environ[key] = value
 
         bucket_factory = create_bucket_factory(self.config.get("rate_limits", {}))
-        self.rate_limiter = pyrate_limiter.Limiter(bucket_factory, max_delay=math.inf)
+        self.rate_limiter = pyrate_limiter.Limiter(bucket_factory, max_delay=200)
         self.is_cancelled = False
 
         self.api = APIWrapper(self)
 
     def reset_env(self):
         os.environ = self._original_env
+        
+    def blocking_acquire(self, key: str, weight: int, wait_time=0.5):
+        while True:
+            try:
+                self.rate_limiter.try_acquire(key, weight=weight)
+                return  # Acquired successfully
+            except LimiterDelayException as e:
+                print(e.meta_info)
+                time_to_wait = e.meta_info["actual_delay"] / 1000
+                self.console.log(f"Rate limits met for {key}; sleeping for {max(time_to_wait, wait_time):.2f} seconds")
+                time.sleep(max(time_to_wait, wait_time))
+            except BucketFullException as e:
+                time_to_wait = e.meta_info["remaining_time"]
+                self.console.log(f"Rate limits met for {key}; sleeping for {max(time_to_wait, wait_time):.2f} seconds")
+                time.sleep(max(time_to_wait, wait_time))

--- a/docetl/config_wrapper.py
+++ b/docetl/config_wrapper.py
@@ -1,11 +1,10 @@
 import datetime
-import math
 import os
 import time
 from typing import Dict, Optional
 
 import pyrate_limiter
-from pyrate_limiter import LimiterDelayException, BucketFullException
+from pyrate_limiter import BucketFullException, LimiterDelayException
 from rich.console import Console
 
 from docetl.console import get_console
@@ -76,7 +75,7 @@ class ConfigWrapper(object):
 
     def reset_env(self):
         os.environ = self._original_env
-        
+
     def blocking_acquire(self, key: str, weight: int, wait_time=0.5):
         while True:
             try:
@@ -85,9 +84,13 @@ class ConfigWrapper(object):
             except LimiterDelayException as e:
                 print(e.meta_info)
                 time_to_wait = e.meta_info["actual_delay"] / 1000
-                self.console.log(f"Rate limits met for {key}; sleeping for {max(time_to_wait, wait_time):.2f} seconds")
+                self.console.log(
+                    f"Rate limits met for {key}; sleeping for {max(time_to_wait, wait_time):.2f} seconds"
+                )
                 time.sleep(max(time_to_wait, wait_time))
             except BucketFullException as e:
                 time_to_wait = e.meta_info["remaining_time"]
-                self.console.log(f"Rate limits met for {key}; sleeping for {max(time_to_wait, wait_time):.2f} seconds")
+                self.console.log(
+                    f"Rate limits met for {key}; sleeping for {max(time_to_wait, wait_time):.2f} seconds"
+                )
                 time.sleep(max(time_to_wait, wait_time))

--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -217,7 +217,6 @@ class MapOperation(BaseOperation):
                     return output, True
                 return output, False
 
-            self.runner.rate_limiter.try_acquire("llm_call", weight=1)
             if self.runner.is_cancelled:
                 raise asyncio.CancelledError("Operation was cancelled")
             llm_result = self.runner.api.call_llm(

--- a/docetl/operations/sample.py
+++ b/docetl/operations/sample.py
@@ -120,7 +120,7 @@ class SampleOperation(BaseOperation):
         cost = 0
         if not input_data:
             return [], cost
-        
+
         if self.config["method"] == "first":
             return input_data[: self.config["samples"]], cost
 

--- a/docetl/operations/utils/api.py
+++ b/docetl/operations/utils/api.py
@@ -77,7 +77,7 @@ class APIWrapper(object):
                 input = [item if item else "None" for item in input]
 
                 # FIXME: Should we use a different limit for embedding?
-                self.runner.rate_limiter.try_acquire("embedding_call", weight=1)
+                self.runner.blocking_acquire("embedding_call", weight=1)
                 if self.runner.is_cancelled:
                     raise asyncio.CancelledError("Operation was cancelled")
                 result = embedding(model=model, input=input)
@@ -206,10 +206,10 @@ class APIWrapper(object):
                             gleaning_config["validation_prompt"],
                             {"output": parsed_output},
                         )
-                        self.runner.rate_limiter.try_acquire("llm_call", weight=1)
+                        self.runner.blocking_acquire("llm_call", weight=1)
                         # Approx the number of tokens in the messages
                         approx_num_tokens = approx_count_tokens(validator_messages + [{"role": "user", "content": validator_prompt}])
-                        self.runner.rate_limiter.try_acquire("llm_tokens", weight=approx_num_tokens)
+                        self.runner.blocking_acquire("llm_tokens", weight=approx_num_tokens)
 
                         # Get params for should refine
                         should_refine_params = {
@@ -616,11 +616,11 @@ Your main result must be sent via send_output. The updated_scratchpad is only fo
         # Truncate messages if they exceed the model's context length
         messages = truncate_messages(messages, model)
 
-        self.runner.rate_limiter.try_acquire("llm_call", weight=1)
+        self.runner.blocking_acquire("llm_call", weight=1)
         
         # Approx the number of tokens in the messages
         approx_num_tokens = approx_count_tokens(messages)
-        self.runner.rate_limiter.try_acquire("llm_tokens", weight=approx_num_tokens)
+        self.runner.blocking_acquire("llm_tokens", weight=approx_num_tokens)
         if self.runner.is_cancelled:
             raise asyncio.CancelledError("Operation was cancelled")
 

--- a/docetl/operations/utils/api.py
+++ b/docetl/operations/utils/api.py
@@ -16,7 +16,13 @@ from rich.text import Text
 from docetl.utils import completion_cost
 
 from .cache import cache, cache_key, freezeargs
-from .llm import InvalidOutputError, LLMResult, timeout, truncate_messages, approx_count_tokens
+from .llm import (
+    InvalidOutputError,
+    LLMResult,
+    approx_count_tokens,
+    timeout,
+    truncate_messages,
+)
 from .validation import (
     convert_dict_schema_to_list_schema,
     convert_val,
@@ -208,8 +214,13 @@ class APIWrapper(object):
                         )
                         self.runner.blocking_acquire("llm_call", weight=1)
                         # Approx the number of tokens in the messages
-                        approx_num_tokens = approx_count_tokens(validator_messages + [{"role": "user", "content": validator_prompt}])
-                        self.runner.blocking_acquire("llm_tokens", weight=approx_num_tokens)
+                        approx_num_tokens = approx_count_tokens(
+                            validator_messages
+                            + [{"role": "user", "content": validator_prompt}]
+                        )
+                        self.runner.blocking_acquire(
+                            "llm_tokens", weight=approx_num_tokens
+                        )
 
                         # Get params for should refine
                         should_refine_params = {
@@ -617,7 +628,7 @@ Your main result must be sent via send_output. The updated_scratchpad is only fo
         messages = truncate_messages(messages, model)
 
         self.runner.blocking_acquire("llm_call", weight=1)
-        
+
         # Approx the number of tokens in the messages
         approx_num_tokens = approx_count_tokens(messages)
         self.runner.blocking_acquire("llm_tokens", weight=approx_num_tokens)

--- a/docetl/operations/utils/llm.py
+++ b/docetl/operations/utils/llm.py
@@ -71,6 +71,7 @@ def approx_count_tokens(messages: List[Dict[str, str]]) -> int:
     """Approximately 4 characters per token. So count the number of characters in the messages and divide by 4."""
     return int(sum(len(msg["content"]) for msg in messages) / 4)
 
+
 def truncate_messages(
     messages: List[Dict[str, str]], model: str, from_agent: bool = False
 ) -> List[Dict[str, str]]:

--- a/docetl/operations/utils/llm.py
+++ b/docetl/operations/utils/llm.py
@@ -67,6 +67,10 @@ def timeout(seconds):
     return decorator
 
 
+def approx_count_tokens(messages: List[Dict[str, str]]) -> int:
+    """Approximately 4 characters per token. So count the number of characters in the messages and divide by 4."""
+    return int(sum(len(msg["content"]) for msg in messages) / 4)
+
 def truncate_messages(
     messages: List[Dict[str, str]], model: str, from_agent: bool = False
 ) -> List[Dict[str, str]]:

--- a/docs/examples/rate-limiting.md
+++ b/docs/examples/rate-limiting.md
@@ -19,6 +19,10 @@ rate_limits:
     - count: 10
       per: 5
       unit: hour
+  llm_tokens:
+    - count: 1000000
+      per: 1
+      unit: minute
 ```
 
 Your YAML configuration should have a `rate_limits` key with the config as shown above. This example sets limits for embedding calls and language model (LLM) calls, with multiple rules for LLM calls to accommodate different time scales.

--- a/website/src/app/api/getInputOutput/route.ts
+++ b/website/src/app/api/getInputOutput/route.ts
@@ -18,6 +18,7 @@ export async function POST(request: Request) {
       name,
       sample_size,
       namespace,
+      extraPipelineSettings,
     } = await request.json();
 
     if (!name) {
@@ -49,7 +50,8 @@ export async function POST(request: Request) {
       { datasetDescription: null, persona: null },
       [],
       "",
-      false
+      false,
+      extraPipelineSettings
     );
 
     // Check if files exist using FastAPI endpoints

--- a/website/src/app/api/getPipelineConfig/route.ts
+++ b/website/src/app/api/getPipelineConfig/route.ts
@@ -13,6 +13,7 @@ export async function POST(request: Request) {
       namespace,
       system_prompt,
       optimizerModel,
+      extraPipelineSettings,
     } = await request.json();
 
     if (!name) {
@@ -46,7 +47,8 @@ export async function POST(request: Request) {
       [],
       "",
       false,
-      optimizerModel
+      optimizerModel,
+      extraPipelineSettings
     );
 
     return NextResponse.json({ pipelineConfig: yamlString });

--- a/website/src/app/api/utils.ts
+++ b/website/src/app/api/utils.ts
@@ -51,7 +51,8 @@ export function generatePipelineConfig(
   apiKeys: APIKey[] = [],
   docetl_encryption_key: string = "",
   enable_observability: boolean = true,
-  optimizerModel: string = "gpt-4o"
+  optimizerModel: string = "gpt-4o",
+  extraPipelineSettings: Record<string, unknown> | null = null
 ) {
   const datasets = {
     input: {
@@ -214,7 +215,7 @@ export function generatePipelineConfig(
     );
 
   // Fix type errors by asserting the pipeline config type
-  const pipelineConfig: any = {
+  let pipelineConfig: any = {
     optimizer_model: optimizerModel,
     datasets,
     default_model,
@@ -280,6 +281,11 @@ export function generatePipelineConfig(
       // @ts-ignore
       pipelineConfig.system_prompt!.persona = system_prompt.persona;
     }
+  }
+
+  if (extraPipelineSettings) {
+    // merge extraPipelineSettings into pipelineConfig
+    pipelineConfig = { ...pipelineConfig, ...extraPipelineSettings };
   }
 
   // Get the inputPath from the intermediate_dir

--- a/website/src/app/api/writePipelineConfig/route.ts
+++ b/website/src/app/api/writePipelineConfig/route.ts
@@ -23,6 +23,7 @@ export async function POST(request: Request) {
       namespace,
       apiKeys,
       optimizerModel,
+      extraPipelineSettings,
     } = await request.json();
 
     if (!name) {
@@ -57,7 +58,8 @@ export async function POST(request: Request) {
       apiKeys,
       docetl_encryption_key,
       true,
-      optimizerModel
+      optimizerModel,
+      extraPipelineSettings
     );
 
     // Use the FastAPI endpoint to write the pipeline config

--- a/website/src/app/localStorageKeys.ts
+++ b/website/src/app/localStorageKeys.ts
@@ -18,3 +18,4 @@ export const AUTO_OPTIMIZE_CHECK_KEY = "docetl_autoOptimizeCheck";
 export const HIGH_LEVEL_GOAL_KEY = "docetl_highLevelGoal";
 export const SYSTEM_PROMPT_KEY = "docetl_systemPrompt";
 export const NAMESPACE_KEY = "docetl_namespace";
+export const EXTRA_PIPELINE_SETTINGS_KEY = "docetl_extraPipelineSettings";

--- a/website/src/components/PipelineSettings.tsx
+++ b/website/src/components/PipelineSettings.tsx
@@ -1,0 +1,398 @@
+import React, { useState, useMemo, useCallback } from "react";
+import { File } from "@/app/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { AlertCircle } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import yaml from "js-yaml";
+
+const PREDEFINED_MODELS = [
+  "gpt-4o-mini",
+  "gpt-4o",
+  "claude-3-7-sonnet-20250219",
+  "claude-3-opus-20240229",
+  "azure/<your-deployment-name>",
+  "gemini/gemini-2.0-flash",
+] as const;
+
+interface ModelInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  suggestions?: readonly string[];
+}
+
+export const ModelInput: React.FC<ModelInputProps> = ({
+  value,
+  onChange,
+  placeholder,
+  suggestions = PREDEFINED_MODELS,
+}) => {
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <div className="relative">
+      <Input
+        value={value || ""}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full"
+        placeholder={placeholder}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => {
+          setTimeout(() => setIsFocused(false), 200);
+        }}
+      />
+      {isFocused &&
+        (value === "" ||
+          suggestions.some((model) =>
+            model.toLowerCase().includes(value?.toLowerCase() || "")
+          )) && (
+          <div className="absolute top-full left-0 w-full mt-1 bg-popover rounded-md border shadow-md z-50 max-h-[200px] overflow-y-auto">
+            {suggestions
+              .filter(
+                (model) =>
+                  value === "" ||
+                  model.toLowerCase().includes(value.toLowerCase())
+              )
+              .map((model) => (
+                <div
+                  key={model}
+                  className="px-2 py-1.5 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground"
+                  onClick={() => {
+                    onChange(model);
+                    setIsFocused(false);
+                  }}
+                >
+                  {model}
+                </div>
+              ))}
+          </div>
+        )}
+    </div>
+  );
+};
+
+interface PipelineSettingsProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  pipelineName: string;
+  setPipelineName: (name: string) => void;
+  currentFile: File | null;
+  setCurrentFile: (file: File | null) => void;
+  defaultModel: string;
+  setDefaultModel: (model: string) => void;
+  optimizerModel: string;
+  setOptimizerModel: (model: string) => void;
+  autoOptimizeCheck: boolean;
+  setAutoOptimizeCheck: (check: boolean) => void;
+  files: File[];
+  apiKeys: Array<{ name: string; value: string }>;
+  extraPipelineSettings: Record<string, unknown> | null;
+  setExtraPipelineSettings: (settings: Record<string, unknown> | null) => void;
+}
+
+const SAMPLE_YAML = `# Example configuration - delete or modify as needed
+rate_limits:
+  llm_call:
+    - count: 1000000
+      per: 1
+      unit: minute
+  llm_tokens:
+    - count: 1000000000
+      per: 1
+      unit: minute`;
+
+const PipelineSettings: React.FC<PipelineSettingsProps> = ({
+  isOpen,
+  onOpenChange,
+  pipelineName,
+  setPipelineName,
+  currentFile,
+  setCurrentFile,
+  defaultModel,
+  setDefaultModel,
+  optimizerModel,
+  setOptimizerModel,
+  autoOptimizeCheck,
+  setAutoOptimizeCheck,
+  files,
+  apiKeys,
+  extraPipelineSettings,
+  setExtraPipelineSettings,
+}) => {
+  const [tempPipelineName, setTempPipelineName] = useState(pipelineName);
+  const [tempCurrentFile, setTempCurrentFile] = useState<File | null>(
+    currentFile
+  );
+  const [tempDefaultModel, setTempDefaultModel] = useState(defaultModel);
+  const [tempOptimizerModel, setTempOptimizerModel] = useState(optimizerModel);
+  const [tempAutoOptimizeCheck, setTempAutoOptimizeCheck] =
+    useState(autoOptimizeCheck);
+  const [isLocalMode, setIsLocalMode] = useState(false);
+
+  // Convert extraPipelineSettings to YAML string
+  const initialYamlString = useMemo(() => {
+    if (!extraPipelineSettings) {
+      return "";
+    }
+    try {
+      return yaml.dump(extraPipelineSettings);
+    } catch (e) {
+      console.error("Error converting settings to YAML:", e);
+      return "";
+    }
+  }, [extraPipelineSettings]);
+
+  const [tempYamlSettings, setTempYamlSettings] = useState(initialYamlString);
+  const [yamlError, setYamlError] = useState<string | null>(null);
+
+  const hasOpenAIKey = useMemo(() => {
+    return apiKeys.some((key) => key.name === "OPENAI_API_KEY");
+  }, [apiKeys]);
+
+  // Update local state when props change
+  React.useEffect(() => {
+    setTempPipelineName(pipelineName);
+    setTempCurrentFile(currentFile);
+    setTempDefaultModel(defaultModel);
+    setTempOptimizerModel(optimizerModel);
+    setTempAutoOptimizeCheck(autoOptimizeCheck);
+
+    // Update YAML when extraPipelineSettings changes
+    if (extraPipelineSettings) {
+      try {
+        setTempYamlSettings(yaml.dump(extraPipelineSettings));
+      } catch (e) {
+        console.error("Error converting settings to YAML:", e);
+      }
+    } else {
+      setTempYamlSettings("");
+    }
+  }, [
+    pipelineName,
+    currentFile,
+    defaultModel,
+    optimizerModel,
+    autoOptimizeCheck,
+    extraPipelineSettings,
+  ]);
+
+  const validateYaml = useCallback((yamlString: string) => {
+    if (!yamlString.trim()) {
+      setYamlError(null);
+      return null;
+    }
+
+    try {
+      const parsed = yaml.load(yamlString);
+      setYamlError(null);
+      return parsed as Record<string, unknown>;
+    } catch (e) {
+      const error = e as Error;
+      setYamlError(`Invalid YAML: ${error.message}`);
+      return null;
+    }
+  }, []);
+
+  const handleYamlChange = useCallback(
+    (value: string) => {
+      setTempYamlSettings(value);
+      validateYaml(value);
+    },
+    [validateYaml]
+  );
+
+  const handleSettingsSave = () => {
+    setPipelineName(tempPipelineName);
+    setCurrentFile(tempCurrentFile);
+    setDefaultModel(tempDefaultModel);
+    setOptimizerModel(tempOptimizerModel);
+    setAutoOptimizeCheck(tempAutoOptimizeCheck);
+
+    // Process and save YAML settings
+    if (tempYamlSettings.trim()) {
+      const parsedSettings = validateYaml(tempYamlSettings);
+      if (parsedSettings) {
+        setExtraPipelineSettings(parsedSettings);
+      }
+    } else {
+      setExtraPipelineSettings(null);
+    }
+
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Pipeline Settings</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="flex flex-col space-y-1.5">
+            <Label htmlFor="pipelineName">Pipeline Name</Label>
+            <Input
+              id="pipelineName"
+              value={tempPipelineName}
+              onChange={(e) => setTempPipelineName(e.target.value)}
+              placeholder="Enter pipeline name"
+            />
+          </div>
+
+          <div className="flex flex-col space-y-1.5">
+            <Label htmlFor="currentFile">Dataset JSON</Label>
+            <Select
+              value={tempCurrentFile?.path || ""}
+              onValueChange={(value) =>
+                setTempCurrentFile(
+                  files.find((file) => file.path === value) || null
+                )
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a file" />
+              </SelectTrigger>
+              <SelectContent>
+                {files
+                  .filter((file) => file.type === "json")
+                  .map((file) => (
+                    <SelectItem key={file.path} value={file.path}>
+                      {file.name}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col space-y-1.5">
+            <Label htmlFor="defaultModel">Default Model</Label>
+            <ModelInput
+              value={tempDefaultModel}
+              onChange={setTempDefaultModel}
+              placeholder="Enter or select a model..."
+            />
+            <p className="text-xs text-muted-foreground">
+              Enter any LiteLLM model name or select from suggestions. Make sure
+              you&apos;ve set your API keys in Edit {">"} Edit API Keys when
+              using our hosted app.{" "}
+              <a
+                href="https://docs.litellm.ai/docs/providers"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 hover:underline"
+              >
+                View all supported models {String.fromCharCode(8594)}
+              </a>
+            </p>
+          </div>
+
+          <div className="flex flex-col space-y-1.5">
+            <Label htmlFor="optimize">Optimizer Model</Label>
+            {!hasOpenAIKey && !isLocalMode ? (
+              <div className="bg-destructive/10 text-destructive rounded-md p-3 text-xs">
+                <div className="flex gap-2">
+                  <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+                  <div>
+                    <p className="font-medium">OpenAI API Key Required</p>
+                    <p className="mt-1">
+                      To use the optimizer, please add your OpenAI API key in
+                      Edit {">"} Edit API Keys.
+                    </p>
+                    <button
+                      className="text-destructive underline hover:opacity-80 mt-1.5 font-medium"
+                      onClick={() => setIsLocalMode(true)}
+                    >
+                      Skip if running locally with environment variables
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <ModelInput
+                  value={tempOptimizerModel}
+                  onChange={setTempOptimizerModel}
+                  placeholder="Enter optimizer model name..."
+                  suggestions={["gpt-4o", "gpt-4o-mini"]}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Enter any LiteLLM model name (e.g., &quot;azure/gpt-4o&quot;)
+                  or select from suggestions above. Make sure the model supports
+                  JSON mode.
+                </p>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col space-y-1.5">
+            <Label htmlFor="autoOptimize">
+              Automatically Check Whether to Optimize
+            </Label>
+            <Switch
+              id="autoOptimize"
+              checked={tempAutoOptimizeCheck}
+              onCheckedChange={(checked) => setTempAutoOptimizeCheck(checked)}
+              disabled={!hasOpenAIKey && !isLocalMode}
+            />
+          </div>
+
+          <div className="flex flex-col space-y-1.5">
+            <div className="flex justify-between items-center">
+              <Label htmlFor="advancedSettings">
+                Advanced Pipeline Settings (YAML)
+              </Label>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setTempYamlSettings(SAMPLE_YAML)}
+              >
+                Add Example
+              </Button>
+            </div>
+            <Textarea
+              id="advancedSettings"
+              value={tempYamlSettings}
+              onChange={(e) => handleYamlChange(e.target.value)}
+              placeholder="Enter YAML configuration for rate limits and other advanced settings"
+              className="font-mono text-sm h-48 resize-y"
+            />
+            {yamlError && (
+              <div className="text-sm text-destructive">{yamlError}</div>
+            )}
+            <p className="text-sm text-muted-foreground">
+              Configure rate limits and other advanced settings in YAML format.
+              These settings will be passed to the backend.
+            </p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            onClick={handleSettingsSave}
+            disabled={!!yamlError && tempYamlSettings.trim() !== ""}
+          >
+            Save changes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PipelineSettings;

--- a/website/src/contexts/PipelineContext.tsx
+++ b/website/src/contexts/PipelineContext.tsx
@@ -14,7 +14,10 @@ import {
   mockPipelineName,
 } from "@/mocks/mockData";
 import * as localStorageKeys from "@/app/localStorageKeys";
-import { BOOKMARKS_STORAGE_KEY } from "@/app/localStorageKeys";
+import {
+  BOOKMARKS_STORAGE_KEY,
+  EXTRA_PIPELINE_SETTINGS_KEY,
+} from "@/app/localStorageKeys";
 import { toast } from "@/hooks/use-toast";
 
 interface PipelineState {
@@ -42,6 +45,7 @@ interface PipelineState {
   systemPrompt: { datasetDescription: string | null; persona: string | null };
   namespace: string | null;
   apiKeys: APIKey[];
+  extraPipelineSettings: Record<string, unknown> | null;
 }
 
 interface PipelineContextType extends PipelineState {
@@ -80,6 +84,9 @@ interface PipelineContextType extends PipelineState {
   >;
   setNamespace: React.Dispatch<React.SetStateAction<string | null>>;
   setApiKeys: React.Dispatch<React.SetStateAction<APIKey[]>>;
+  setExtraPipelineSettings: React.Dispatch<
+    React.SetStateAction<Record<string, unknown> | null>
+  >;
 }
 
 const PipelineContext = createContext<PipelineContextType | undefined>(
@@ -320,6 +327,10 @@ export const PipelineProvider: React.FC<{ children: React.ReactNode }> = ({
     }),
     namespace: loadFromLocalStorage(localStorageKeys.NAMESPACE_KEY, null),
     apiKeys: [],
+    extraPipelineSettings: loadFromLocalStorage(
+      EXTRA_PIPELINE_SETTINGS_KEY,
+      null
+    ),
   }));
 
   const [unsavedChanges, setUnsavedChanges] = useState(false);
@@ -395,6 +406,14 @@ export const PipelineProvider: React.FC<{ children: React.ReactNode }> = ({
       localStorageKeys.SYSTEM_PROMPT_KEY,
       JSON.stringify(stateRef.current.systemPrompt)
     );
+    localStorage.setItem(
+      localStorageKeys.NAMESPACE_KEY,
+      JSON.stringify(stateRef.current.namespace)
+    );
+    localStorage.setItem(
+      EXTRA_PIPELINE_SETTINGS_KEY,
+      JSON.stringify(stateRef.current.extraPipelineSettings)
+    );
     setUnsavedChanges(false);
   }, []);
 
@@ -421,6 +440,7 @@ export const PipelineProvider: React.FC<{ children: React.ReactNode }> = ({
       systemPrompt: { datasetDescription: null, persona: null },
       namespace: null,
       apiKeys: stateRef.current.apiKeys,
+      extraPipelineSettings: null,
     });
     setUnsavedChanges(false);
   }, []);
@@ -563,6 +583,10 @@ export const PipelineProvider: React.FC<{ children: React.ReactNode }> = ({
     ),
     setApiKeys: useCallback(
       (value) => setStateAndUpdate("apiKeys", value),
+      [setStateAndUpdate]
+    ),
+    setExtraPipelineSettings: useCallback(
+      (value) => setStateAndUpdate("extraPipelineSettings", value),
       [setStateAndUpdate]
     ),
   };

--- a/website/src/contexts/PipelineContext.tsx
+++ b/website/src/contexts/PipelineContext.tsx
@@ -14,10 +14,6 @@ import {
   mockPipelineName,
 } from "@/mocks/mockData";
 import * as localStorageKeys from "@/app/localStorageKeys";
-import {
-  BOOKMARKS_STORAGE_KEY,
-  EXTRA_PIPELINE_SETTINGS_KEY,
-} from "@/app/localStorageKeys";
 import { toast } from "@/hooks/use-toast";
 
 interface PipelineState {
@@ -102,7 +98,7 @@ const loadFromLocalStorage = <T,>(key: string, defaultValue: T): T => {
 };
 
 const serializeState = async (state: PipelineState): Promise<string> => {
-  const bookmarks = loadFromLocalStorage(BOOKMARKS_STORAGE_KEY, []);
+  const bookmarks = loadFromLocalStorage(localStorageKeys.BOOKMARKS_KEY, []);
 
   // Get important output samples
   let outputSample = "";
@@ -328,7 +324,7 @@ export const PipelineProvider: React.FC<{ children: React.ReactNode }> = ({
     namespace: loadFromLocalStorage(localStorageKeys.NAMESPACE_KEY, null),
     apiKeys: [],
     extraPipelineSettings: loadFromLocalStorage(
-      EXTRA_PIPELINE_SETTINGS_KEY,
+      localStorageKeys.EXTRA_PIPELINE_SETTINGS_KEY,
       null
     ),
   }));
@@ -411,7 +407,7 @@ export const PipelineProvider: React.FC<{ children: React.ReactNode }> = ({
       JSON.stringify(stateRef.current.namespace)
     );
     localStorage.setItem(
-      EXTRA_PIPELINE_SETTINGS_KEY,
+      localStorageKeys.EXTRA_PIPELINE_SETTINGS_KEY,
       JSON.stringify(stateRef.current.extraPipelineSettings)
     );
     setUnsavedChanges(false);


### PR DESCRIPTION
We got a request from the community to add support for setting rate limits in DocWrangler. This PR allows users to set other pipeline settings like rate limits, and adds support for token per minute (TPM) rate limits. We also added a TPM example to the documentation.

There are three types of rate limits: embedding_call, llm_call (e.g., RPM), and llm_tokens (e.g., TPM).

<img width="814" alt="Screenshot 2025-04-19 at 10 33 58 PM" src="https://github.com/user-attachments/assets/6937ebb4-e107-45ce-a1bd-1cdcc30d213e" />
