### PR TITLE
Clean up utility code

### DIFF
--- a/docetl/operations/base.py
+++ b/docetl/operations/base.py
@@ -10,15 +10,7 @@ from rich.console import Console
 from rich.status import Status
 
 from docetl.console import DOCETL_CONSOLE
-
-
-# FIXME: This should probably live in some utils module?
-class classproperty(object):
-    def __init__(self, f):
-        self.f = f
-
-    def __get__(self, obj, owner):
-        return self.f(owner)
+from docetl.utils import classproperty
 
 
 class BaseOperationMeta(ABCMeta):

--- a/docetl/operations/utils/progress.py
+++ b/docetl/operations/utils/progress.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from concurrent.futures import as_completed
 
 from rich.console import Console
@@ -37,7 +37,7 @@ class RichLoopBar:
         except TypeError:
             return None
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterable:
         self.tqdm = tqdm(
             self.iterable,
             total=self.total,

--- a/docetl/schemas.py
+++ b/docetl/schemas.py
@@ -1,5 +1,7 @@
 from . import dataset
 from .base_schemas import *  # noqa: F403
+
+# ruff: noqa: F403
 from .operations import (
     cluster,
     equijoin,


### PR DESCRIPTION
Depends on #389, so does not make sense to review until that is merged in. This PR makes the following improvements to `docetl/utils.py`:

1. Adds type annotations to fix `mypy` issues in this file.
2. Removes the duplicate `classproperty` definition in `docetl/operations/base.py`