### PR TITLE
Fix hardcoded temperature override for calibrate: true in map args

### DIFF
--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -184,8 +184,12 @@ Reference anchors:"""
 
             # Call LLM to get calibration suggestions
             messages = [{"role": "user", "content": calibration_prompt}]
-            completion_kwargs = self.config.get("litellm_completion_kwargs", {})
-            completion_kwargs["temperature"] = 0.0
+            # Use a copy of the user-provided completion kwargs so we don't mutate the original
+            # and avoid hard-coding temperature to a value that may not be supported by certain models.
+            completion_kwargs = dict(self.config.get("litellm_completion_kwargs", {}))
+            # If the user did not explicitly specify a temperature, let the model default handle it
+            # to prevent incompatibility errors with providers that don't support 0.0.
+            # If a temperature is already provided, respect the user's choice.
 
             llm_result = self.runner.api.call_llm(
                 self.config.get("model", self.default_model),


### PR DESCRIPTION
Remove hardcoded temperature override in LLM calls to fix unsupported value errors and respect model defaults.

The previous logic forced `temperature=0.0`, which caused a 400 error with Azure when using certain models. This change now copies user-supplied `litellm_completion_kwargs` and allows the model's default temperature to be used if not explicitly set by the user, ensuring compatibility while still allowing user overrides. This resolves #405.

---
<a href="https://cursor.com/background-agent?bcId=bc-a11795ea-aa96-4a64-bca9-e0140da66ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a11795ea-aa96-4a64-bca9-e0140da66ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

