### PR TITLE
Clean up and reorganize pytest tests

### DIFF
--- a/tests/basic/test_basic_filter_split_gather.py
+++ b/tests/basic/test_basic_filter_split_gather.py
@@ -7,7 +7,7 @@ from docetl.operations.gather import GatherOperation
 from docetl.operations.utils import APIWrapper
 from docetl.config_wrapper import ConfigWrapper
 from dotenv import load_dotenv
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 
 
 load_dotenv()
@@ -35,9 +35,9 @@ def filter_sample_data():
 
 
 def test_filter_operation(
-    filter_config, default_model, max_threads, filter_sample_data, api_wrapper
+    filter_config, default_model, max_threads, filter_sample_data, runner
 ):
-    operation = FilterOperation(api_wrapper, filter_config, default_model, max_threads)
+    operation = FilterOperation(runner, filter_config, default_model, max_threads)
     results, cost = operation.execute(filter_sample_data)
 
     assert len(results) < len(filter_sample_data)
@@ -45,9 +45,9 @@ def test_filter_operation(
 
 
 def test_filter_operation_empty_input(
-    filter_config, default_model, max_threads, api_wrapper
+    filter_config, default_model, max_threads, runner
 ):
-    operation = FilterOperation(api_wrapper, filter_config, default_model, max_threads)
+    operation = FilterOperation(runner, filter_config, default_model, max_threads)
     results, cost = operation.execute([])
 
     assert len(results) == 0
@@ -96,10 +96,10 @@ def dict_unnest_sample_data():
 
 
 def test_dict_unnest_operation(
-    dict_unnest_config, default_model, max_threads, dict_unnest_sample_data, api_wrapper
+    dict_unnest_config, default_model, max_threads, dict_unnest_sample_data, runner
 ):
     operation = UnnestOperation(
-        api_wrapper, dict_unnest_config, default_model, max_threads
+        runner, dict_unnest_config, default_model, max_threads
     )
     results, cost = operation.execute(dict_unnest_sample_data)
 
@@ -118,10 +118,10 @@ def test_dict_unnest_operation(
 
 
 def test_dict_unnest_operation_empty_input(
-    dict_unnest_config, default_model, max_threads, api_wrapper
+    dict_unnest_config, default_model, max_threads, runner
 ):
     operation = UnnestOperation(
-        api_wrapper, dict_unnest_config, default_model, max_threads
+        runner, dict_unnest_config, default_model, max_threads
     )
     results, cost = operation.execute([])
 
@@ -130,9 +130,9 @@ def test_dict_unnest_operation_empty_input(
 
 
 def test_unnest_operation(
-    unnest_config, default_model, max_threads, unnest_sample_data, api_wrapper
+    unnest_config, default_model, max_threads, unnest_sample_data, runner
 ):
-    operation = UnnestOperation(api_wrapper, unnest_config, default_model, max_threads)
+    operation = UnnestOperation(runner, unnest_config, default_model, max_threads)
     results, cost = operation.execute(unnest_sample_data)
 
     assert len(results) == 6  # 3 + 2 + 1
@@ -141,9 +141,9 @@ def test_unnest_operation(
 
 
 def test_unnest_operation_empty_input(
-    unnest_config, default_model, max_threads, api_wrapper
+    unnest_config, default_model, max_threads, runner
 ):
-    operation = UnnestOperation(api_wrapper, unnest_config, default_model, max_threads)
+    operation = UnnestOperation(runner, unnest_config, default_model, max_threads)
     results, cost = operation.execute([])
 
     assert len(results) == 0
@@ -182,10 +182,10 @@ def right_data():
 
 
 def test_equijoin_operation(
-    equijoin_config, default_model, max_threads, left_data, right_data, api_wrapper
+    equijoin_config, default_model, max_threads, left_data, right_data, runner
 ):
     operation = EquijoinOperation(
-        api_wrapper, equijoin_config, default_model, max_threads
+        runner, equijoin_config, default_model, max_threads
     )
     results, cost = operation.execute(left_data, right_data)
 
@@ -194,10 +194,10 @@ def test_equijoin_operation(
 
 
 def test_equijoin_operation_empty_input(
-    equijoin_config, default_model, max_threads, api_wrapper
+    equijoin_config, default_model, max_threads, runner
 ):
     operation = EquijoinOperation(
-        api_wrapper, equijoin_config, default_model, max_threads
+        runner, equijoin_config, default_model, max_threads
     )
     results, cost = operation.execute([], [])
 
@@ -253,9 +253,9 @@ def sample_data():
 
 
 def test_split_operation(
-    split_config, default_model, max_threads, sample_data, api_wrapper
+    split_config, default_model, max_threads, sample_data, runner
 ):
-    operation = SplitOperation(api_wrapper, split_config, default_model, max_threads)
+    operation = SplitOperation(runner, split_config, default_model, max_threads)
     results, cost = operation.execute(sample_data)
 
     assert len(results) > len(sample_data)
@@ -287,14 +287,14 @@ def test_split_operation(
 
 
 def test_gather_operation(
-    split_config, gather_config, default_model, max_threads, sample_data, api_wrapper
+    split_config, gather_config, default_model, max_threads, sample_data, runner
 ):
     # First, split the data
-    split_op = SplitOperation(api_wrapper, split_config, default_model, max_threads)
+    split_op = SplitOperation(runner, split_config, default_model, max_threads)
     split_results, _ = split_op.execute(sample_data)
 
     # Now, gather the split results
-    gather_op = GatherOperation(api_wrapper, gather_config, default_model, max_threads)
+    gather_op = GatherOperation(runner, gather_config, default_model, max_threads)
     results, cost = gather_op.execute(split_results)
 
     assert len(results) == len(split_results)
@@ -313,10 +313,10 @@ def test_gather_operation(
 
 
 def test_split_gather_combined(
-    split_config, gather_config, default_model, max_threads, sample_data, api_wrapper
+    split_config, gather_config, default_model, max_threads, sample_data, runner
 ):
-    split_op = SplitOperation(api_wrapper, split_config, default_model, max_threads)
-    gather_op = GatherOperation(api_wrapper, gather_config, default_model, max_threads)
+    split_op = SplitOperation(runner, split_config, default_model, max_threads)
+    gather_op = GatherOperation(runner, gather_config, default_model, max_threads)
 
     split_results, split_cost = split_op.execute(sample_data)
     gather_results, gather_cost = gather_op.execute(split_results)
@@ -334,10 +334,10 @@ def test_split_gather_combined(
 
 
 def test_split_gather_empty_input(
-    split_config, gather_config, default_model, max_threads, api_wrapper
+    split_config, gather_config, default_model, max_threads, runner
 ):
-    split_op = SplitOperation(api_wrapper, split_config, default_model, max_threads)
-    gather_op = GatherOperation(api_wrapper, gather_config, default_model, max_threads)
+    split_op = SplitOperation(runner, split_config, default_model, max_threads)
+    gather_op = GatherOperation(runner, gather_config, default_model, max_threads)
 
     split_results, split_cost = split_op.execute([])
     assert len(split_results) == 0

--- a/tests/basic/test_basic_map.py
+++ b/tests/basic/test_basic_map.py
@@ -2,17 +2,17 @@
 
 from docetl.operations.map import MapOperation
 from tests.conftest import (
-    api_wrapper as api_wrapper,
-    map_config_with_batching as map_config_with_batching,
-    default_model as default_model,
-    max_threads as max_threads,
-    map_sample_data as map_sample_data,
-    map_sample_data_large as map_sample_data_large,
-    map_config as map_config,
-    test_map_operation_instance as test_map_operation_instance,
-    map_config_with_drop_keys as map_config_with_drop_keys,
-    map_sample_data_with_extra_keys as map_sample_data_with_extra_keys,
-    map_config_with_drop_keys_no_prompt as map_config_with_drop_keys_no_prompt,
+    runner,
+    map_config_with_batching,
+    default_model,
+    max_threads,
+    map_sample_data,
+    map_sample_data_large,
+    map_config,
+    test_map_operation_instance,
+    map_config_with_drop_keys,
+    map_sample_data_with_extra_keys,
+    map_config_with_drop_keys_no_prompt,
 )
 import pytest
 import docetl
@@ -32,8 +32,8 @@ def test_map_operation(
     )
 
 
-def test_map_operation_empty_input(map_config, default_model, max_threads, api_wrapper):
-    operation = MapOperation(api_wrapper, map_config, default_model, max_threads)
+def test_map_operation_empty_input(map_config, default_model, max_threads, runner):
+    operation = MapOperation(runner, map_config, default_model, max_threads)
     results, cost = operation.execute([])
 
     assert len(results) == 0
@@ -45,11 +45,11 @@ def test_map_operation_with_drop_keys(
     default_model,
     max_threads,
     map_sample_data_with_extra_keys,
-    api_wrapper,
+    runner,
 ):
     map_config_with_drop_keys["bypass_cache"] = True
     operation = MapOperation(
-        api_wrapper, map_config_with_drop_keys, default_model, max_threads
+        runner, map_config_with_drop_keys, default_model, max_threads
     )
     results, cost = operation.execute(map_sample_data_with_extra_keys)
 
@@ -69,10 +69,10 @@ def test_map_operation_with_drop_keys_no_prompt(
     default_model,
     max_threads,
     map_sample_data_with_extra_keys,
-    api_wrapper,
+    runner,
 ):
     operation = MapOperation(
-        api_wrapper, map_config_with_drop_keys_no_prompt, default_model, max_threads
+        runner, map_config_with_drop_keys_no_prompt, default_model, max_threads
     )
     results, cost = operation.execute(map_sample_data_with_extra_keys)
 
@@ -88,10 +88,10 @@ def test_map_operation_with_batching(
     default_model,
     max_threads,
     map_sample_data,
-    api_wrapper,
+    runner,
 ):
     operation = MapOperation(
-        api_wrapper, map_config_with_batching, default_model, max_threads
+        runner, map_config_with_batching, default_model, max_threads
     )
     results, cost = operation.execute(map_sample_data)
 
@@ -104,10 +104,10 @@ def test_map_operation_with_batching(
 
 
 def test_map_operation_with_empty_input(
-    map_config_with_batching, default_model, max_threads, api_wrapper
+    map_config_with_batching, default_model, max_threads, runner
 ):
     operation = MapOperation(
-        api_wrapper, map_config_with_batching, default_model, max_threads
+        runner, map_config_with_batching, default_model, max_threads
     )
     results, cost = operation.execute([])
 
@@ -120,11 +120,11 @@ def test_map_operation_with_large_max_batch_size(
     default_model,
     max_threads,
     map_sample_data,
-    api_wrapper,
+    runner,
 ):
     map_config_with_batching["max_batch_size"] = 5  # Set batch size larger than data
     operation = MapOperation(
-        api_wrapper, map_config_with_batching, default_model, max_threads
+        runner, map_config_with_batching, default_model, max_threads
     )
     results, cost = operation.execute(map_sample_data)
 
@@ -132,9 +132,9 @@ def test_map_operation_with_large_max_batch_size(
 
 
 def test_map_operation_with_word_count_tool(
-    map_config_with_tools, synthetic_data, api_wrapper
+    map_config_with_tools, synthetic_data, runner
 ):
-    operation = MapOperation(api_wrapper, map_config_with_tools, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_tools, "gpt-4o-mini", 4)
     results, cost = operation.execute(synthetic_data)
 
     assert len(results) == len(synthetic_data)
@@ -174,7 +174,7 @@ def simple_sample_data():
 
 
 # @pytest.mark.flaky(reruns=2)
-# def test_map_operation_with_timeout(simple_map_config, simple_sample_data, api_wrapper):
+# def test_map_operation_with_timeout(simple_map_config, simple_sample_data, runner):
 #     # Add timeout to the map configuration
 #     map_config_with_timeout = {
 #         **simple_map_config,
@@ -183,14 +183,14 @@ def simple_sample_data():
 #         "bypass_cache": True,
 #     }
 
-#     operation = MapOperation(api_wrapper, map_config_with_timeout, "gpt-4o-mini", 4)
+#     operation = MapOperation(runner, map_config_with_timeout, "gpt-4o-mini", 4)
 
 #     # Execute the operation and expect empty results
 #     results, cost = operation.execute(simple_sample_data)
 #     assert len(results) == 0
 
 
-def test_map_operation_with_gleaning(simple_map_config, map_sample_data, api_wrapper):
+def test_map_operation_with_gleaning(simple_map_config, map_sample_data, runner):
     # Add gleaning configuration to the map configuration
     map_config_with_gleaning = {
         **simple_map_config,
@@ -201,7 +201,7 @@ def test_map_operation_with_gleaning(simple_map_config, map_sample_data, api_wra
         "bypass_cache": True,
     }
 
-    operation = MapOperation(api_wrapper, map_config_with_gleaning, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_gleaning, "gpt-4o-mini", 4)
 
     # Execute the operation
     results, cost = operation.execute(map_sample_data)
@@ -218,14 +218,14 @@ def test_map_operation_with_gleaning(simple_map_config, map_sample_data, api_wra
         any(vs in result["sentiment"] for vs in valid_sentiments) for result in results
     )
 
-def test_map_with_enum_output(simple_map_config, map_sample_data, api_wrapper):
+def test_map_with_enum_output(simple_map_config, map_sample_data, runner):
     map_config_with_enum_output = {
         **simple_map_config,
         "output": {"schema": {"sentiment": "enum[positive, negative, neutral]"}},
         "bypass_cache": True,
     }
 
-    operation = MapOperation(api_wrapper, map_config_with_enum_output, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_enum_output, "gpt-4o-mini", 4)
     results, cost = operation.execute(map_sample_data)
 
     assert len(results) == len(map_sample_data)
@@ -234,7 +234,7 @@ def test_map_with_enum_output(simple_map_config, map_sample_data, api_wrapper):
 
     # # Try gemini model
     # map_config_with_enum_output["model"] = "gemini/gemini-1.5-flash"
-    # operation = MapOperation(api_wrapper, map_config_with_enum_output, "gemini/gemini-1.5-flash", 4)
+    # operation = MapOperation(runner, map_config_with_enum_output, "gemini/gemini-1.5-flash", 4)
     # results, cost = operation.execute(map_sample_data)
 
     # assert len(results) == len(map_sample_data)
@@ -244,7 +244,7 @@ def test_map_with_enum_output(simple_map_config, map_sample_data, api_wrapper):
 
     # Try list of enum types
     map_config_with_enum_output["output"] = {"schema": {"possible_sentiments": "list[enum[positive, negative, neutral]]"}}
-    operation = MapOperation(api_wrapper, map_config_with_enum_output, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_enum_output, "gpt-4o-mini", 4)
     results, cost = operation.execute(map_sample_data)
     assert cost > 0
 
@@ -256,7 +256,7 @@ def test_map_with_enum_output(simple_map_config, map_sample_data, api_wrapper):
 
     
 
-def test_map_operation_with_batch_processing(simple_map_config, map_sample_data, api_wrapper):
+def test_map_operation_with_batch_processing(simple_map_config, map_sample_data, runner):
     # Add batch processing configuration
     map_config_with_batch = {
         **simple_map_config,
@@ -275,7 +275,7 @@ For each text, provide a sentiment analysis in the following format:
         "num_retries_on_validate_failure": 1,
     }
 
-    operation = MapOperation(api_wrapper, map_config_with_batch, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_batch, "gpt-4o-mini", 4)
 
     # Execute the operation
     results, cost = operation.execute(map_sample_data)
@@ -292,7 +292,7 @@ For each text, provide a sentiment analysis in the following format:
         any(vs in result["sentiment"] for vs in valid_sentiments) for result in results
     )
 
-def test_map_operation_with_larger_batch(simple_map_config, map_sample_data_with_extra_keys, api_wrapper):
+def test_map_operation_with_larger_batch(simple_map_config, map_sample_data_with_extra_keys, runner):
     # Add batch processing configuration with larger batch size
     map_config_with_large_batch = {
         **simple_map_config,
@@ -311,7 +311,7 @@ For each text, provide a sentiment analysis in the following format:
         "num_retries_on_validate_failure": 1,
     }
 
-    operation = MapOperation(api_wrapper, map_config_with_large_batch, "gpt-4o-mini", 64)
+    operation = MapOperation(runner, map_config_with_large_batch, "gpt-4o-mini", 64)
 
     # Execute the operation with the larger dataset
     results, cost = operation.execute(map_sample_data_with_extra_keys * 4)
@@ -328,7 +328,7 @@ For each text, provide a sentiment analysis in the following format:
         any(vs in result["sentiment"] for vs in valid_sentiments) for result in results
     )
 
-def test_map_operation_with_max_tokens(simple_map_config, map_sample_data, api_wrapper):
+def test_map_operation_with_max_tokens(simple_map_config, map_sample_data, runner):
     # Add litellm_completion_kwargs configuration with max_tokens
     map_config_with_max_tokens = {
         **simple_map_config,
@@ -338,7 +338,7 @@ def test_map_operation_with_max_tokens(simple_map_config, map_sample_data, api_w
         "bypass_cache": True
     }
 
-    operation = MapOperation(api_wrapper, map_config_with_max_tokens, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_max_tokens, "gpt-4o-mini", 4)
 
     # Execute the operation
     results, cost = operation.execute(map_sample_data)
@@ -359,7 +359,7 @@ def test_map_operation_with_max_tokens(simple_map_config, map_sample_data, api_w
     # The sentiment field should contain just the sentiment value without much extra text
     assert all(len(result["sentiment"]) <= 20 for result in results)
     
-def test_map_operation_with_verbose(simple_map_config, map_sample_data, api_wrapper):
+def test_map_operation_with_verbose(simple_map_config, map_sample_data, runner):
     # Add verbose configuration
     map_config_with_verbose = {
         **simple_map_config,
@@ -367,7 +367,7 @@ def test_map_operation_with_verbose(simple_map_config, map_sample_data, api_wrap
         "bypass_cache": True
     }
 
-    operation = MapOperation(api_wrapper, map_config_with_verbose, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_verbose, "gpt-4o-mini", 4)
 
     # Execute the operation
     results, cost = operation.execute(map_sample_data)
@@ -385,7 +385,7 @@ def test_map_operation_with_verbose(simple_map_config, map_sample_data, api_wrap
     )
 
 def test_map_operation_partial_checkpoint(
-    tmp_path, simple_map_config, default_model, max_threads, map_sample_data, api_wrapper
+    tmp_path, simple_map_config, default_model, max_threads, map_sample_data, runner
 ):
     """
     Test that MapOperation flushes partial results to disk when checkpoint_partial is enabled.
@@ -412,11 +412,11 @@ def test_map_operation_partial_checkpoint(
     }
 
     # Set the runner's intermediate_dir.
-    # In our tests, 'api_wrapper' acts as the runner.
-    api_wrapper.intermediate_dir = str(intermediate_dir)
+    # Set the runner's intermediate_dir for testing
+    runner.intermediate_dir = str(intermediate_dir)
 
     # Create and run the MapOperation.
-    operation = MapOperation(api_wrapper, map_config, default_model, max_threads)
+    operation = MapOperation(runner, map_config, default_model, max_threads)
     results, cost = operation.execute(map_sample_data)
 
     # Determine the expected batch folder based on the operation name.
@@ -436,7 +436,7 @@ def test_map_operation_partial_checkpoint(
         assert data, "Partial checkpoint file is empty"
 
 
-def test_map_operation_with_calibration(simple_map_config, map_sample_data, api_wrapper):
+def test_map_operation_with_calibration(simple_map_config, map_sample_data, runner):
     """
     Test that MapOperation performs calibration when enabled.
     
@@ -454,7 +454,7 @@ def test_map_operation_with_calibration(simple_map_config, map_sample_data, api_
         "bypass_cache": True
     }
 
-    operation = MapOperation(api_wrapper, map_config_with_calibration, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_calibration, "gpt-4o-mini", 4)
     
     # Execute the operation with calibration
     results, cost = operation.execute(map_sample_data)
@@ -475,7 +475,7 @@ def test_map_operation_with_calibration(simple_map_config, map_sample_data, api_
     assert cost > 0
 
 
-def test_map_operation_calibration_with_larger_sample(simple_map_config, map_sample_data_large, api_wrapper):
+def test_map_operation_calibration_with_larger_sample(simple_map_config, map_sample_data_large, runner):
     """
     Test calibration with a larger dataset to ensure proper sampling.
     """
@@ -487,7 +487,7 @@ def test_map_operation_calibration_with_larger_sample(simple_map_config, map_sam
         "bypass_cache": True
     }
 
-    operation = MapOperation(api_wrapper, map_config_with_calibration, "gpt-4o-mini", 4)
+    operation = MapOperation(runner, map_config_with_calibration, "gpt-4o-mini", 4)
     
     # Execute the operation with calibration on larger dataset
     results, cost = operation.execute(map_sample_data_large)
@@ -507,10 +507,10 @@ def test_map_operation_calibration_with_larger_sample(simple_map_config, map_sam
     # Verify that cost is greater than 0
     assert cost > 0
 
-def test_should_glean_condition(api_wrapper):
+def test_should_glean_condition(runner):
     """Unit-test the conditional gleaning logic on DSLRunner.api.should_glean."""
 
-    wrapper = api_wrapper.api  # APIWrapper instance attached to the runner
+    wrapper = runner.api  # APIWrapper instance attached to the runner
 
     # Case 1: condition evaluates to True
     gleaning_config = {"if": "output['flag'] == True"}

--- a/tests/basic/test_basic_parallel_map.py
+++ b/tests/basic/test_basic_parallel_map.py
@@ -5,11 +5,11 @@ from docetl.operations.map import ParallelMapOperation
 from dotenv import load_dotenv
 from typing import Dict, Any, List, Tuple
 from tests.conftest import (
-    parallel_map_config as parallel_map_config,
-    parallel_map_sample_data as parallel_map_sample_data,
-    default_model as default_model,
-    max_threads as max_threads,
-    api_wrapper as api_wrapper,
+    parallel_map_config,
+    parallel_map_sample_data,
+    default_model,
+    max_threads,
+    runner,
 )
 
 load_dotenv()
@@ -20,11 +20,11 @@ def test_parallel_map_operation(
     default_model,
     max_threads,
     parallel_map_sample_data,
-    api_wrapper,
+    runner,
 ):
     parallel_map_config["bypass_cache"] = True
     operation = ParallelMapOperation(
-        api_wrapper, parallel_map_config, default_model, max_threads
+        runner, parallel_map_config, default_model, max_threads
     )
     results, cost = operation.execute(parallel_map_sample_data)
 
@@ -39,10 +39,10 @@ def test_parallel_map_operation(
 
 
 def test_parallel_map_operation_empty_input(
-    parallel_map_config, default_model, max_threads, api_wrapper
+    parallel_map_config, default_model, max_threads, runner
 ):
     operation = ParallelMapOperation(
-        api_wrapper, parallel_map_config, default_model, max_threads
+        runner, parallel_map_config, default_model, max_threads
     )
     results, cost = operation.execute([])
 
@@ -51,10 +51,10 @@ def test_parallel_map_operation_empty_input(
 
 
 def test_parallel_map_operation_with_empty_input(
-    parallel_map_config, default_model, max_threads, api_wrapper
+    parallel_map_config, default_model, max_threads, runner
 ):
     operation = ParallelMapOperation(
-        api_wrapper, parallel_map_config, default_model, max_threads
+        runner, parallel_map_config, default_model, max_threads
     )
     results, cost = operation.execute([])
 

--- a/tests/basic/test_basic_parallel_map.py
+++ b/tests/basic/test_basic_parallel_map.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 from typing import Dict, Any, List, Tuple
 from tests.conftest import (
     parallel_map_config,
-    parallel_map_sample_data,
     default_model,
     max_threads,
     runner,
@@ -14,6 +13,23 @@ from tests.conftest import (
 
 load_dotenv()
 
+
+# =============================================================================
+# FIXTURES SPECIFIC TO PARALLEL MAP OPERATION TESTS
+# =============================================================================
+
+@pytest.fixture
+def parallel_map_sample_data():
+    return [
+        {"text": "This is a positive sentence."},
+        {"text": "This is a negative sentence."},
+        {"text": "This is a neutral sentence."},
+    ]
+
+
+# =============================================================================
+# TEST FUNCTIONS
+# =============================================================================
 
 def test_parallel_map_operation(
     parallel_map_config,

--- a/tests/basic/test_basic_reduce_resolve.py
+++ b/tests/basic/test_basic_reduce_resolve.py
@@ -2,7 +2,7 @@
 import pytest
 from docetl.operations.reduce import ReduceOperation
 from docetl.operations.resolve import ResolveOperation
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 
 
 @pytest.fixture
@@ -40,10 +40,10 @@ def reduce_sample_data_with_list_key():
 
 
 def test_reduce_operation(
-    reduce_config, default_model, max_threads, reduce_sample_data, api_wrapper
+    reduce_config, default_model, max_threads, reduce_sample_data, runner
 ):
     reduce_config["bypass_cache"] = True
-    operation = ReduceOperation(api_wrapper, reduce_config, default_model, max_threads)
+    operation = ReduceOperation(runner, reduce_config, default_model, max_threads)
     results, cost = operation.execute(reduce_sample_data)
 
     assert len(results) == 3  # 3 unique groups
@@ -55,10 +55,10 @@ def test_reduce_operation(
 
 
 def test_reduce_operation_with_all_key(
-    reduce_config, default_model, max_threads, reduce_sample_data, api_wrapper
+    reduce_config, default_model, max_threads, reduce_sample_data, runner
 ):
     reduce_config["reduce_key"] = "_all"
-    operation = ReduceOperation(api_wrapper, reduce_config, default_model, max_threads)
+    operation = ReduceOperation(runner, reduce_config, default_model, max_threads)
     results, cost = operation.execute(reduce_sample_data)
 
     assert len(results) == 1
@@ -69,11 +69,11 @@ def test_reduce_operation_with_list_key(
     default_model,
     max_threads,
     reduce_sample_data_with_list_key,
-    api_wrapper,
+    runner,
 ):
     reduce_config["reduce_key"] = ["group", "category"]
 
-    operation = ReduceOperation(api_wrapper, reduce_config, default_model, max_threads)
+    operation = ReduceOperation(runner, reduce_config, default_model, max_threads)
     results, cost = operation.execute(reduce_sample_data_with_list_key)
 
     assert len(results) == 3  # 3 unique groups
@@ -87,9 +87,9 @@ def test_reduce_operation_with_list_key(
 
 
 def test_reduce_operation_empty_input(
-    reduce_config, default_model, max_threads, api_wrapper
+    reduce_config, default_model, max_threads, runner
 ):
-    operation = ReduceOperation(api_wrapper, reduce_config, default_model, max_threads)
+    operation = ReduceOperation(runner, reduce_config, default_model, max_threads)
     results, cost = operation.execute([])
 
     assert len(results) == 0
@@ -124,10 +124,10 @@ def resolve_sample_data():
 
 
 def test_resolve_operation(
-    resolve_config, max_threads, resolve_sample_data, api_wrapper
+    resolve_config, max_threads, resolve_sample_data, runner
 ):
     operation = ResolveOperation(
-        api_wrapper, resolve_config, "text-embedding-3-small", max_threads
+        runner, resolve_config, "text-embedding-3-small", max_threads
     )
     results, cost = operation.execute(resolve_sample_data)
 
@@ -135,9 +135,9 @@ def test_resolve_operation(
     assert len(distinct_names) < len(results)
 
 
-def test_resolve_operation_empty_input(resolve_config, max_threads, api_wrapper):
+def test_resolve_operation_empty_input(resolve_config, max_threads, runner):
     operation = ResolveOperation(
-        api_wrapper, resolve_config, "text-embedding-3-small", max_threads
+        runner, resolve_config, "text-embedding-3-small", max_threads
     )
     results, cost = operation.execute([])
 
@@ -146,13 +146,13 @@ def test_resolve_operation_empty_input(resolve_config, max_threads, api_wrapper)
 
 
 def test_reduce_operation_with_lineage(
-    reduce_config, max_threads, reduce_sample_data, api_wrapper
+    reduce_config, max_threads, reduce_sample_data, runner
 ):
     # Add lineage configuration to reduce_config
     reduce_config["output"]["lineage"] = ["name", "email"]
 
     operation = ReduceOperation(
-        api_wrapper, reduce_config, "text-embedding-3-small", max_threads
+        runner, reduce_config, "text-embedding-3-small", max_threads
     )
     results, cost = operation.execute(reduce_sample_data)
 
@@ -166,7 +166,7 @@ def test_reduce_operation_with_lineage(
         assert all("name" in item and "email" in item for item in lineage)
 
 
-def test_reduce_with_list_key(api_wrapper, default_model, max_threads):
+def test_reduce_with_list_key(runner, default_model, max_threads):
     """Test reduce operation with a list-type key"""
     
     # Test data with list-type classifications
@@ -205,7 +205,7 @@ def test_reduce_with_list_key(api_wrapper, default_model, max_threads):
     }
 
     # Create and execute reduce operation
-    operation = ReduceOperation(api_wrapper, config, default_model, max_threads)
+    operation = ReduceOperation(runner, config, default_model, max_threads)
     results, _ = operation.execute(input_data)
 
     # Verify results

--- a/tests/basic/test_cluster_and_sample.py
+++ b/tests/basic/test_cluster_and_sample.py
@@ -1,7 +1,7 @@
 import pytest
 from docetl.operations.cluster import ClusterOperation
 from docetl.operations.sample import SampleOperation
-from tests.conftest import api_wrapper, default_model, max_threads
+from tests.conftest import runner, default_model, max_threads
 
 
 @pytest.fixture
@@ -84,11 +84,11 @@ def sample_data():
 
 
 def test_cluster_operation(
-    cluster_config, sample_data, api_wrapper, default_model, max_threads
+    cluster_config, sample_data, runner, default_model, max_threads
 ):
     cluster_config["bypass_cache"] = True
     operation = ClusterOperation(
-        api_wrapper, cluster_config, default_model, max_threads
+        runner, cluster_config, default_model, max_threads
     )
     results, cost = operation.execute(sample_data)
 
@@ -106,10 +106,10 @@ def test_cluster_operation(
 
 
 def test_cluster_operation_empty_input(
-    cluster_config, api_wrapper, default_model, max_threads
+    cluster_config, runner, default_model, max_threads
 ):
     operation = ClusterOperation(
-        api_wrapper, cluster_config, default_model, max_threads
+        runner, cluster_config, default_model, max_threads
     )
     results, cost = operation.execute([])
 
@@ -118,13 +118,13 @@ def test_cluster_operation_empty_input(
 
 
 def test_cluster_operation_single_item(
-    cluster_config, api_wrapper, default_model, max_threads
+    cluster_config, runner, default_model, max_threads
 ):
     single_item = [
         {"concept": "House", "description": "A building for human habitation."}
     ]
     operation = ClusterOperation(
-        api_wrapper, cluster_config, default_model, max_threads
+        runner, cluster_config, default_model, max_threads
     )
     results, cost = operation.execute(single_item)
 
@@ -144,11 +144,11 @@ def sample_config():
 
 
 def test_sample_operation_with_count(
-    sample_config, sample_data, api_wrapper, default_model, max_threads
+    sample_config, sample_data, runner, default_model, max_threads
 ):
     sample_config["samples"] = 5
     sample_config["method"] = "uniform"
-    operation = SampleOperation(api_wrapper, sample_config, default_model, max_threads)
+    operation = SampleOperation(runner, sample_config, default_model, max_threads)
     results, cost = operation.execute(sample_data)
 
     assert len(results) == 5
@@ -157,11 +157,11 @@ def test_sample_operation_with_count(
 
 
 def test_sample_operation_with_fraction(
-    sample_config, sample_data, api_wrapper, default_model, max_threads
+    sample_config, sample_data, runner, default_model, max_threads
 ):
     sample_config["samples"] = 0.5
     sample_config["method"] = "uniform"
-    operation = SampleOperation(api_wrapper, sample_config, default_model, max_threads)
+    operation = SampleOperation(runner, sample_config, default_model, max_threads)
     results, cost = operation.execute(sample_data)
 
     assert len(results) == len(sample_data) // 2
@@ -170,12 +170,12 @@ def test_sample_operation_with_fraction(
 
 
 def test_sample_operation_with_list(
-    sample_config, sample_data, api_wrapper, default_model, max_threads
+    sample_config, sample_data, runner, default_model, max_threads
 ):
     sample_list = [{"id": 1}, {"id": 3}, {"id": 5}]
     sample_config["samples"] = sample_list
     sample_config["method"] = "custom"
-    operation = SampleOperation(api_wrapper, sample_config, default_model, max_threads)
+    operation = SampleOperation(runner, sample_config, default_model, max_threads)
     results, cost = operation.execute(sample_data)
 
     assert len(results) == len(sample_list)
@@ -184,12 +184,12 @@ def test_sample_operation_with_list(
 
 
 def test_sample_operation_with_stratify(
-    sample_config, sample_data, api_wrapper, default_model, max_threads
+    sample_config, sample_data, runner, default_model, max_threads
 ):
     sample_config["samples"] = 5
     sample_config["method"] = "stratify"
     sample_config["method_kwargs"] = {"stratify_key": "group"}
-    operation = SampleOperation(api_wrapper, sample_config, default_model, max_threads)
+    operation = SampleOperation(runner, sample_config, default_model, max_threads)
     results, cost = operation.execute(sample_data)
 
     assert len(results) == 5
@@ -199,7 +199,7 @@ def test_sample_operation_with_stratify(
 
 
 def test_sample_operation_with_outliers(
-    sample_config, sample_data, api_wrapper, default_model, max_threads
+    sample_config, sample_data, runner, default_model, max_threads
 ):
     sample_config["method"] = "outliers"
     sample_config["method_kwargs"] = {
@@ -207,7 +207,7 @@ def test_sample_operation_with_outliers(
         "embedding_keys": ["concept", "description"],
         "keep": True,
     }
-    operation = SampleOperation(api_wrapper, sample_config, default_model, max_threads)
+    operation = SampleOperation(runner, sample_config, default_model, max_threads)
     results, cost = operation.execute(sample_data)
 
     assert len(results) < len(sample_data)
@@ -216,11 +216,11 @@ def test_sample_operation_with_outliers(
 
 
 def test_sample_operation_empty_input(
-    sample_config, api_wrapper, default_model, max_threads
+    sample_config, runner, default_model, max_threads
 ):
     sample_config["samples"] = 3
     sample_config["method"] = "uniform"
-    operation = SampleOperation(api_wrapper, sample_config, default_model, max_threads)
+    operation = SampleOperation(runner, sample_config, default_model, max_threads)
     results, cost = operation.execute([])
 
     assert len(results) == 0
@@ -228,7 +228,7 @@ def test_sample_operation_empty_input(
 
 
 def test_sample_operation_with_outliers_and_center(
-    sample_config, sample_data, api_wrapper, default_model, max_threads
+    sample_config, sample_data, runner, default_model, max_threads
 ):
     sample_config["method"] = "outliers"
     sample_config["method_kwargs"] = {
@@ -240,7 +240,7 @@ def test_sample_operation_with_outliers_and_center(
             "description": "A small house built among the branches of a tree for children to play in.",
         },
     }
-    operation = SampleOperation(api_wrapper, sample_config, default_model, max_threads)
+    operation = SampleOperation(runner, sample_config, default_model, max_threads)
     results, cost = operation.execute(sample_data)
 
     assert len(results) < len(sample_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from docetl.config_wrapper import ConfigWrapper
 from docetl.runner import DSLRunner
 
 # =============================================================================
-# BASIC TEST CONFIGURATION FIXTURES
+# BASIC TEST CONFIGURATION FIXTURES (SHARED ACROSS MULTIPLE TEST FILES)
 # =============================================================================
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def runner():
 
 
 # =============================================================================
-# TEST DATA FIXTURES
+# SHARED TEST DATA FIXTURES (USED ACROSS MULTIPLE TEST FILES)
 # =============================================================================
 
 @pytest.fixture
@@ -59,36 +59,6 @@ def map_sample_data_large():
 
 
 @pytest.fixture
-def map_sample_data_with_extra_keys():
-    return [
-        {
-            "text": "This is a positive sentence.",
-            "original_sentiment": "positive",
-            "to_be_dropped": "extra",
-        },
-        {
-            "text": "This is a negative sentence.",
-            "original_sentiment": "negative",
-            "to_be_dropped": "extra",
-        },
-        {
-            "text": "This is a neutral sentence.",
-            "original_sentiment": "neutral",
-            "to_be_dropped": "extra",
-        },
-    ]
-
-
-@pytest.fixture
-def parallel_map_sample_data():
-    return [
-        {"text": "This is a positive sentence."},
-        {"text": "This is a negative sentence."},
-        {"text": "This is a neutral sentence."},
-    ]
-
-
-@pytest.fixture
 def synthetic_data():
     return [
         {"text": "This is a short sentence."},
@@ -98,24 +68,8 @@ def synthetic_data():
     ]
 
 
-@pytest.fixture
-def response_lookup():
-    return {
-        "This is a good day.": {"sentiment": "positive", "word_count": 5},
-        "This is a bad day.": {"sentiment": "negative", "word_count": 5},
-        "This is just a day.": {"sentiment": "neutral", "word_count": 5},
-        "Feeling great!": {"sentiment": "positive", "word_count": 2},
-        "Everything is terrible.": {"sentiment": "negative", "word_count": 3},
-        "Not sure how I feel.": {"sentiment": "neutral", "word_count": 5},
-        "Good vibes only.": {"sentiment": "positive", "word_count": 3},
-        "Bad news everywhere.": {"sentiment": "negative", "word_count": 4},
-        "Neutral stance.": {"sentiment": "neutral", "word_count": 2},
-        "Average day overall.": {"sentiment": "neutral", "word_count": 3},
-    }
-
-
 # =============================================================================
-# MAP OPERATION CONFIGURATION FIXTURES
+# SHARED OPERATION CONFIGURATION FIXTURES
 # =============================================================================
 
 @pytest.fixture
@@ -142,67 +96,6 @@ def map_config_with_batching():
 
 
 @pytest.fixture
-def map_config_with_drop_keys():
-    return {
-        "name": "sentiment_analysis_with_drop",
-        "type": "map",
-        "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
-        "output": {"schema": {"sentiment": "string"}},
-        "model": "gpt-4o-mini",
-        "drop_keys": ["to_be_dropped"],
-    }
-
-
-@pytest.fixture
-def map_config_with_drop_keys_no_prompt():
-    return {
-        "name": "drop_keys_only",
-        "type": "map",
-        "drop_keys": ["to_be_dropped"],
-        "model": "gpt-4o-mini",
-    }
-
-
-@pytest.fixture
-def map_config_with_tools():
-    return {
-        "type": "map",
-        "name": "word_count",
-        "prompt": "Count the number of words in the following text: '{{ input.text }}'",
-        "output": {"schema": {"word_count": "integer"}},
-        "model": "gpt-4o-mini",
-        "tools": [
-            {
-                "required": True,
-                "code": """
-def count_words(text):
-    return {"word_count": len(text.split())}
-                """,
-                "function": {
-                    "name": "count_words",
-                    "description": "Count the number of words in a text string.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "text": {
-                                "type": "string",
-                            }
-                        },
-                        "required": ["text"],
-                    },
-                },
-            }
-        ],
-        "validate": ["len(output['text']) > 0"],
-        "num_retries_on_validate_failure": 3,
-    }
-
-
-# =============================================================================
-# PARALLEL MAP OPERATION CONFIGURATION FIXTURES
-# =============================================================================
-
-@pytest.fixture
 def parallel_map_config():
     return {
         "name": "sentiment_and_word_count",
@@ -225,67 +118,4 @@ def parallel_map_config():
     }
 
 
-@pytest.fixture
-def parallel_map_config_with_batching():
-    return {
-        "name": "sentiment_and_word_count",
-        "type": "parallel_map",
-        "prompts": [
-            {
-                "name": "sentiment",
-                "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
-                "output_keys": ["sentiment"],
-                "model": "gpt-4o-mini",
-            },
-            {
-                "name": "word_count",
-                "prompt": "Count the number of words in the following text: '{{ input.text }}'. Return the count as an integer.",
-                "output_keys": ["word_count"],
-                "model": "gpt-4o-mini",
-            },
-        ],
-        "output": {"schema": {"sentiment": "string", "word_count": "integer"}},
-        "batch_size": 2,
-        "clustering_method": "sem_cluster",
-    }
 
-
-# =============================================================================
-# OPERATION INSTANCE FIXTURES
-# =============================================================================
-
-@pytest.fixture
-def test_map_operation_instance(
-    map_config_with_batching, default_model, max_threads, runner
-):
-    return MapOperation(
-        runner, map_config_with_batching, default_model, max_threads
-    )
-
-
-# =============================================================================
-# TEST FUNCTIONS (USED AS EXAMPLES/VALIDATION)
-# =============================================================================
-
-def test_map_operation_with_batching(
-    map_config_with_batching, default_model, max_threads, runner
-):
-    operation = MapOperation(
-        runner, map_config_with_batching, default_model, max_threads
-    )
-
-    # Sample data for testing
-    map_sample_data = [
-        {"text": "This is a positive sentence."},
-        {"text": "This is a negative sentence."},
-        {"text": "This is a neutral sentence."},
-    ]
-
-    results, cost = operation.execute(map_sample_data)
-
-    assert len(results) == len(map_sample_data)
-    assert cost > 0
-    assert all("sentiment" in result for result in results)
-    assert all(
-        result["sentiment"] in ["positive", "negative", "neutral"] for result in results
-    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@ from docetl.operations.map import MapOperation
 from docetl.config_wrapper import ConfigWrapper
 from docetl.runner import DSLRunner
 
+# =============================================================================
+# BASIC TEST CONFIGURATION FIXTURES
+# =============================================================================
 
 @pytest.fixture
 def default_model():
@@ -15,46 +18,7 @@ def max_threads():
 
 
 @pytest.fixture
-def response_lookup():
-    return {
-        "This is a good day.": {"sentiment": "positive", "word_count": 5},
-        "This is a bad day.": {"sentiment": "negative", "word_count": 5},
-        "This is just a day.": {"sentiment": "neutral", "word_count": 5},
-        "Feeling great!": {"sentiment": "positive", "word_count": 2},
-        "Everything is terrible.": {"sentiment": "negative", "word_count": 3},
-        "Not sure how I feel.": {"sentiment": "neutral", "word_count": 5},
-        "Good vibes only.": {"sentiment": "positive", "word_count": 3},
-        "Bad news everywhere.": {"sentiment": "negative", "word_count": 4},
-        "Neutral stance.": {"sentiment": "neutral", "word_count": 2},
-        "Average day overall.": {"sentiment": "neutral", "word_count": 3},
-    }
-
-
-@pytest.fixture
-def map_config():
-    return {
-        "name": "sentiment_analysis",
-        "type": "map",
-        "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
-        "output": {"schema": {"sentiment": "string"}},
-        "model": "gpt-4o-mini",
-    }
-
-
-@pytest.fixture
-def map_config_with_batching():
-    return {
-        "name": "sentiment_analysis_batching",
-        "type": "map",
-        "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
-        "output": {"schema": {"sentiment": "string"}},
-        "model": "gpt-4o-mini",
-        "batch_size": 2,  # Specify batch size for testing
-    }
-
-
-@pytest.fixture
-def api_wrapper():
+def runner():
     return DSLRunner(
         {
             "default_model": "gpt-4o-mini",
@@ -65,63 +29,9 @@ def api_wrapper():
     )
 
 
-@pytest.fixture
-def test_map_operation_instance(
-    map_config_with_batching, default_model, max_threads, api_wrapper
-):
-    return MapOperation(
-        api_wrapper, map_config_with_batching, default_model, max_threads
-    )
-
-
-def test_map_operation_with_batching(
-    map_config_with_batching, default_model, max_threads, api_wrapper
-):
-    operation = MapOperation(
-        api_wrapper, map_config_with_batching, default_model, max_threads
-    )
-
-    # Sample data for testing
-    map_sample_data = [
-        {"text": "This is a positive sentence."},
-        {"text": "This is a negative sentence."},
-        {"text": "This is a neutral sentence."},
-    ]
-
-    results, cost = operation.execute(map_sample_data)
-
-    assert len(results) == len(map_sample_data)
-    assert cost > 0
-    assert all("sentiment" in result for result in results)
-    assert all(
-        result["sentiment"] in ["positive", "negative", "neutral"] for result in results
-    )
-
-
-@pytest.fixture
-def parallel_map_config_with_batching():
-    return {
-        "name": "sentiment_and_word_count",
-        "type": "parallel_map",
-        "prompts": [
-            {
-                "name": "sentiment",
-                "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
-                "output_keys": ["sentiment"],
-                "model": "gpt-4o-mini",
-            },
-            {
-                "name": "word_count",
-                "prompt": "Count the number of words in the following text: '{{ input.text }}'. Return the count as an integer.",
-                "output_keys": ["word_count"],
-                "model": "gpt-4o-mini",
-            },
-        ],
-        "output": {"schema": {"sentiment": "string", "word_count": "integer"}},
-        "batch_size": 2,
-        "clustering_method": "sem_cluster",
-    }
-
+# =============================================================================
+# TEST DATA FIXTURES
+# =============================================================================
 
 @pytest.fixture
 def map_sample_data():
@@ -148,28 +58,25 @@ def map_sample_data_large():
     ]
 
 
-# Parallel Map Operation Tests
 @pytest.fixture
-def parallel_map_config():
-    return {
-        "name": "sentiment_and_word_count",
-        "type": "parallel_map",
-        "prompts": [
-            {
-                "name": "sentiment",
-                "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
-                "output_keys": ["sentiment"],
-                "model": "gpt-4o-mini",
-            },
-            {
-                "name": "word_count",
-                "prompt": "Count the number of words in the following text: '{{ input.text }}'. Return the count as an integer.",
-                "output_keys": ["word_count"],
-                "model": "gpt-4o-mini",
-            },
-        ],
-        "output": {"schema": {"sentiment": "string", "word_count": "integer"}},
-    }
+def map_sample_data_with_extra_keys():
+    return [
+        {
+            "text": "This is a positive sentence.",
+            "original_sentiment": "positive",
+            "to_be_dropped": "extra",
+        },
+        {
+            "text": "This is a negative sentence.",
+            "original_sentiment": "negative",
+            "to_be_dropped": "extra",
+        },
+        {
+            "text": "This is a neutral sentence.",
+            "original_sentiment": "neutral",
+            "to_be_dropped": "extra",
+        },
+    ]
 
 
 @pytest.fixture
@@ -192,6 +99,49 @@ def synthetic_data():
 
 
 @pytest.fixture
+def response_lookup():
+    return {
+        "This is a good day.": {"sentiment": "positive", "word_count": 5},
+        "This is a bad day.": {"sentiment": "negative", "word_count": 5},
+        "This is just a day.": {"sentiment": "neutral", "word_count": 5},
+        "Feeling great!": {"sentiment": "positive", "word_count": 2},
+        "Everything is terrible.": {"sentiment": "negative", "word_count": 3},
+        "Not sure how I feel.": {"sentiment": "neutral", "word_count": 5},
+        "Good vibes only.": {"sentiment": "positive", "word_count": 3},
+        "Bad news everywhere.": {"sentiment": "negative", "word_count": 4},
+        "Neutral stance.": {"sentiment": "neutral", "word_count": 2},
+        "Average day overall.": {"sentiment": "neutral", "word_count": 3},
+    }
+
+
+# =============================================================================
+# MAP OPERATION CONFIGURATION FIXTURES
+# =============================================================================
+
+@pytest.fixture
+def map_config():
+    return {
+        "name": "sentiment_analysis",
+        "type": "map",
+        "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
+        "output": {"schema": {"sentiment": "string"}},
+        "model": "gpt-4o-mini",
+    }
+
+
+@pytest.fixture
+def map_config_with_batching():
+    return {
+        "name": "sentiment_analysis_batching",
+        "type": "map",
+        "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
+        "output": {"schema": {"sentiment": "string"}},
+        "model": "gpt-4o-mini",
+        "batch_size": 2,  # Specify batch size for testing
+    }
+
+
+@pytest.fixture
 def map_config_with_drop_keys():
     return {
         "name": "sentiment_analysis_with_drop",
@@ -211,27 +161,6 @@ def map_config_with_drop_keys_no_prompt():
         "drop_keys": ["to_be_dropped"],
         "model": "gpt-4o-mini",
     }
-
-
-@pytest.fixture
-def map_sample_data_with_extra_keys():
-    return [
-        {
-            "text": "This is a positive sentence.",
-            "original_sentiment": "positive",
-            "to_be_dropped": "extra",
-        },
-        {
-            "text": "This is a negative sentence.",
-            "original_sentiment": "negative",
-            "to_be_dropped": "extra",
-        },
-        {
-            "text": "This is a neutral sentence.",
-            "original_sentiment": "neutral",
-            "to_be_dropped": "extra",
-        },
-    ]
 
 
 @pytest.fixture
@@ -267,3 +196,96 @@ def count_words(text):
         "validate": ["len(output['text']) > 0"],
         "num_retries_on_validate_failure": 3,
     }
+
+
+# =============================================================================
+# PARALLEL MAP OPERATION CONFIGURATION FIXTURES
+# =============================================================================
+
+@pytest.fixture
+def parallel_map_config():
+    return {
+        "name": "sentiment_and_word_count",
+        "type": "parallel_map",
+        "prompts": [
+            {
+                "name": "sentiment",
+                "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
+                "output_keys": ["sentiment"],
+                "model": "gpt-4o-mini",
+            },
+            {
+                "name": "word_count",
+                "prompt": "Count the number of words in the following text: '{{ input.text }}'. Return the count as an integer.",
+                "output_keys": ["word_count"],
+                "model": "gpt-4o-mini",
+            },
+        ],
+        "output": {"schema": {"sentiment": "string", "word_count": "integer"}},
+    }
+
+
+@pytest.fixture
+def parallel_map_config_with_batching():
+    return {
+        "name": "sentiment_and_word_count",
+        "type": "parallel_map",
+        "prompts": [
+            {
+                "name": "sentiment",
+                "prompt": "Analyze the sentiment of the following text: '{{ input.text }}'. Classify it as either positive, negative, or neutral.",
+                "output_keys": ["sentiment"],
+                "model": "gpt-4o-mini",
+            },
+            {
+                "name": "word_count",
+                "prompt": "Count the number of words in the following text: '{{ input.text }}'. Return the count as an integer.",
+                "output_keys": ["word_count"],
+                "model": "gpt-4o-mini",
+            },
+        ],
+        "output": {"schema": {"sentiment": "string", "word_count": "integer"}},
+        "batch_size": 2,
+        "clustering_method": "sem_cluster",
+    }
+
+
+# =============================================================================
+# OPERATION INSTANCE FIXTURES
+# =============================================================================
+
+@pytest.fixture
+def test_map_operation_instance(
+    map_config_with_batching, default_model, max_threads, runner
+):
+    return MapOperation(
+        runner, map_config_with_batching, default_model, max_threads
+    )
+
+
+# =============================================================================
+# TEST FUNCTIONS (USED AS EXAMPLES/VALIDATION)
+# =============================================================================
+
+def test_map_operation_with_batching(
+    map_config_with_batching, default_model, max_threads, runner
+):
+    operation = MapOperation(
+        runner, map_config_with_batching, default_model, max_threads
+    )
+
+    # Sample data for testing
+    map_sample_data = [
+        {"text": "This is a positive sentence."},
+        {"text": "This is a negative sentence."},
+        {"text": "This is a neutral sentence."},
+    ]
+
+    results, cost = operation.execute(map_sample_data)
+
+    assert len(results) == len(map_sample_data)
+    assert cost > 0
+    assert all("sentiment" in result for result in results)
+    assert all(
+        result["sentiment"] in ["positive", "negative", "neutral"] for result in results
+    )

--- a/tests/ranking/test_rank.py
+++ b/tests/ranking/test_rank.py
@@ -24,7 +24,7 @@ lotus.settings.configure(lm=lm, rm=rm)
 
 console = Console()
 
-api_wrapper = DSLRunner(
+runner = DSLRunner(
     {
         "default_model": "gemini/gemini-2.0-flash",
         "operations": [],
@@ -57,7 +57,7 @@ def calculate_ndcg(y_true, y_pred, k=10):
     
     return ndcg_score(y_true, y_pred, k=k)
 
-def test_order_square_dataset(api_wrapper):
+def test_order_square_dataset(runner):
     """
     Test ordering methods using a synthetic dataset of ASCII squares.
     Each square is n × n pixels, where n starts at 20 and increases by 3 for each subsequent square.
@@ -103,7 +103,7 @@ def test_order_square_dataset(api_wrapper):
     }
     
     order_operation = RankOperation(
-        api_wrapper,
+        runner,
         order_config,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -111,7 +111,7 @@ def test_order_square_dataset(api_wrapper):
     likert_initial_config = order_config.copy()
     likert_initial_config["initial_ordering_method"] = "likert"
     order_operation_likert_initial = RankOperation(
-        api_wrapper,
+        runner,
         likert_initial_config,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -343,7 +343,7 @@ def test_order_square_dataset(api_wrapper):
     # Return the sorted results and NDCG scores
     return sorted_results, sorted_ndcg, lotus_num_calls
 
-def test_order_medical_transcripts_by_pain(api_wrapper):
+def test_order_medical_transcripts_by_pain(runner):
     """
     Test ordering methods for medical transcripts from workloads/medical/raw.json
     based on patient pain levels in descending order (most pain first).
@@ -373,7 +373,7 @@ def test_order_medical_transcripts_by_pain(api_wrapper):
     }
     
     order_operation = RankOperation(
-        api_wrapper,
+        runner,
         order_config,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -382,7 +382,7 @@ def test_order_medical_transcripts_by_pain(api_wrapper):
     order_config_likert_initial = order_config.copy()
     order_config_likert_initial["initial_ordering_method"] = "likert"
     order_operation_likert_initial = RankOperation(
-        api_wrapper,
+        runner,
         order_config_likert_initial,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -630,7 +630,7 @@ def test_order_medical_transcripts_by_pain(api_wrapper):
     # Return the same structure as test_order_square_dataset
     return sorted_results, sorted_ndcg, lotus_num_calls
 
-def test_order_scifact_dataset(api_wrapper):
+def test_order_scifact_dataset(runner):
     """
     Test ordering methods on the scifact dataset.
     For each of 5 sampled claims from queries.jsonl, we rank the corpus.jsonl
@@ -762,7 +762,7 @@ def test_order_scifact_dataset(api_wrapper):
             }
             
             order_operation = RankOperation(
-                api_wrapper,
+                runner,
                 order_config,
                 default_model="gemini/gemini-2.0-flash",
                 max_threads=64,
@@ -983,7 +983,7 @@ def test_order_scifact_dataset(api_wrapper):
     # Return the same structure as other test methods, with placeholder value for lotus calls
     return sorted_results, sorted_ndcg, 0  # Using 0 as placeholder for lotus_num_calls
 
-def test_order_number_words(api_wrapper):
+def test_order_number_words(runner):
     """
     Test sorting a list of number words ("one", "two", "three", ...,"five hundred")
     in ascending numerical order using different ordering methods and compare their accuracy.
@@ -1050,7 +1050,7 @@ def test_order_number_words(api_wrapper):
     }
     
     order_operation = RankOperation(
-        api_wrapper,
+        runner,
         order_config,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -1059,7 +1059,7 @@ def test_order_number_words(api_wrapper):
     order_config_copy = order_config.copy()
     order_config_copy["initial_ordering_method"] = "likert"
     order_operation_likert = RankOperation(
-        api_wrapper,
+        runner,
         order_config_copy,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -1351,7 +1351,7 @@ def test_order_number_words(api_wrapper):
     
     return sorted_results, sorted_ndcg, lotus_num_calls
 
-def test_order_synthetic_abstracts(api_wrapper, num_abstracts=200):
+def test_order_synthetic_abstracts(runner, num_abstracts=200):
     """
     Test sorting a list of synthetic paper abstracts in ascending order by the accuracy values 
     they report using different ordering methods and compare their performance.
@@ -1407,7 +1407,7 @@ def test_order_synthetic_abstracts(api_wrapper, num_abstracts=200):
     
     # Create MapOperation instance
     map_operation = MapOperation(
-        api_wrapper,
+        runner,
         map_config,
         default_model="gpt-4o-mini",
         max_threads=64
@@ -1444,7 +1444,7 @@ def test_order_synthetic_abstracts(api_wrapper, num_abstracts=200):
     }
     
     order_operation = RankOperation(
-        api_wrapper,
+        runner,
         order_config,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -1453,7 +1453,7 @@ def test_order_synthetic_abstracts(api_wrapper, num_abstracts=200):
     order_config_likert = order_config.copy()
     order_config_likert["initial_ordering_method"] = "likert"
     order_operation_likert = RankOperation(
-        api_wrapper,
+        runner,
         order_config_likert,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -1761,7 +1761,7 @@ def scifact():
         
         # Run the scifact test
         console.print(f"\n[bold cyan]Testing SciFact Dataset (Trial {trial+1})[/bold cyan]\n")
-        trial_scifact_results, trial_scifact_ndcg, _ = test_order_scifact_dataset(api_wrapper)
+        trial_scifact_results, trial_scifact_ndcg, _ = test_order_scifact_dataset(runner)
         scifact_results.append(trial_scifact_results)
         scifact_ndcg_results.append(trial_scifact_ndcg)
     
@@ -1864,7 +1864,7 @@ def run_abstract_tests():
             console.print(f"\n[bold magenta]Running Trial {trial+1}/{n_trials} with {num_abstracts} abstracts[/bold magenta]\n")
             
             # Execute the test
-            trial_results, trial_ndcg, lotus_calls = test_order_synthetic_abstracts(api_wrapper, num_abstracts=num_abstracts)
+            trial_results, trial_ndcg, lotus_calls = test_order_synthetic_abstracts(runner, num_abstracts=num_abstracts)
             
             # Store the results
             results_collection.append(trial_results)
@@ -1984,7 +1984,7 @@ def run_abstract_tests():
     
 
 
-def test_chat_harmfulness(api_wrapper, num_samples=200):
+def test_chat_harmfulness(runner, num_samples=200):
     """
     Test ranking chat transcripts by harmlessness.
     Lower min_harmlessness_score_transcript values indicate more harmful content,
@@ -2038,7 +2038,7 @@ def test_chat_harmfulness(api_wrapper, num_samples=200):
     
     # Create order operation instance
     order_operation = RankOperation(
-        api_wrapper,
+        runner,
         order_config,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -2060,7 +2060,7 @@ def test_chat_harmfulness(api_wrapper, num_samples=200):
     order_config_likert = order_config.copy()
     order_config_likert["initial_ordering_method"] = "likert"
     order_operation_likert = RankOperation(
-        api_wrapper,
+        runner,
         order_config_likert,
         default_model="gemini/gemini-2.0-flash",
         max_threads=64,
@@ -2359,7 +2359,7 @@ def run_harmlessness_tests():
             console.print(f"\n[bold magenta]Running Trial {trial+1}/{n_trials} with {num_samples} transcripts[/bold magenta]\n")
             
             # Execute the test
-            trial_results, trial_ndcg, lotus_calls = test_chat_harmfulness(api_wrapper, num_samples=num_samples)
+            trial_results, trial_ndcg, lotus_calls = test_chat_harmfulness(runner, num_samples=num_samples)
             
             # Store the results
             results_collection.append(trial_results)
@@ -2478,5 +2478,5 @@ def run_harmlessness_tests():
 
 if __name__ == "__main__":
     # Uncomment the function you want to run:
-    test_chat_harmfulness(api_wrapper)
+    test_chat_harmfulness(runner)
     # run_harmlessness_tests()

--- a/tests/ranking/test_rank_budget.py
+++ b/tests/ranking/test_rank_budget.py
@@ -19,7 +19,7 @@ import random
 
 from docetl.runner import DSLRunner
 
-api_wrapper = DSLRunner(
+runner = DSLRunner(
     {
         "default_model": "gpt-4o-mini",
         "operations": [],
@@ -220,7 +220,7 @@ def load_synthetic_abstracts_data(num_abstracts=200):
         "num_retries_on_validate_failure": 2,
     }
     map_operation = MapOperation(
-        api_wrapper,
+        runner,
         map_config,
         default_model="gpt-4o-mini",
         max_threads=64,
@@ -287,7 +287,7 @@ def load_medical_data(num_samples=200):
     }
     
     operation = RankOperation(
-        api_wrapper,
+        runner,
         order_config,
         default_model="gpt-4o-mini",
         max_threads=64,
@@ -302,7 +302,7 @@ def load_medical_data(num_samples=200):
     
     return medical_data, ground_truth_ranks
 
-def test_ranking_with_budget_variation(api_wrapper, dataset, ground_truth_ranks, dataset_name):
+def test_ranking_with_budget_variation(runner, dataset, ground_truth_ranks, dataset_name):
     """
     Test ranking with varying budget parameters.
     
@@ -313,7 +313,7 @@ def test_ranking_with_budget_variation(api_wrapper, dataset, ground_truth_ranks,
     - Picky Window with Calibrated Embedding initial (varying rerank_call_budget)
     
     Args:
-        api_wrapper: API wrapper for LLM calls
+        runner: API wrapper for LLM calls
         dataset: List of documents to rank
         ground_truth_ranks: Dictionary mapping document IDs to ground truth ranks
         dataset_name: Name of the dataset being used
@@ -351,7 +351,7 @@ def test_ranking_with_budget_variation(api_wrapper, dataset, ground_truth_ranks,
         config["batch_size"] = batch_size
         
         operation = RankOperation(
-            api_wrapper,
+            runner,
             config,
             default_model="gpt-4o-mini",
             max_threads=64,
@@ -404,7 +404,7 @@ def test_ranking_with_budget_variation(api_wrapper, dataset, ground_truth_ranks,
         config["batch_size"] = batch_size
         
         operation = RankOperation(
-            api_wrapper,
+            runner,
             config,
             default_model="gpt-4o-mini",
             max_threads=64,
@@ -462,7 +462,7 @@ def test_ranking_with_budget_variation(api_wrapper, dataset, ground_truth_ranks,
         config["initial_ordering_method"] = "likert"
         
         operation = RankOperation(
-            api_wrapper,
+            runner,
             config,
             default_model="gpt-4o-mini",
             max_threads=64,
@@ -517,7 +517,7 @@ def test_ranking_with_budget_variation(api_wrapper, dataset, ground_truth_ranks,
         config["initial_ordering_method"] = "calibrated_embedding"
         
         operation = RankOperation(
-            api_wrapper,
+            runner,
             config,
             default_model="gpt-4o-mini",
             max_threads=64,
@@ -774,7 +774,7 @@ def run_budget_tests(dataset_name="harmfulness", num_samples=200):
         return {}
     
     # Run tests
-    results = test_ranking_with_budget_variation(api_wrapper, data, ground_truth_ranks, dataset_name)
+    results = test_ranking_with_budget_variation(runner, data, ground_truth_ranks, dataset_name)
     
     # Create plots
     create_budget_performance_plots(results, output_filename)

--- a/tests/test_azure_rl.py
+++ b/tests/test_azure_rl.py
@@ -4,7 +4,7 @@ from docetl.operations.map import MapOperation
 import random
 import os
 from dotenv import load_dotenv
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 
 load_dotenv()
 

--- a/tests/test_eugene.py
+++ b/tests/test_eugene.py
@@ -17,7 +17,7 @@ def max_threads():
 
 
 @pytest.fixture
-def synthetic_data():
+def database_survey_data():
     return [
         {
             "survey_response": "the database normalization stuff was pretty hard but super interesting. breaking down tables into their most efficient form was confusing at first, but as we did more examples, i started to see how cool well-normalized schemas are. the SQL queries were really fun to learn, especially when we got into the complicated joins and subqueries. i liked how the teacher gave us real-world examples of where we'd use this stuff, it helped me understand better.",
@@ -138,7 +138,7 @@ def summarize_themes_config():
 
 
 def test_database_survey_pipeline(
-    synthetic_data,
+    database_survey_data,
     extract_themes_config,
     unnest_themes_config,
     resolve_themes_config,
@@ -151,9 +151,9 @@ def test_database_survey_pipeline(
     extract_op = MapOperation(
         runner, extract_themes_config, default_model, max_threads
     )
-    extracted_results, extract_cost = extract_op.execute(synthetic_data)
+    extracted_results, extract_cost = extract_op.execute(database_survey_data)
 
-    assert len(extracted_results) == len(synthetic_data)
+    assert len(extracted_results) == len(database_survey_data)
     assert all("theme" in result for result in extracted_results)
     assert all(len(result["theme"]) >= 2 for result in extracted_results)
 

--- a/tests/test_eugene.py
+++ b/tests/test_eugene.py
@@ -3,7 +3,7 @@ from docetl.operations.map import MapOperation
 from docetl.operations.unnest import UnnestOperation
 from docetl.operations.resolve import ResolveOperation
 from docetl.operations.reduce import ReduceOperation
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 
 
 @pytest.fixture
@@ -145,11 +145,11 @@ def test_database_survey_pipeline(
     summarize_themes_config,
     default_model,
     max_threads,
-    api_wrapper,
+    runner,
 ):
     # Extract themes
     extract_op = MapOperation(
-        api_wrapper, extract_themes_config, default_model, max_threads
+        runner, extract_themes_config, default_model, max_threads
     )
     extracted_results, extract_cost = extract_op.execute(synthetic_data)
 
@@ -159,7 +159,7 @@ def test_database_survey_pipeline(
 
     # Unnest themes
     unnest_op = UnnestOperation(
-        api_wrapper, unnest_themes_config, default_model, max_threads
+        runner, unnest_themes_config, default_model, max_threads
     )
     unnested_results, unnest_cost = unnest_op.execute(extracted_results)
 
@@ -168,7 +168,7 @@ def test_database_survey_pipeline(
 
     # Resolve themes
     resolve_op = ResolveOperation(
-        api_wrapper, resolve_themes_config, default_model, max_threads
+        runner, resolve_themes_config, default_model, max_threads
     )
     resolved_results, resolve_cost = resolve_op.execute(unnested_results)
 
@@ -177,7 +177,7 @@ def test_database_survey_pipeline(
 
     # Summarize themes
     summarize_op = ReduceOperation(
-        api_wrapper, summarize_themes_config, default_model, max_threads
+        runner, summarize_themes_config, default_model, max_threads
     )
     summarized_results, summarize_cost = summarize_op.execute(resolved_results)
 

--- a/tests/test_reduce_scale.py
+++ b/tests/test_reduce_scale.py
@@ -1,7 +1,7 @@
 import pytest
 from docetl.operations.reduce import ReduceOperation
 from dotenv import load_dotenv
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 import random
 
 load_dotenv()
@@ -84,9 +84,9 @@ def reduce_sample_data():
 
 
 def test_reduce_operation(
-    api_wrapper, reduce_config, default_model, max_threads, reduce_sample_data
+    runner, reduce_config, default_model, max_threads, reduce_sample_data
 ):
-    operation = ReduceOperation(api_wrapper, reduce_config, default_model, max_threads)
+    operation = ReduceOperation(runner, reduce_config, default_model, max_threads)
     results, cost = operation.execute(reduce_sample_data)
 
     assert len(results) == 3, "Should have results for 3 unique categories"
@@ -104,10 +104,10 @@ def test_reduce_operation(
 
 
 def test_reduce_operation_pass_through(
-    api_wrapper, reduce_config, default_model, max_threads, reduce_sample_data
+    runner, reduce_config, default_model, max_threads, reduce_sample_data
 ):
     reduce_config["pass_through"] = True
-    operation = ReduceOperation(api_wrapper, reduce_config, default_model, max_threads)
+    operation = ReduceOperation(runner, reduce_config, default_model, max_threads)
     results, cost = operation.execute(reduce_sample_data)
 
     assert len(results) == 3, "Should have results for 3 unique categories"
@@ -131,7 +131,7 @@ def test_reduce_operation_pass_through(
 
 
 def test_reduce_operation_error_handling(
-    api_wrapper, reduce_config, default_model, max_threads
+    runner, reduce_config, default_model, max_threads
 ):
 
     # Test with missing fold_prompt when merge_prompt is present
@@ -144,10 +144,10 @@ def test_reduce_operation_error_handling(
         ValueError,
         match="'fold_prompt' is required when 'merge_prompt' is specified",
     ):
-        ReduceOperation(api_wrapper, invalid_config, default_model, max_threads)
+        ReduceOperation(runner, invalid_config, default_model, max_threads)
 
 
-def test_reduce_operation_non_associative(api_wrapper, default_model, max_threads):
+def test_reduce_operation_non_associative(runner, default_model, max_threads):
     # Define a new non-associative reduce config
     non_associative_config = {
         "name": "non_associative_reduce",
@@ -169,7 +169,7 @@ def test_reduce_operation_non_associative(api_wrapper, default_model, max_thread
     ]
 
     operation = ReduceOperation(
-        api_wrapper, non_associative_config, default_model, max_threads
+        runner, non_associative_config, default_model, max_threads
     )
     results, cost = operation.execute(sample_data)
 
@@ -199,7 +199,7 @@ def test_reduce_operation_non_associative(api_wrapper, default_model, max_thread
 
 
 def test_reduce_operation_persist_intermediates(
-    api_wrapper, default_model, max_threads
+    runner, default_model, max_threads
 ):
     # Define a config with persist_intermediates enabled
     persist_intermediates_config = {
@@ -223,7 +223,7 @@ def test_reduce_operation_persist_intermediates(
     ]
 
     operation = ReduceOperation(
-        api_wrapper, persist_intermediates_config, default_model, max_threads
+        runner, persist_intermediates_config, default_model, max_threads
     )
     results, cost = operation.execute(sample_data)
 

--- a/tests/test_reduce_value_sampling.py
+++ b/tests/test_reduce_value_sampling.py
@@ -1,7 +1,7 @@
 import pytest
 import random
 from docetl.operations.reduce import ReduceOperation
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ def large_sample_data():
     return data
 
 
-def test_random_sampling(api_wrapper, default_model, max_threads, large_sample_data):
+def test_random_sampling(runner, default_model, max_threads, large_sample_data):
     config = {
         "name": "reduce_value_sampling",
         "type": "reduce",
@@ -42,7 +42,7 @@ def test_random_sampling(api_wrapper, default_model, max_threads, large_sample_d
         "output": {"schema": {"summary": "string"}},
     }
 
-    operation = ReduceOperation(api_wrapper, config, default_model, max_threads)
+    operation = ReduceOperation(runner, config, default_model, max_threads)
     results, cost = operation.execute(large_sample_data)
 
     assert len(results) == 3, "Should have results for all three groups A, B, and C"
@@ -51,7 +51,7 @@ def test_random_sampling(api_wrapper, default_model, max_threads, large_sample_d
         assert len(result["summary"]) > 0, "Summary should not be empty"
 
 
-def test_first_n_sampling(api_wrapper, default_model, max_threads, large_sample_data):
+def test_first_n_sampling(runner, default_model, max_threads, large_sample_data):
     config = {
         "name": "reduce_value_sampling",
         "type": "reduce",
@@ -61,7 +61,7 @@ def test_first_n_sampling(api_wrapper, default_model, max_threads, large_sample_
         "output": {"schema": {"summary": "string"}},
     }
 
-    operation = ReduceOperation(api_wrapper, config, default_model, max_threads)
+    operation = ReduceOperation(runner, config, default_model, max_threads)
     results, cost = operation.execute(large_sample_data)
 
     assert len(results) == 3, "Should have results for all three groups A, B, and C"
@@ -70,7 +70,7 @@ def test_first_n_sampling(api_wrapper, default_model, max_threads, large_sample_
         assert len(result["summary"]) > 0, "Summary should not be empty"
 
 
-def test_cluster_sampling(api_wrapper, default_model, max_threads, large_sample_data):
+def test_cluster_sampling(runner, default_model, max_threads, large_sample_data):
     config = {
         "name": "reduce_value_sampling",
         "type": "reduce",
@@ -86,7 +86,7 @@ def test_cluster_sampling(api_wrapper, default_model, max_threads, large_sample_
         "output": {"schema": {"summary": "string"}},
     }
 
-    operation = ReduceOperation(api_wrapper, config, default_model, max_threads)
+    operation = ReduceOperation(runner, config, default_model, max_threads)
     results, cost = operation.execute(large_sample_data)
 
     assert len(results) == 3, "Should have results for all three groups A, B, and C"
@@ -96,7 +96,7 @@ def test_cluster_sampling(api_wrapper, default_model, max_threads, large_sample_
 
 
 def test_semantic_similarity_sampling(
-    api_wrapper, default_model, max_threads, large_sample_data
+    runner, default_model, max_threads, large_sample_data
 ):
     config = {
         "name": "reduce_value_sampling",
@@ -114,7 +114,7 @@ def test_semantic_similarity_sampling(
         "output": {"schema": {"summary": "string"}},
     }
 
-    operation = ReduceOperation(api_wrapper, config, default_model, max_threads)
+    operation = ReduceOperation(runner, config, default_model, max_threads)
     results, cost = operation.execute(large_sample_data)
 
     assert len(results) == 3, "Should have results for all three groups A, B, and C"
@@ -130,7 +130,7 @@ def test_semantic_similarity_sampling(
 
 
 def test_invalid_sampling_method(
-    api_wrapper, default_model, max_threads, large_sample_data
+    runner, default_model, max_threads, large_sample_data
 ):
     config = {
         "name": "reduce_value_sampling",
@@ -146,4 +146,4 @@ def test_invalid_sampling_method(
     }
 
     with pytest.raises(ValueError, match="Invalid 'method'"):
-        ReduceOperation(api_wrapper, config, default_model, max_threads)
+        ReduceOperation(runner, config, default_model, max_threads)

--- a/tests/test_resolve_auto_batch.py
+++ b/tests/test_resolve_auto_batch.py
@@ -1,7 +1,7 @@
 
 import pytest
 from docetl.operations.resolve import ResolveOperation
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 @pytest.fixture(scope='session')
 def resolve_config():
     return {
@@ -112,10 +112,10 @@ def resolve_sample_data():
 
 
 def test_resolve_operation(
-    resolve_config, max_threads, resolve_sample_data, api_wrapper
+    resolve_config, max_threads, resolve_sample_data, runner
 ):
     operation = ResolveOperation(
-        api_wrapper, resolve_config, "text-embedding-3-small", max_threads
+        runner, resolve_config, "text-embedding-3-small", max_threads
     )
     results, cost = operation.execute(resolve_sample_data[:25])
 

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -2,7 +2,7 @@ import pytest
 from docetl.operations.split import SplitOperation
 from docetl.operations.map import MapOperation
 from docetl.operations.gather import GatherOperation
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 
 
 @pytest.fixture
@@ -106,7 +106,7 @@ def input_data():
 
 
 def test_split_map_gather_operations(
-    api_wrapper,
+    runner,
     split_config,
     map_config,
     gather_config,
@@ -114,9 +114,9 @@ def test_split_map_gather_operations(
     default_model,
     max_threads,
 ):
-    split_op = SplitOperation(api_wrapper, split_config, default_model, max_threads)
-    map_op = MapOperation(api_wrapper, map_config, default_model, max_threads)
-    gather_op = GatherOperation(api_wrapper, gather_config, default_model, max_threads)
+    split_op = SplitOperation(runner, split_config, default_model, max_threads)
+    map_op = MapOperation(runner, map_config, default_model, max_threads)
+    gather_op = GatherOperation(runner, gather_config, default_model, max_threads)
 
     # Execute split operation
     split_results, split_cost = split_op.execute(input_data)
@@ -189,11 +189,11 @@ def test_split_map_gather_operations(
 
 
 def test_split_map_gather_empty_input(
-    api_wrapper, split_config, map_config, gather_config, default_model, max_threads
+    runner, split_config, map_config, gather_config, default_model, max_threads
 ):
-    split_op = SplitOperation(api_wrapper, split_config, default_model, max_threads)
-    map_op = MapOperation(api_wrapper, map_config, default_model, max_threads)
-    gather_op = GatherOperation(api_wrapper, gather_config, default_model, max_threads)
+    split_op = SplitOperation(runner, split_config, default_model, max_threads)
+    map_op = MapOperation(runner, map_config, default_model, max_threads)
+    gather_op = GatherOperation(runner, gather_config, default_model, max_threads)
 
     split_results, split_cost = split_op.execute([])
     assert len(split_results) == 0
@@ -209,7 +209,7 @@ def test_split_map_gather_empty_input(
 
 
 def test_split_delimiter_no_summarization(
-    api_wrapper, split_config_delimiter, default_model, max_threads
+    runner, split_config_delimiter, default_model, max_threads
 ):
     input_data = [
         {"id": "1", "content": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6"},
@@ -217,7 +217,7 @@ def test_split_delimiter_no_summarization(
     ]
 
     split_op = SplitOperation(
-        api_wrapper, split_config_delimiter, default_model, max_threads, api_wrapper
+        runner, split_config_delimiter, default_model, max_threads
     )
     results, cost = split_op.execute(input_data)
 

--- a/tests/test_synth_gather.py
+++ b/tests/test_synth_gather.py
@@ -7,7 +7,7 @@ from docetl.runner import DSLRunner
 from docetl.operations.split import SplitOperation
 from docetl.operations.map import MapOperation
 from docetl.operations.gather import GatherOperation
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 
 
 def generate_random_content(length):
@@ -171,7 +171,7 @@ def test_synth_gather(config_yaml):
 #     test_synth_gather(config)
 
 
-def test_split_map_gather(sample_data, api_wrapper):
+def test_split_map_gather(sample_data, runner):
     default_model = "gpt-4o-mini"
     # Define split operation
     split_config = {
@@ -219,10 +219,10 @@ def test_split_map_gather(sample_data, api_wrapper):
     }
 
     # Initialize operations
-    split_op = SplitOperation(api_wrapper, split_config, default_model, max_threads=64)
-    map_op = MapOperation(api_wrapper, map_config, default_model, max_threads=64)
+    split_op = SplitOperation(runner, split_config, default_model, max_threads=64)
+    map_op = MapOperation(runner, map_config, default_model, max_threads=64)
     gather_op = GatherOperation(
-        api_wrapper, gather_config, default_model, max_threads=64
+        runner, gather_config, default_model, max_threads=64
     )
 
     # Execute operations

--- a/tests/test_synthetic_output.py
+++ b/tests/test_synthetic_output.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 
 from docetl.runner import DSLRunner
-from tests.conftest import api_wrapper
+from tests.conftest import runner
 
 
 @pytest.fixture
@@ -87,7 +87,7 @@ def config_yaml(synthetic_fruits_data):
 
 @pytest.mark.parametrize("use_runner", [True])
 def test_synthetic_output_count(
-    synthetic_fruits_data, config_yaml, api_wrapper, use_runner
+    synthetic_fruits_data, config_yaml, runner, use_runner
 ):
     """
     Test that ensures the synthetic workload generates the expected number of outputs.

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 import pytest
 from docetl.operations.map import MapOperation
-from tests.conftest import api_wrapper, default_model, max_threads
+from tests.conftest import runner, default_model, max_threads
 
 
 @pytest.fixture
@@ -29,11 +29,11 @@ def sample_data():
 
 
 def test_map_operation_with_validation(
-    map_config_with_validation, sample_data, api_wrapper, default_model, max_threads
+    map_config_with_validation, sample_data, runner, default_model, max_threads
 ):
     map_config_with_validation["bypass_cache"] = True
     operation = MapOperation(
-        api_wrapper, map_config_with_validation, default_model, max_threads
+        runner, map_config_with_validation, default_model, max_threads
     )
     results, cost = operation.execute(sample_data)
 


### PR DESCRIPTION
Refactor pytest fixtures and test organization to improve maintainability and readability.

The `conftest.py` file was significantly reduced (by 55%) by moving test-specific fixtures to their respective test files, removing unused fixtures, and relocating a misplaced test function. Additionally, the `api_wrapper` fixture was renamed to `runner` for better semantic clarity, with all references updated across the test suite. These changes centralize truly shared fixtures and localize single-use ones, making the test suite leaner and easier to navigate.