### PR TITLE
Add structured output mode support to pandas API

### DIFF
--- a/docs/pandas/examples.md
+++ b/docs/pandas/examples.md
@@ -32,10 +32,12 @@ result = df.semantic.map(
     3. Overall sentiment
     
     Review: {{input.review}}""",
-    output_schema={
-        "features": "list[str]",
-        "feature_sentiments": "dict[str, str]",
-        "overall_sentiment": "str"
+    output={
+        "schema": {
+            "features": "list[str]",
+            "feature_sentiments": "dict[str, str]",
+            "overall_sentiment": "str"
+        }
     }
 )
 
@@ -96,7 +98,7 @@ df = pd.DataFrame({
 # First, use a semantic map to extract the topic from each article
 df = df.semantic.map(
     prompt="Extract the topic from this article: {{input.content}}",
-    output_schema={"topic": "str"}
+    output={"schema": {"topic": "str"}}
 )
 
 # Group similar articles and generate summaries
@@ -151,10 +153,12 @@ analyzed = posts.semantic.map(
     3. Issues/Praise points
     
     Post: {{input.text}}""",
-    output_schema={
-        "product": "str",
-        "sentiment": "str",
-        "points": "list[str]"
+    output={
+        "schema": {
+            "product": "str",
+            "sentiment": "str",
+            "points": "list[str]"
+        }
     }
 )
 
@@ -200,10 +204,12 @@ df = pd.DataFrame({
 try:
     result = df.semantic.map(
         prompt="Extract product specifications from: {{input.description}}. There should be at least one feature.",
-        output_schema={
-            "category": "str",
-            "features": "list[str]",
-            "price_range": "enum[budget, mid-range, premium, luxury]"
+        output={
+            "schema": {
+                "category": "str",
+                "features": "list[str]",
+                "price_range": "enum[budget, mid-range, premium, luxury]"
+            }
         },
         # Validation rules
         validate=[
@@ -234,7 +240,9 @@ df = pd.DataFrame({
 
 result_df = df.semantic.map(
     prompt="Summarize the air crash report and determine any contributing factors",
-    output_schema={"summary": "str", "contributing_factors": "list[str]"},
+    output={
+        "schema": {"summary": "str", "contributing_factors": "list[str]"}
+    },
     pdf_url_key="PdfPath", # This is the column with the PDF paths
 )
 
@@ -265,8 +273,7 @@ variations = df.semantic.map(
     - Highlight the key benefit of the product
     - Be between 5-10 words
     """,
-    output_schema={"headline": "str"},
-    n=5  # Generate 5 variations for each input row
+    output={"schema": {"headline": "str"}, "n": 5}  # Generate 5 variations for each input row
 )
 
 print(f"Original dataframe rows: {len(df)}")
@@ -338,10 +345,12 @@ analyzed_chunks = enhanced_chunks.semantic.map(
     
     Document chunk with context:
     {{input.content_chunk_rendered}}""",
-    output_schema={
-        "section_topic": "str",
-        "key_concepts": "list[str]",
-        "action_items": "list[str]"
+    output={
+        "schema": {
+            "section_topic": "str",
+            "key_concepts": "list[str]",
+            "action_items": "list[str]"
+        }
     }
 )
 
@@ -423,10 +432,12 @@ interest_analysis = with_ratings.semantic.map(
     Product ratings: Quality={{input.product_quality}}, Service={{input.customer_service}}, Value={{input.value}}
     
     Provide insights about how this interest might relate to their demographics and satisfaction.""",
-    output_schema={
-        "demographic_insight": "str",
-        "interest_category": "str",
-        "satisfaction_correlation": "str"
+    output={
+        "schema": {
+            "demographic_insight": "str",
+            "interest_category": "str",
+            "satisfaction_correlation": "str"
+        }
     }
 )
 
@@ -505,11 +516,13 @@ Extract:
 2. Key findings or claims
 3. Technical concepts mentioned
 4. Research gaps or future work mentioned""",
-    output_schema={
-        "section_type": "str",
-        "key_findings": "list[str]",
-        "technical_concepts": "list[str]",
-        "future_work": "list[str]"
+    output={
+        "schema": {
+            "section_type": "str",
+            "key_findings": "list[str]",
+            "technical_concepts": "list[str]",
+            "future_work": "list[str]"
+        }
     }
 )
 

--- a/docs/pandas/index.md
+++ b/docs/pandas/index.md
@@ -44,10 +44,12 @@ df.semantic.set_config(default_model="gpt-4o-mini")
 # Extract structured information
 result = df.semantic.map(
     prompt="Extract company and product from: {{input.text}}",
-    output_schema={
-        "company": "str",
-        "product": "str",
-        "features": "list[str]"
+    output={
+        "schema": {
+            "company": "str",
+            "product": "str",
+            "features": "list[str]"
+        }
     }
 )
 
@@ -88,6 +90,54 @@ For detailed configuration options and best practices, refer to:
 - [Pipeline Configuration](../concepts/pipelines.md)
 - [Output Schemas](../concepts/schemas.md)
 - [Rate Limiting](../examples/rate-limiting.md) 
+
+## Output Modes
+
+DocETL supports two output modes for LLM calls:
+
+### Tools Mode (Default)
+Uses function calling to ensure structured outputs:
+```python
+result = df.semantic.map(
+    prompt="Extract data from: {{input.text}}",
+    output={
+        "schema": {"name": "str", "age": "int"},
+        "mode": "tools"  # Default mode
+    }
+)
+```
+
+### Structured Output Mode
+Uses native JSON schema validation for supported models (like GPT-4o):
+```python
+result = df.semantic.map(
+    prompt="Extract data from: {{input.text}}",
+    output={
+        "schema": {"name": "str", "age": "int"},
+        "mode": "structured_output"  # Better JSON schema support
+    }
+)
+```
+
+!!! tip "When to Use Structured Output Mode"
+    
+    Use `"structured_output"` mode when:
+    - You're using models that support native JSON schema (like GPT-4o)
+    - You need stricter adherence to complex JSON schemas
+    - You want potentially better performance for structured data extraction
+    
+    The default `"tools"` mode works with all models and is more widely compatible.
+
+### Backward Compatibility
+
+The old `output_schema` parameter is still supported for backward compatibility:
+```python
+# This still works (automatically uses tools mode)
+result = df.semantic.map(
+    prompt="Extract data from: {{input.text}}",
+    output_schema={"name": "str", "age": "int"}
+)
+```
 
 ## Cost Tracking
 

--- a/docs/pandas/operations.md
+++ b/docs/pandas/operations.md
@@ -2,7 +2,7 @@
 
 The pandas integration provides several semantic operations through the `.semantic` accessor. Each operation is designed to handle specific types of transformations and analyses using LLMs.
 
-All semantic operations return a new DataFrame that preserves the original columns and adds new columns based on the `output_schema`. For example, if your original DataFrame has a column `text` and you use `map` with an `output_schema={"sentiment": "str", "keywords": "list[str]"}`, the resulting DataFrame will have three columns: `text`, `sentiment`, and `keywords`. This makes it easy to chain operations and maintain data lineage.
+All semantic operations return a new DataFrame that preserves the original columns and adds new columns based on the output schema. For example, if your original DataFrame has a column `text` and you use `map` with an `output={"schema": {"sentiment": "str", "keywords": "list[str]"}}`, the resulting DataFrame will have three columns: `text`, `sentiment`, and `keywords`. This makes it easy to chain operations and maintain data lineage.
 
 ## Map Operation
 
@@ -13,14 +13,36 @@ All semantic operations return a new DataFrame that preserves the original colum
 
 Example usage:
 ```python
+# Basic map operation
 df.semantic.map(
     prompt="Extract sentiment and key points from: {{input.text}}",
-    output_schema={
-        "sentiment": "str",
-        "key_points": "list[str]"
+    output={
+        "schema": {
+            "sentiment": "str",
+            "key_points": "list[str]"
+        }
     },
     validate=["len(output['key_points']) <= 5"],
     num_retries_on_validate_failure=2
+)
+
+# Using structured output mode for better JSON schema support
+df.semantic.map(
+    prompt="Extract detailed information from: {{input.text}}",
+    output={
+        "schema": {
+            "company": "str",
+            "product": "str",
+            "features": "list[str]"
+        },
+        "mode": "structured_output"
+    }
+)
+
+# Backward compatible syntax (still supported)
+df.semantic.map(
+    prompt="Extract sentiment from: {{input.text}}",
+    output_schema={"sentiment": "str"}
 )
 ```
 
@@ -41,9 +63,11 @@ df.semantic.filter(
 # Custom output schema with reasons
 df.semantic.filter(
     prompt="Analyze if this is relevant: {{input.text}}",
-    output_schema={
-        "keep": "bool",
-        "reason": "str"
+    output={
+        "schema": {
+            "keep": "bool",
+            "reason": "str"
+        }
     }
 )
 ```


### PR DESCRIPTION
This commit addresses issue #393 by adding the ability to specify structured output mode in the pandas semantic accessor.

Key changes:
- Enhanced map() method to accept 'output' parameter with schema and mode
- Added support for 'structured_output' mode alongside existing 'tools' mode
- Maintained backward compatibility with existing 'output_schema' parameter
- Added comprehensive parameter validation and error handling

New API format:
```python
df.semantic.map(
    prompt="Extract data: {{input.text}}",
    output={
        "schema": {"name": "str", "age": "int"},
        "mode": "structured_output"  # Optional, defaults to "tools"
    }
)
```

Tests added:
- test_semantic_map_structured_output: Tests new structured output functionality
- test_semantic_map_invalid_output_mode: Tests output mode validation
- test_semantic_map_structured_output_vs_tools: Compares both output modes
- test_semantic_map_backward_compatibility: Ensures old API still works
- test_semantic_map_parameter_validation: Comprehensive parameter validation

🤖 Generated with [Claude Code](https://claude.ai/code)