### PR TITLE
fix: create join optimizer object correctly

### DIFF
--- a/docetl/optimizers/reduce_optimizer.py
+++ b/docetl/optimizers/reduce_optimizer.py
@@ -486,6 +486,7 @@ class ReduceOptimizer:
                 },
             }
             optimized_resolve_config, resolve_cost = JoinOptimizer(
+                self.runner,
                 self.config,
                 resolve_config,
                 self.console,


### PR DESCRIPTION
As title. Fixes the following bug (found on Discord)

```
21:54:42 - LiteLLM:INFO: utils.py:1120 - Wrapper: Completed Call, calling success_handler
           INFO     Wrapper: Completed Call, calling success_handler                                                                             utils.py:1120
Error occurred:
Traceback (most recent call last):
  File "/app/server/app/routes/pipeline.py", line 244, in websocket_run_pipeline
    result = await pipeline_task
             ^^^^^^^^^^^^^^^^^^^
  File "/app/server/app/routes/pipeline.py", line 189, in run_pipeline
    return await asyncio.to_thread(runner.optimize, return_pipeline=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)

                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/docetl/optimizers/reduce_optimizer.py", line 252, in optimize
    return self._optimize_decomposed_reduce(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/docetl/optimizers/reduce_optimizer.py", line 488, in _optimize_decomposed_reduce
    optimized_resolve_config, resolve_cost = JoinOptimizer(
                                             ^^^^^^^^^^^^^^
  File "/app/docetl/optimizers/join_optimizer.py", line 27, in init
    self.config = runner.config
                  ^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'config'
```