### PR TITLE
feat: add topk implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Load environment variables from .env file
 include .env
 
-.PHONY: tests tests-basic lint install mypy update install-ui run-ui-dev run-ui docker docker-clean test-aws help
+.PHONY: tests tests-basic lint install mypy update install-ui run-ui-dev run-ui docker docker-clean test-aws docs-serve help
 
 # Test commands
 tests:
@@ -77,6 +77,10 @@ docker:
 docker-clean:
 	docker volume rm docetl-data
 
+# Documentation commands
+docs-serve:
+	uv run mkdocs serve -a localhost:8001
+
 # Test AWS connectivity
 test-aws:
 	@if ! command -v aws > /dev/null; then \
@@ -128,5 +132,6 @@ help:
 	@echo "  make run-ui       : Run UI production server"
 	@echo "  make docker       : Build and run docetl in Docker"
 	@echo "  make docker-clean : Remove docetl Docker volume"
+	@echo "  make docs-serve   : Serve documentation locally on port 8001"
 	@echo "  make test-aws     : Test AWS credentials configuration"
 	@echo "  make help         : Show this help message"

--- a/docetl/operations/sample.py
+++ b/docetl/operations/sample.py
@@ -1,18 +1,18 @@
-from typing import Any, Literal, Union
-import random
 from collections import defaultdict
+from typing import Any, Literal, Union
 
 import numpy as np
 from pydantic import Field, field_validator, model_validator
 
 from docetl.operations.base import BaseOperation
 from docetl.operations.clustering_utils import get_embeddings_for_clustering
+from docetl.operations.utils import strict_render
 
 
 class SampleOperation(BaseOperation):
     """
     Samples items from input data using various methods with optional stratification.
-    
+
     Params:
     - method: "uniform", "outliers", "custom", "first"
     - samples: int, float, or list depending on method
@@ -29,7 +29,9 @@ class SampleOperation(BaseOperation):
 
     class schema(BaseOperation.schema):
         type: str = "sample"
-        method: Literal["uniform", "outliers", "custom", "first"]
+        method: Literal[
+            "uniform", "outliers", "custom", "first", "top_embedding", "top_fts"
+        ]
         samples: Union[int, float, list] | None = None
         stratify_key: Union[str, list[str]] | None = None
         samples_per_group: bool = False
@@ -40,23 +42,23 @@ class SampleOperation(BaseOperation):
         def validate_samples(cls, v, info):
             if v is None:
                 return v
-                
+
             method = info.data.get("method") if hasattr(info, "data") else None
-            
+
             if method == "custom":
                 if not isinstance(v, list):
                     raise TypeError("'samples' must be a list for custom sampling")
             elif isinstance(v, (int, float)):
                 if v <= 0:
                     raise ValueError("'samples' must be a positive number")
-                    
+
             return v
 
         @field_validator("stratify_key")
         def validate_stratify_key(cls, v):
             if v is None:
                 return v
-                
+
             if isinstance(v, str):
                 pass  # Single key is valid
             elif isinstance(v, list):
@@ -66,19 +68,16 @@ class SampleOperation(BaseOperation):
                     raise TypeError("All items in 'stratify_key' must be strings")
             else:
                 raise TypeError("'stratify_key' must be a string or list of strings")
-                
+
             return v
 
         @field_validator("method_kwargs")
         def validate_method_kwargs(cls, v, info):
             if v is None:
                 return {}
-                
+
             if not isinstance(v, dict):
                 raise TypeError("'method_kwargs' must be a dictionary")
-
-            # Get method from context if available
-            method = info.data.get("method") if hasattr(info, "data") else None
 
             # Validate outlier-specific kwargs
             if "embedding_keys" in v:
@@ -93,7 +92,9 @@ class SampleOperation(BaseOperation):
 
             if "samples" in v:
                 if not isinstance(v["samples"], (int, float)) or v["samples"] <= 0:
-                    raise ValueError("'samples' in method_kwargs must be a positive number")
+                    raise ValueError(
+                        "'samples' in method_kwargs must be a positive number"
+                    )
 
             if "center" in v and not isinstance(v["center"], dict):
                 raise TypeError("'center' must be a dictionary")
@@ -121,16 +122,48 @@ class SampleOperation(BaseOperation):
                         "'embedding_keys' must be specified in outliers configuration"
                     )
 
+            # Top embedding method requirements
+            if method == "top_embedding":
+                if "keys" not in method_kwargs:
+                    raise ValueError(
+                        "'keys' must be specified in top_embedding configuration"
+                    )
+                if "query" not in method_kwargs:
+                    raise ValueError(
+                        "'query' must be specified in top_embedding configuration"
+                    )
+                if self.samples is None:
+                    raise ValueError(
+                        "Must specify 'samples' for top_embedding sampling"
+                    )
+
+            # Top FTS method requirements
+            if method == "top_fts":
+                if "keys" not in method_kwargs:
+                    raise ValueError(
+                        "'keys' must be specified in top_fts configuration"
+                    )
+                if "query" not in method_kwargs:
+                    raise ValueError(
+                        "'query' must be specified in top_fts configuration"
+                    )
+                if self.samples is None:
+                    raise ValueError("Must specify 'samples' for top_fts sampling")
+
             # Custom method requirements
             if method == "custom":
                 if self.samples is None:
                     raise ValueError("Must specify 'samples' for custom sampling")
                 if self.stratify_key is not None:
-                    raise ValueError("Stratification is not supported with custom sampling")
-                    
+                    raise ValueError(
+                        "Stratification is not supported with custom sampling"
+                    )
+
             # Validate samples_per_group only makes sense with stratification
             if self.samples_per_group and not self.stratify_key:
-                raise ValueError("'samples_per_group' requires 'stratify_key' to be set")
+                raise ValueError(
+                    "'samples_per_group' requires 'stratify_key' to be set"
+                )
 
             return self
 
@@ -143,18 +176,20 @@ class SampleOperation(BaseOperation):
                     # Check pipeline config for doc_id_keys
                     pipeline_config = getattr(self._runner, "config", {})
                     doc_id_keys = set()
-                    
+
                     for op in pipeline_config.get("operations", []):
                         if "doc_id_key" in op:
                             doc_id_keys.add(op["doc_id_key"])
-                    
+
                     # Warn about missing keys
                     for key in stratify_key:
                         if key not in doc_id_keys:
-                            print(f"Warning: stratify_key '{key}' is not found as a doc_id_key in any pipeline operation")
+                            print(
+                                f"Warning: stratify_key '{key}' is not found as a doc_id_key in any pipeline operation"
+                            )
                             if doc_id_keys:
                                 print(f"Available doc_id_keys: {sorted(doc_id_keys)}")
-            
+
             return self
 
     def __init__(self, *args, **kwargs):
@@ -181,11 +216,11 @@ class SampleOperation(BaseOperation):
 
         method = self.config["method"]
         stratify_key = self.config.get("stratify_key")
-        
+
         # If stratification is requested, handle it here
         if stratify_key:
             return self._sample_with_stratification(input_data, method)
-        
+
         # Otherwise, dispatch to appropriate sampling method
         if method == "first":
             return self._sample_first(input_data)
@@ -195,6 +230,10 @@ class SampleOperation(BaseOperation):
             return self._sample_outliers(input_data)
         elif method == "custom":
             return self._sample_custom(input_data)
+        elif method == "top_embedding":
+            return self._sample_top_embedding(input_data)
+        elif method == "top_fts":
+            return self._sample_top_fts(input_data)
         else:
             raise ValueError(f"Unknown sampling method: {method}")
 
@@ -211,7 +250,7 @@ class SampleOperation(BaseOperation):
     ) -> tuple[list[dict], float]:
         """Apply stratification to any sampling method."""
         samples_per_group = self.config.get("samples_per_group", False)
-        
+
         # Group data by stratification key(s)
         groups = defaultdict(list)
         for item in input_data:
@@ -220,7 +259,7 @@ class SampleOperation(BaseOperation):
         # Apply sampling method to each group
         output_data = []
         total_cost = 0.0
-        
+
         if samples_per_group:
             # Sample N items from each group
             for group_items in groups.values():
@@ -230,9 +269,15 @@ class SampleOperation(BaseOperation):
                     sampled, cost = self._sample_uniform(group_items)
                 elif method == "outliers":
                     sampled, cost = self._sample_outliers(group_items)
+                elif method == "top_embedding":
+                    sampled, cost = self._sample_top_embedding(group_items)
+                elif method == "top_fts":
+                    sampled, cost = self._sample_top_fts(group_items)
                 else:
-                    raise ValueError(f"Method {method} not supported with stratification")
-                
+                    raise ValueError(
+                        f"Method {method} not supported with stratification"
+                    )
+
                 output_data.extend(sampled)
                 total_cost += cost
         else:
@@ -245,9 +290,15 @@ class SampleOperation(BaseOperation):
             elif method == "outliers":
                 # For outliers, we need to handle differently
                 return self._sample_stratified_outliers(input_data, groups)
+            elif method == "top_embedding":
+                return self._sample_stratified_top_embedding(input_data, groups)
+            elif method == "top_fts":
+                return self._sample_stratified_top_fts(input_data, groups)
             else:
-                raise ValueError(f"Method {method} not supported with proportional stratification")
-        
+                raise ValueError(
+                    f"Method {method} not supported with proportional stratification"
+                )
+
         return output_data, total_cost
 
     def _sample_stratified_proportional(
@@ -255,9 +306,9 @@ class SampleOperation(BaseOperation):
     ) -> tuple[list[dict], float]:
         """Traditional stratified sampling with proportional allocation."""
         import sklearn.model_selection
-        
+
         stratify_values = [self._get_stratify_value(item) for item in input_data]
-        
+
         output_data, _ = sklearn.model_selection.train_test_split(
             input_data,
             train_size=self.config["samples"],
@@ -275,7 +326,7 @@ class SampleOperation(BaseOperation):
             n_samples = int(samples * len(input_data))
         else:
             n_samples = samples
-        
+
         # Calculate proportional samples per group
         output_data = []
         for group_key, group_items in groups.items():
@@ -283,7 +334,7 @@ class SampleOperation(BaseOperation):
             group_samples = int(n_samples * group_proportion)
             if group_samples > 0:
                 output_data.extend(group_items[:group_samples])
-        
+
         # If we're short due to rounding, add more from largest group
         while len(output_data) < n_samples and len(output_data) < len(input_data):
             largest_group = max(groups.values(), key=len)
@@ -291,7 +342,7 @@ class SampleOperation(BaseOperation):
                 if item not in output_data:
                     output_data.append(item)
                     break
-        
+
         return output_data[:n_samples], 0.0
 
     def _sample_stratified_outliers(
@@ -300,14 +351,14 @@ class SampleOperation(BaseOperation):
         """Apply outlier detection within each stratum and combine results."""
         output_data = []
         total_cost = 0.0
-        
+
         # Apply outlier detection to each group
         for group_items in groups.values():
             if len(group_items) > 0:
                 sampled, cost = self._sample_outliers(group_items)
                 output_data.extend(sampled)
                 total_cost += cost
-        
+
         return output_data, total_cost
 
     def _sample_first(self, input_data: list[dict]) -> tuple[list[dict], float]:
@@ -322,13 +373,13 @@ class SampleOperation(BaseOperation):
     def _sample_uniform(self, input_data: list[dict]) -> tuple[list[dict], float]:
         """Uniformly sample from input data."""
         import sklearn.model_selection
-        
+
         samples = self.config["samples"]
-        
+
         # Handle the case where we have very few items
         if isinstance(samples, int) and samples >= len(input_data):
             return input_data, 0.0
-        
+
         output_data, _ = sklearn.model_selection.train_test_split(
             input_data,
             train_size=samples,
@@ -339,7 +390,7 @@ class SampleOperation(BaseOperation):
     def _sample_outliers(self, input_data: list[dict]) -> tuple[list[dict], float]:
         """Sample based on outlier detection using embeddings."""
         outliers_config = self.config.get("method_kwargs", {})
-        
+
         # Get embeddings
         embeddings, cost = get_embeddings_for_clustering(
             input_data, outliers_config, self.runner.api
@@ -361,18 +412,22 @@ class SampleOperation(BaseOperation):
 
         # Determine cutoff
         if "std" in outliers_config:
-            cutoff = np.sqrt((embeddings.std(axis=0) ** 2).sum()) * outliers_config["std"]
+            cutoff = (
+                np.sqrt((embeddings.std(axis=0) ** 2).sum()) * outliers_config["std"]
+            )
         else:  # "samples" in method_kwargs
             distance_distribution = np.sort(distances)
             n_samples = outliers_config["samples"]
             if isinstance(n_samples, float):
                 n_samples = int(n_samples * len(distance_distribution))
-            cutoff = distance_distribution[min(n_samples, len(distance_distribution) - 1)]
+            cutoff = distance_distribution[
+                min(n_samples, len(distance_distribution) - 1)
+            ]
 
         # Filter based on cutoff
         keep = outliers_config.get("keep", False)
         include = distances > cutoff if keep else distances <= cutoff
-        
+
         output_data = [item for idx, item in enumerate(input_data) if include[idx]]
         return output_data, cost
 
@@ -381,21 +436,231 @@ class SampleOperation(BaseOperation):
         samples = self.config["samples"]
         if not samples:
             return [], 0.0
-            
+
         # Get keys from first sample
         keys = list(samples[0].keys())
-        
+
         # Create lookup map
-        key_to_doc = {
-            tuple(doc.get(key) for key in keys): doc 
-            for doc in input_data
-        }
-        
+        key_to_doc = {tuple(doc.get(key) for key in keys): doc for doc in input_data}
+
         # Extract requested samples
         output_data = []
         for sample in samples:
             lookup_key = tuple(sample.get(key) for key in keys)
             if lookup_key in key_to_doc:
                 output_data.append(key_to_doc[lookup_key])
-                
+
         return output_data, 0.0
+
+    def _sample_top_embedding(self, input_data: list[dict]) -> tuple[list[dict], float]:
+        """Sample top items based on embedding similarity to a query."""
+        config = self.config.get("method_kwargs", {})
+        keys = config["keys"]
+        query_template = config["query"]
+        samples = self.config["samples"]
+
+        if isinstance(samples, float):
+            n_samples = int(samples * len(input_data))
+        else:
+            n_samples = min(samples, len(input_data))
+
+        if len(input_data) == 0 or n_samples == 0:
+            return [], 0.0
+
+        # Render query template if needed
+        if "{{" in query_template and "}}" in query_template:
+            # Use the first item as context for template rendering
+            query = strict_render(query_template, {"input": input_data[0]})
+        else:
+            query = query_template
+
+        # Get embeddings for all items
+        embedding_config = {
+            "embedding_keys": keys,
+            "embedding_model": config.get("embedding_model", "text-embedding-3-small"),
+        }
+        embeddings, cost = get_embeddings_for_clustering(
+            input_data, embedding_config, self.runner.api
+        )
+        embeddings = np.array(embeddings)
+
+        # Get embedding for query
+        query_embedding, query_cost = get_embeddings_for_clustering(
+            [{key: query for key in keys}], embedding_config, self.runner.api
+        )
+        cost += query_cost
+        query_embedding = np.array(query_embedding[0])
+
+        # Calculate cosine similarities
+        # Normalize vectors
+        embeddings_norm = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
+        query_norm = query_embedding / np.linalg.norm(query_embedding)
+
+        # Compute cosine similarity
+        similarities = np.dot(embeddings_norm, query_norm)
+
+        # Get top N indices
+        top_indices = np.argsort(similarities)[-n_samples:][::-1]
+
+        output_data = [input_data[idx] for idx in top_indices]
+        return output_data, cost
+
+    def _sample_top_fts(self, input_data: list[dict]) -> tuple[list[dict], float]:
+        """Sample top items based on full-text search similarity to a query using BM25."""
+        config = self.config.get("method_kwargs", {})
+        keys = config["keys"]
+        query_template = config["query"]
+        samples = self.config["samples"]
+
+        if isinstance(samples, float):
+            n_samples = int(samples * len(input_data))
+        else:
+            n_samples = min(samples, len(input_data))
+
+        if len(input_data) == 0 or n_samples == 0:
+            return [], 0.0
+
+        # Render query template if needed
+        if "{{" in query_template and "}}" in query_template:
+            # Use the first item as context for template rendering
+            query = strict_render(query_template, {"input": input_data[0]})
+        else:
+            query = query_template
+
+        # Use BM25 for full-text search
+        try:
+            from rank_bm25 import BM25Okapi
+        except ImportError:
+            # Fall back to TF-IDF if rank-bm25 is not installed
+            import re
+
+            from sklearn.feature_extraction.text import TfidfVectorizer
+
+            def normalize_text(text):
+                """Normalize text for better FTS matching."""
+                text = text.lower()
+                text = re.sub(r"\s+", " ", text)
+                text = re.sub(r"[^a-z0-9\s]", " ", text)
+                return text.strip()
+
+            documents = [
+                normalize_text(" ".join(str(item[key]) for key in keys if key in item))
+                for item in input_data
+            ]
+            normalized_query = normalize_text(query)
+
+            if not any(documents):
+                return input_data[:n_samples], 0.0
+
+            vectorizer = TfidfVectorizer(
+                lowercase=True,
+                stop_words="english",
+                ngram_range=(1, 1),  # Use unigrams only for FTS-like behavior
+                max_features=10000,
+                token_pattern=r"\b[a-z0-9]+\b",
+                min_df=1,
+                max_df=0.95,
+            )
+
+            try:
+                tfidf_matrix = vectorizer.fit_transform(documents)
+                query_vector = vectorizer.transform([normalized_query])
+            except ValueError:
+                return input_data[:n_samples], 0.0
+
+            from sklearn.metrics.pairwise import cosine_similarity
+
+            similarities = cosine_similarity(query_vector, tfidf_matrix).flatten()
+            top_indices = np.argsort(similarities)[-n_samples:][::-1]
+            output_data = [input_data[idx] for idx in top_indices]
+            return output_data, 0.0
+
+        import re
+
+        def preprocess_text(text):
+            """Preprocess text for BM25: lowercase, remove punctuation, split into tokens."""
+            # Convert to lowercase
+            text = text.lower()
+            # Remove punctuation and special characters, keep alphanumeric and spaces
+            text = re.sub(r"[^a-z0-9\s]", " ", text)
+            # Remove extra whitespace
+            text = re.sub(r"\s+", " ", text).strip()
+            # Split into tokens
+            return text.split()
+
+        # Create tokenized documents from the specified keys
+        tokenized_docs = []
+        for item in input_data:
+            doc_text = " ".join(str(item[key]) for key in keys if key in item)
+            tokenized_docs.append(preprocess_text(doc_text))
+
+        # Handle empty documents
+        if not any(tokenized_docs):
+            return input_data[:n_samples], 0.0
+
+        # Initialize BM25
+        bm25 = BM25Okapi(tokenized_docs)
+
+        # Tokenize query
+        tokenized_query = preprocess_text(query)
+
+        # Get BM25 scores
+        scores = bm25.get_scores(tokenized_query)
+
+        # Get top N indices
+        top_indices = np.argsort(scores)[-n_samples:][::-1]
+
+        # Filter out documents with zero scores if needed
+        top_indices = [idx for idx in top_indices if scores[idx] > 0]
+
+        # If we don't have enough matches with positive scores, add highest scoring docs
+        if len(top_indices) < n_samples:
+            remaining_indices = np.argsort(scores)[::-1]
+            for idx in remaining_indices:
+                if idx not in top_indices and len(top_indices) < n_samples:
+                    top_indices.append(idx)
+
+        output_data = [input_data[idx] for idx in top_indices[:n_samples]]
+        return output_data, 0.0
+
+    def _sample_stratified_top_embedding(
+        self, input_data: list[dict], groups: dict
+    ) -> tuple[list[dict], float]:
+        """Apply top embedding sampling within each stratum and combine results."""
+        output_data = []
+        total_cost = 0.0
+
+        # Apply top embedding sampling to each group
+        for group_items in groups.values():
+            if len(group_items) > 0:
+                sampled, cost = self._sample_top_embedding(group_items)
+                output_data.extend(sampled)
+                total_cost += cost
+
+        # If we have too many items, take the top ones across all groups
+        if len(output_data) > self.config["samples"]:
+            # Re-rank all selected items
+            return self._sample_top_embedding(output_data)
+
+        return output_data, total_cost
+
+    def _sample_stratified_top_fts(
+        self, input_data: list[dict], groups: dict
+    ) -> tuple[list[dict], float]:
+        """Apply top FTS sampling within each stratum and combine results."""
+        output_data = []
+        total_cost = 0.0
+
+        # Apply top FTS sampling to each group
+        for group_items in groups.values():
+            if len(group_items) > 0:
+                sampled, cost = self._sample_top_fts(group_items)
+                output_data.extend(sampled)
+                total_cost += cost
+
+        # If we have too many items, take the top ones across all groups
+        if len(output_data) > self.config["samples"]:
+            # Re-rank all selected items
+            return self._sample_top_fts(output_data)
+
+        return output_data, total_cost

--- a/docetl/operations/topk.py
+++ b/docetl/operations/topk.py
@@ -1,0 +1,235 @@
+"""TopK operation for retrieving top documents by similarity."""
+
+from typing import Literal, Union
+
+from pydantic import Field, field_validator, model_validator
+
+from docetl.operations.base import BaseOperation
+from docetl.operations.rank import RankOperation
+from docetl.operations.sample import SampleOperation
+
+
+class TopKOperation(BaseOperation):
+    """
+    Retrieves top-k items based on similarity to a query using embeddings or full-text search.
+
+    This operation is a specialized interface for the sample operation's top_embedding
+    and top_fts methods, providing a cleaner API for retrieval use cases.
+
+    Attributes:
+        method: "embedding" for semantic similarity or "fts" for full-text search
+        k: Number of items to retrieve (int or float for percentage)
+        keys: List of keys to use for similarity matching
+        query: Query string (supports Jinja templates with {{ input.field }})
+        stratify_key: Optional key(s) for stratified retrieval
+        embedding_model: Model to use for embeddings (only for embedding method)
+    """
+
+    class schema(BaseOperation.schema):
+        type: str = "topk"
+        method: Literal["embedding", "fts", "llm_compare"]
+        k: Union[int, float] = Field(..., description="Number of items to retrieve")
+        keys: list[str] = Field(
+            ..., description="Keys to use for similarity matching or comparison"
+        )
+        query: str = Field(
+            ...,
+            description="Query string for similarity or comparison criteria (supports Jinja templates)",
+        )
+        stratify_key: Union[str, list[str]] | None = Field(
+            None, description="Key(s) for stratified retrieval"
+        )
+        embedding_model: str | None = Field(
+            "text-embedding-3-small",
+            description="Embedding model (for embedding and llm_compare methods)",
+        )
+        model: str | None = Field(None, description="LLM model for llm_compare method")
+        batch_size: int | None = Field(
+            10, description="Batch size for LLM comparisons in llm_compare method"
+        )
+
+        @field_validator("k")
+        def validate_k(cls, v):
+            if isinstance(v, (int, float)):
+                if v <= 0:
+                    raise ValueError("'k' must be a positive number")
+            else:
+                raise TypeError("'k' must be an integer or float")
+            return v
+
+        @field_validator("keys")
+        def validate_keys(cls, v):
+            if not v:
+                raise ValueError("'keys' cannot be empty")
+            if not all(isinstance(key, str) for key in v):
+                raise TypeError("All items in 'keys' must be strings")
+            return v
+
+        @field_validator("query")
+        def validate_query(cls, v):
+            if not v or not v.strip():
+                raise ValueError("'query' cannot be empty")
+            return v
+
+        @field_validator("stratify_key")
+        def validate_stratify_key(cls, v):
+            if v is None:
+                return v
+
+            if isinstance(v, str):
+                pass  # Single key is valid
+            elif isinstance(v, list):
+                if not v:
+                    raise ValueError("'stratify_key' list cannot be empty")
+                if not all(isinstance(key, str) for key in v):
+                    raise TypeError("All items in 'stratify_key' must be strings")
+            else:
+                raise TypeError("'stratify_key' must be a string or list of strings")
+
+            return v
+
+        @model_validator(mode="after")
+        def validate_method_specific_fields(self):
+            """Validate method-specific fields."""
+            # FTS doesn't need embedding_model
+            if (
+                self.method == "fts"
+                and self.embedding_model != "text-embedding-3-small"
+            ):
+                print("Warning: 'embedding_model' is ignored when method='fts'")
+
+            # llm_compare specific validations
+            if self.method == "llm_compare":
+                # Needs model
+                if not self.model:
+                    raise ValueError(
+                        "'model' must be specified when method='llm_compare'"
+                    )
+
+                # Doesn't support stratification (rank operates on entire dataset)
+                if self.stratify_key:
+                    raise ValueError(
+                        "'stratify_key' is not supported with method='llm_compare'"
+                    )
+
+                # Doesn't support Jinja templates (needs consistent criteria)
+                if "{{" in self.query or "}}" in self.query:
+                    raise ValueError(
+                        "'query' cannot contain Jinja templates ({{ }}) when method='llm_compare'. "
+                        "The ranking criteria must be consistent across all documents."
+                    )
+
+            return self
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def execute(
+        self, input_data: list[dict], is_build: bool = False
+    ) -> tuple[list[dict], float]:
+        """
+        Execute the topk operation by delegating to appropriate operation.
+
+        Args:
+            input_data: List of dictionaries to retrieve from
+            is_build: Whether this is a build phase execution
+
+        Returns:
+            Tuple of (top_k_items, cost)
+        """
+        # Handle llm_compare method using RankOperation
+        if self.config["method"] == "llm_compare":
+            return self._execute_llm_compare(input_data, is_build)
+
+        # Handle embedding and fts methods using SampleOperation
+        # Build sample configuration
+        sample_config = {
+            "name": self.config.get("name", "topk_operation"),
+            "type": "sample",
+            "method": f"top_{self.config['method']}",
+            "samples": self.config["k"],
+            "method_kwargs": {
+                "keys": self.config["keys"],
+                "query": self.config["query"],
+            },
+        }
+
+        # Add stratification if specified
+        if self.config.get("stratify_key"):
+            sample_config["stratify_key"] = self.config["stratify_key"]
+            # When stratifying, we want to retrieve top-k from each group
+            sample_config["samples_per_group"] = True
+
+        # Add embedding model for embedding method
+        if self.config["method"] == "embedding":
+            sample_config["method_kwargs"]["embedding_model"] = self.config.get(
+                "embedding_model", "text-embedding-3-small"
+            )
+
+        # Add any additional config like random_state, bypass_cache
+        if "random_state" in self.config:
+            sample_config["random_state"] = self.config["random_state"]
+        if "bypass_cache" in self.config:
+            sample_config["bypass_cache"] = self.config["bypass_cache"]
+
+        # Create and execute sample operation
+        sample_op = SampleOperation(
+            self.runner, sample_config, self.default_model, self.max_threads
+        )
+
+        return sample_op.execute(input_data, is_build)
+
+    def _execute_llm_compare(
+        self, input_data: list[dict], is_build: bool = False
+    ) -> tuple[list[dict], float]:
+        """
+        Execute LLM-based comparison using RankOperation.
+
+        Args:
+            input_data: List of dictionaries to rank
+            is_build: Whether this is a build phase execution
+
+        Returns:
+            Tuple of (top_k_items, cost)
+        """
+        # Build rank configuration
+        rank_config = {
+            "name": self.config.get("name", "topk_llm_operation"),
+            "type": "order",
+            "prompt": self.config["query"],  # Use query as the ranking criteria
+            "input_keys": self.config["keys"],
+            "direction": "desc",  # We want highest ranking items first for top-k
+            "model": self.config["model"],
+            "k": (
+                self.config["k"]
+                if isinstance(self.config["k"], int)
+                else int(self.config["k"] * len(input_data))
+            ),
+            "initial_ordering_method": "embedding",
+            "embedding_model": self.config.get(
+                "embedding_model", "text-embedding-3-small"
+            ),
+            "batch_size": self.config.get("batch_size", 10),
+            "rerank_call_budget": 100,  # Default budget for reranking
+        }
+
+        # Add optional configs
+        if "bypass_cache" in self.config:
+            rank_config["bypass_cache"] = self.config["bypass_cache"]
+        if "timeout" in self.config:
+            rank_config["timeout"] = self.config["timeout"]
+
+        # Create and execute rank operation
+        rank_op = RankOperation(
+            self.runner, rank_config, self.default_model, self.max_threads
+        )
+
+        # Get ranked results
+        ranked_results, cost = rank_op.execute(input_data)
+
+        # Return only top k items
+        k = self.config["k"]
+        if isinstance(k, float):
+            k = int(k * len(input_data))
+
+        return ranked_results[:k], cost

--- a/docs/operators/topk.md
+++ b/docs/operators/topk.md
@@ -1,0 +1,214 @@
+# TopK Operation
+
+The TopK operation retrieves the most relevant items from your dataset using three different retrieval methods: semantic similarity, full-text search, or LLM-based comparison. It provides a clean, specialized interface for retrieval tasks where you need to find and rank the best matching documents based on specific criteria.
+
+## Overview
+
+TopK is designed for retrieval and ranking use cases such as finding relevant documents for a query, filtering large datasets to the most important items, implementing retrieval-augmented generation (RAG) pipelines, and building recommendation systems. Unlike general sampling operations, TopK focuses specifically on retrieving the best matches according to your chosen method and criteria.
+
+The operation supports three distinct retrieval methods, each optimized for different use cases. The **embedding method** uses semantic similarity to find conceptually related documents, making it ideal when meaning matters more than exact words. The **full-text search (FTS) method** employs the BM25 algorithm for keyword-based retrieval, perfect for when specific terms are important. The **LLM compare method** leverages a language model to rank documents based on complex criteria that require reasoning and multi-factor comparisons.
+
+## Configuration
+
+### Core Parameters
+
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+| `method` | `"embedding"` \| `"fts"` \| `"llm_compare"` | Retrieval method to use | Yes |
+| `k` | `int` or `float` | Number of items to retrieve (float = percentage) | Yes |
+| `keys` | `list[str]` | Document fields to use for matching/comparison | Yes |
+| `query` | `str` | Query or ranking criteria (Jinja templates supported for `embedding` and `fts` only) | Yes |
+
+### Method-Specific Parameters
+
+| Parameter | Type | Methods | Description | Default |
+|-----------|------|---------|-------------|---------|
+| `embedding_model` | `str` | `embedding`, `llm_compare` | Model for embeddings | `"text-embedding-3-small"` |
+| `model` | `str` | `llm_compare` | LLM model for comparisons | Required for `llm_compare` |
+| `batch_size` | `int` | `llm_compare` | Batch size for LLM ranking | `10` |
+| `stratify_key` | `str` or `list[str]` | `embedding`, `fts` | Keys for stratified retrieval | `None` |
+
+## Examples
+
+### Semantic Search with Embeddings
+
+When you need to find documents based on meaning rather than exact keywords, the embedding method excels. This example finds support tickets semantically similar to payment processing issues:
+
+```yaml
+- name: find_relevant_tickets
+  type: topk
+  method: embedding
+  k: 5
+  keys: 
+    - subject
+    - description
+    - customer_feedback
+  query: "payment processing errors with international transactions"
+  embedding_model: text-embedding-3-small
+```
+
+### Keyword Search with FTS
+
+For cases where specific terms matter, such as searching a product catalog, the FTS method provides fast, accurate keyword matching without API costs:
+
+```yaml
+- name: search_products
+  type: topk
+  method: fts
+  k: 20
+  keys:
+    - product_name
+    - description
+    - category
+    - tags
+  query: "wireless noise cancelling headphones bluetooth"
+```
+
+### Complex Ranking with LLM Compare
+
+When you need to rank items based on multiple factors or subjective criteria, the LLM compare method allows you to specify complex ranking logic. Note that this method requires consistent criteria across all documents and doesn't support Jinja templates:
+
+```yaml
+- name: screen_resumes
+  type: topk
+  method: llm_compare
+  k: 10
+  keys:
+    - skills
+    - experience
+    - education
+  query: |
+    Rank candidates based on their fit for a Senior Backend Engineer role requiring:
+    - 5+ years Python experience
+    - Distributed systems expertise
+    - Strong knowledge of PostgreSQL and Redis
+    - Experience with microservices architecture
+    - Leadership experience is a plus
+    
+    Prioritize hands-on technical experience over academic credentials.
+  model: gpt-4o
+  batch_size: 5
+```
+
+### Dynamic Queries with Templates
+
+The embedding and FTS methods support Jinja templates for dynamic queries that adapt based on input data. This enables personalized search experiences:
+
+```yaml
+- name: personalized_search
+  type: topk
+  method: embedding
+  k: 10
+  keys:
+    - content
+    - tags
+  query: |
+    {{ input.user_preferences }} 
+    Focus on {{ input.topic_of_interest }}
+    Exclude anything related to {{ input.blocked_topics }}
+```
+
+### Stratified Retrieval
+
+Both embedding and FTS methods support stratification, which ensures you retrieve top items from each group. This is useful for maintaining diversity in results:
+
+```yaml
+- name: recommendations_by_category
+  type: topk
+  method: fts
+  k: 3  # Get top 3 from each category
+  keys:
+    - product_name
+    - description
+  query: "premium quality bestseller"
+  stratify_key: category
+```
+
+## Common Patterns
+
+### Single-Document RAG Pipeline
+
+A retrieval-augmented generation pipeline for answering questions about a single document typically retrieves the most relevant chunks, then synthesizes them into a coherent answer using reduce:
+
+```yaml
+# Step 1: Retrieve most relevant document chunks
+- name: retrieve_context
+  type: topk
+  method: embedding
+  k: 5
+  keys: [content]
+  query: "{{ input.user_question }}"
+
+# Step 2: Generate comprehensive answer from all retrieved chunks
+- name: generate_answer
+  type: reduce
+  reduce_key: user_question  # Group by the question
+  prompt: |
+    Based on the following document excerpts, provide a comprehensive answer to the question.
+    
+    Question: {{ inputs[0].user_question }}
+    
+    Retrieved context from document:
+    {% for chunk in inputs %}
+    - {{ chunk.content }}
+    {% endfor %}
+    
+    Synthesize the information from all excerpts into a single, coherent answer.
+  output_schema:
+    answer: string
+```
+
+### Multi-Stage Filtering
+
+For complex retrieval tasks, you might combine multiple TopK operations with different methods, progressively refining your results:
+
+```yaml
+# Cast a wide net with keyword search
+- name: initial_search
+  type: topk
+  method: fts
+  k: 100
+  keys: [title, content]
+  query: "machine learning"
+
+# Refine with semantic search
+- name: refine_results
+  type: topk
+  method: embedding
+  k: 20
+  keys: [title, content]
+  query: "practical applications of deep learning in healthcare"
+
+# Final ranking with LLM
+- name: final_ranking
+  type: topk
+  method: llm_compare
+  k: 5
+  keys: [title, abstract, impact_factor]
+  query: "Rank by potential clinical impact and implementation feasibility"
+  model: gpt-4o
+```
+
+## Performance Considerations
+
+Each retrieval method has different performance characteristics that should guide your choice. The **FTS method** is the fastest and has no API costs since it uses local BM25 scoring, making it ideal for high-volume or cost-sensitive applications. The **embedding method** requires API calls to generate embeddings for both documents and queries, but once computed, similarity matching is very fast. It provides excellent semantic understanding but at a moderate cost. The **LLM compare method** has the highest cost and slowest performance due to multiple LLM calls, but offers unmatched flexibility for complex ranking criteria.
+
+When optimizing performance, consider preprocessing embeddings offline for the embedding method, using FTS for initial filtering before applying more expensive methods, and carefully tuning the batch_size parameter for LLM compare to balance speed and accuracy.
+
+## Implementation Details
+
+### Embedding Method
+
+The embedding method converts both your documents and query into high-dimensional vectors using the specified embedding model (defaulting to OpenAI's text-embedding-3-small). It then calculates cosine similarity between the query vector and each document vector, returning the k documents with highest similarity scores. The method handles text normalization and truncation automatically, and when stratification is enabled, it performs this process independently for each stratum.
+
+### FTS Method
+
+The full-text search method uses the BM25 algorithm, the same ranking function used by search engines like Elasticsearch. Documents are tokenized and lowercase-normalized, with special characters removed. The BM25 scoring function considers term frequency (with saturation to prevent overweighting repeated terms), inverse document frequency (giving more weight to rare terms), and document length normalization. The implementation uses the rank-bm25 library for efficient scoring.
+
+### LLM Compare Method
+
+The LLM compare method delegates to the rank operation, which implements sophisticated comparison algorithms from human-powered sorting research. It starts with an initial ordering using embeddings, then applies sliding windows of documents for pairwise comparison by the LLM. The LLM evaluates documents in batches (controlled by batch_size) and produces rankings based on the specified criteria. This method requires consistent ranking criteria across all documents, which is why Jinja templates are not supported—the LLM needs to compare all documents using the same criteria for fair ranking.
+
+## Error Handling
+
+The TopK operation is designed to handle edge cases gracefully. If k exceeds the number of available documents, it returns all available items rather than failing. When specified keys are missing from some documents, it uses whatever fields are available. For the FTS method, documents with empty text after normalization are handled appropriately, and for the embedding method, API failures include automatic retries with exponential backoff.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
           - Gather: operators/gather.md
           - Unnest: operators/unnest.md
           - Sample: operators/sample.md
+          - TopK: operators/topk.md
           - Code: operators/code.md
       - APIs:
           - Python API Guide: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "pandas>=2.3.0",
   "python-multipart>=0.0.20",
   "litellm>=1.75.4",
+  "rank-bm25>=0.2.2",
 ]
 
 # Optional extras mapped from Poetry extras and optional deps
@@ -66,6 +67,7 @@ resolve = "docetl.operations.resolve:ResolveOperation"
 gather = "docetl.operations.gather:GatherOperation"
 cluster = "docetl.operations.cluster:ClusterOperation"
 sample = "docetl.operations.sample:SampleOperation"
+topk = "docetl.operations.topk:TopKOperation"
 link_resolve = "docetl.operations.link_resolve:LinkResolveOperation"
 code_map = "docetl.operations.code_operations:CodeMapOperation"
 code_reduce = "docetl.operations.code_operations:CodeReduceOperation"

--- a/tests/basic/test_sample_top_methods.py
+++ b/tests/basic/test_sample_top_methods.py
@@ -1,0 +1,497 @@
+"""Tests for top_embedding and top_fts sample methods."""
+
+import pytest
+from docetl.operations.sample import SampleOperation
+from tests.conftest import runner, default_model, max_threads
+
+
+@pytest.fixture
+def sample_documents():
+    """Sample documents with different topics for testing."""
+    return [
+        {
+            "id": 1,
+            "title": "Python Programming",
+            "content": "Python is a high-level programming language known for its simplicity and readability.",
+            "category": "programming",
+            "subcategory": "languages",
+        },
+        {
+            "id": 2,
+            "title": "Machine Learning Basics",
+            "content": "Machine learning is a subset of artificial intelligence that enables systems to learn from data.",
+            "category": "ai",
+            "subcategory": "ml",
+        },
+        {
+            "id": 3,
+            "title": "JavaScript Frameworks",
+            "content": "JavaScript frameworks like React and Vue help developers build modern web applications efficiently.",
+            "category": "programming",
+            "subcategory": "web",
+        },
+        {
+            "id": 4,
+            "title": "Deep Learning",
+            "content": "Deep learning uses neural networks with multiple layers to process complex patterns in data.",
+            "category": "ai",
+            "subcategory": "dl",
+        },
+        {
+            "id": 5,
+            "title": "Database Design",
+            "content": "Good database design ensures efficient data storage and retrieval in applications.",
+            "category": "programming",
+            "subcategory": "databases",
+        },
+        {
+            "id": 6,
+            "title": "Natural Language Processing",
+            "content": "NLP enables computers to understand, interpret, and generate human language.",
+            "category": "ai",
+            "subcategory": "nlp",
+        },
+        {
+            "id": 7,
+            "title": "Web Development",
+            "content": "Web development involves creating websites and web applications using HTML, CSS, and JavaScript.",
+            "category": "programming",
+            "subcategory": "web",
+        },
+        {
+            "id": 8,
+            "title": "Computer Vision",
+            "content": "Computer vision allows machines to interpret and understand visual information from images and videos.",
+            "category": "ai",
+            "subcategory": "cv",
+        },
+    ]
+
+
+class TestTopEmbedding:
+    """Tests for the top_embedding sampling method."""
+
+    def test_top_embedding_basic(self, sample_documents, runner, default_model, max_threads):
+        """Test basic top_embedding functionality without stratification."""
+        config = {
+            "name": "test_top_embedding",
+            "type": "sample",
+            "method": "top_embedding",
+            "samples": 3,
+            "method_kwargs": {
+                "keys": ["title", "content"],
+                "query": "artificial intelligence and machine learning",
+                "embedding_model": "text-embedding-3-small",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should return 3 items
+        assert len(results) == 3
+        assert cost > 0  # Embedding calls have a cost
+        
+        # Results should be AI-related documents (IDs 2, 4, 6, 8)
+        ai_ids = {2, 4, 6, 8}
+        result_ids = {doc["id"] for doc in results}
+        assert result_ids.issubset(ai_ids), f"Expected AI-related docs, got IDs: {result_ids}"
+
+    def test_top_embedding_with_template(self, sample_documents, runner, default_model, max_threads):
+        """Test top_embedding with Jinja template in query."""
+        # Modify first document to have a query field
+        docs_with_query = sample_documents.copy()
+        docs_with_query[0]["user_query"] = "web programming tutorials"
+        
+        config = {
+            "name": "test_top_embedding_template",
+            "type": "sample",
+            "method": "top_embedding",
+            "samples": 2,
+            "method_kwargs": {
+                "keys": ["title", "content"],
+                "query": "{{ input.user_query }}",
+                "embedding_model": "text-embedding-3-small",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs_with_query)
+        
+        assert len(results) == 2
+        assert cost > 0
+        
+        # Should return web-related documents
+        web_ids = {3, 7}  # JavaScript Frameworks and Web Development
+        result_ids = {doc["id"] for doc in results}
+        # At least one should be web-related
+        assert len(result_ids.intersection(web_ids)) >= 1
+
+    def test_top_embedding_with_stratification(self, sample_documents, runner, default_model, max_threads):
+        """Test top_embedding with stratification by category."""
+        config = {
+            "name": "test_top_embedding_stratified",
+            "type": "sample",
+            "method": "top_embedding",
+            "samples": 4,
+            "stratify_key": "category",
+            "samples_per_group": True,  # Sample from each group
+            "method_kwargs": {
+                "keys": ["title", "content"],
+                "query": "advanced techniques and frameworks",
+                "embedding_model": "text-embedding-3-small",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should return samples from both categories
+        assert len(results) > 0
+        assert cost > 0
+        
+        # Check that we have results from both categories
+        categories = {doc["category"] for doc in results}
+        assert "programming" in categories
+        assert "ai" in categories
+
+    def test_top_embedding_float_samples(self, sample_documents, runner, default_model, max_threads):
+        """Test top_embedding with float sample size (percentage)."""
+        config = {
+            "name": "test_top_embedding_float",
+            "type": "sample",
+            "method": "top_embedding",
+            "samples": 0.5,  # 50% of documents
+            "method_kwargs": {
+                "keys": ["title"],
+                "query": "programming",
+                "embedding_model": "text-embedding-3-small",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should return 4 documents (50% of 8)
+        assert len(results) == 4
+        assert cost > 0
+
+    def test_top_embedding_empty_data(self, runner, default_model, max_threads):
+        """Test top_embedding with empty input data."""
+        config = {
+            "name": "test_top_embedding_empty",
+            "type": "sample",
+            "method": "top_embedding",
+            "samples": 3,
+            "method_kwargs": {
+                "keys": ["title"],
+                "query": "test query",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute([])
+        
+        assert len(results) == 0
+        assert cost == 0
+
+
+class TestTopFTS:
+    """Tests for the top_fts sampling method."""
+
+    def test_top_fts_basic(self, sample_documents, runner, default_model, max_threads):
+        """Test basic top_fts functionality without stratification."""
+        config = {
+            "name": "test_top_fts",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 3,
+            "method_kwargs": {
+                "keys": ["title", "content"],
+                "query": "machine learning neural networks",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should return 3 items
+        assert len(results) == 3
+        assert cost == 0  # FTS doesn't use API calls
+        
+        # Should prioritize ML/DL documents
+        ml_ids = {2, 4}  # Machine Learning Basics and Deep Learning
+        result_ids = {doc["id"] for doc in results}
+        # At least one should be ML-related
+        assert len(result_ids.intersection(ml_ids)) >= 1
+
+    def test_top_fts_text_normalization(self, runner, default_model, max_threads):
+        """Test that FTS properly normalizes text (lowercase, special chars)."""
+        docs = [
+            {"id": 1, "text": "UPPERCASE TEXT WITH SPECIAL CHARS!!!"},
+            {"id": 2, "text": "lowercase text with special chars..."},
+            {"id": 3, "text": "MiXeD CaSe TeXt #$%^&*"},
+            {"id": 4, "text": "normal text without issues"},
+        ]
+        
+        config = {
+            "name": "test_fts_normalization",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 2,
+            "method_kwargs": {
+                "keys": ["text"],
+                "query": "UPPERCASE text",  # Query with mixed case
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs)
+        
+        assert len(results) == 2
+        assert cost == 0
+        
+        # Should match documents 1 and 2 (both have "text" and one has "uppercase")
+        result_ids = {doc["id"] for doc in results}
+        assert 1 in result_ids  # Has both "uppercase" and "text"
+
+    def test_top_fts_with_template(self, sample_documents, runner, default_model, max_threads):
+        """Test top_fts with Jinja template in query."""
+        docs_with_query = sample_documents.copy()
+        docs_with_query[0]["search_term"] = "JavaScript React Vue"
+        
+        config = {
+            "name": "test_fts_template",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 2,
+            "method_kwargs": {
+                "keys": ["title", "content"],
+                "query": "{{ input.search_term }}",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs_with_query)
+        
+        assert len(results) == 2
+        assert cost == 0
+        
+        # Should return JavaScript Frameworks (ID 3) as top result
+        result_ids = [doc["id"] for doc in results]
+        assert 3 in result_ids
+
+    def test_top_fts_with_stratification(self, sample_documents, runner, default_model, max_threads):
+        """Test top_fts with stratification by category."""
+        config = {
+            "name": "test_fts_stratified",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 4,
+            "stratify_key": "category",
+            "samples_per_group": True,
+            "method_kwargs": {
+                "keys": ["title", "content"],
+                "query": "learning data",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        assert len(results) > 0
+        assert cost == 0
+        
+        # Check that we have results from both categories
+        categories = {doc["category"] for doc in results}
+        assert len(categories) == 2  # Should have both categories
+
+    def test_top_fts_with_multiple_stratify_keys(self, sample_documents, runner, default_model, max_threads):
+        """Test top_fts with multiple stratification keys."""
+        config = {
+            "name": "test_fts_multi_stratified",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 4,
+            "stratify_key": ["category", "subcategory"],
+            "samples_per_group": True,
+            "method_kwargs": {
+                "keys": ["content"],
+                "query": "development",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        assert len(results) > 0
+        assert cost == 0
+
+    def test_top_fts_ngrams(self, runner, default_model, max_threads):
+        """Test BM25 ranking with phrase-like queries."""
+        docs = [
+            {"id": 1, "text": "machine learning is powerful"},
+            {"id": 2, "text": "learning machine basics"},
+            {"id": 3, "text": "powerful machines for learning"},
+            {"id": 4, "text": "basic machine operation"},
+        ]
+        
+        config = {
+            "name": "test_fts_ngrams",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 2,
+            "method_kwargs": {
+                "keys": ["text"],
+                "query": "machine learning",  # BM25 will match both terms
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs)
+        
+        assert len(results) == 2
+        assert cost == 0
+        
+        # Documents with both "machine" and "learning" should rank higher
+        result_ids = {doc["id"] for doc in results}
+        # Docs 1 and 2 have both terms
+        assert 1 in result_ids or 2 in result_ids
+
+    def test_top_fts_empty_documents(self, runner, default_model, max_threads):
+        """Test top_fts with documents that have empty text."""
+        docs = [
+            {"id": 1, "text": ""},
+            {"id": 2, "text": ""},
+            {"id": 3, "text": "some content here"},
+        ]
+        
+        config = {
+            "name": "test_fts_empty_docs",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 2,
+            "method_kwargs": {
+                "keys": ["text"],
+                "query": "content",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs)
+        
+        # Should handle empty documents gracefully
+        assert len(results) == 2
+        assert cost == 0
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error conditions."""
+
+    def test_missing_keys_parameter(self, runner, default_model, max_threads):
+        """Test that missing 'keys' parameter raises an error."""
+        config = {
+            "name": "test_missing_keys",
+            "type": "sample",
+            "method": "top_embedding",
+            "samples": 3,
+            "method_kwargs": {
+                "query": "test query",
+                # Missing 'keys'
+            },
+        }
+        
+        with pytest.raises(ValueError, match="'keys' must be specified"):
+            SampleOperation(runner, config, default_model, max_threads)
+
+    def test_missing_query_parameter(self, runner, default_model, max_threads):
+        """Test that missing 'query' parameter raises an error."""
+        config = {
+            "name": "test_missing_query",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 3,
+            "method_kwargs": {
+                "keys": ["title"],
+                # Missing 'query'
+            },
+        }
+        
+        with pytest.raises(ValueError, match="'query' must be specified"):
+            SampleOperation(runner, config, default_model, max_threads)
+
+    def test_missing_samples_parameter(self, runner, default_model, max_threads):
+        """Test that missing 'samples' parameter raises an error."""
+        config = {
+            "name": "test_missing_samples",
+            "type": "sample",
+            "method": "top_embedding",
+            # Missing 'samples'
+            "method_kwargs": {
+                "keys": ["title"],
+                "query": "test",
+            },
+        }
+        
+        with pytest.raises(ValueError, match="Must specify 'samples'"):
+            SampleOperation(runner, config, default_model, max_threads)
+
+    def test_samples_exceed_data_size(self, sample_documents, runner, default_model, max_threads):
+        """Test requesting more samples than available data."""
+        config = {
+            "name": "test_exceed_samples",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 100,  # More than 8 documents
+            "method_kwargs": {
+                "keys": ["title"],
+                "query": "test",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should return all available documents
+        assert len(results) == len(sample_documents)
+        assert cost == 0
+
+    def test_nonexistent_keys_in_documents(self, runner, default_model, max_threads):
+        """Test behavior when specified keys don't exist in documents."""
+        docs = [
+            {"id": 1, "title": "Document 1"},
+            {"id": 2, "title": "Document 2"},
+            {"id": 3, "title": "Document 3"},
+        ]
+        
+        config = {
+            "name": "test_nonexistent_keys",
+            "type": "sample",
+            "method": "top_fts",
+            "samples": 2,
+            "method_kwargs": {
+                "keys": ["title", "nonexistent_field"],
+                "query": "document",
+            },
+            "bypass_cache": True,
+        }
+        
+        operation = SampleOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs)
+        
+        # Should handle missing keys gracefully
+        assert len(results) == 2
+        assert cost == 0

--- a/tests/basic/test_topk.py
+++ b/tests/basic/test_topk.py
@@ -1,0 +1,503 @@
+"""Tests for TopK operation."""
+
+import pytest
+from docetl.operations.topk import TopKOperation
+from tests.conftest import runner, default_model, max_threads
+
+
+@pytest.fixture
+def sample_documents():
+    """Sample documents for testing topk retrieval."""
+    return [
+        {
+            "id": 1,
+            "title": "Introduction to Python",
+            "content": "Python is a versatile programming language great for beginners.",
+            "category": "programming",
+        },
+        {
+            "id": 2,
+            "title": "Machine Learning Fundamentals",
+            "content": "Machine learning enables computers to learn from data without explicit programming.",
+            "category": "ai",
+        },
+        {
+            "id": 3,
+            "title": "Web Development with JavaScript",
+            "content": "JavaScript powers interactive web applications and modern frameworks.",
+            "category": "programming",
+        },
+        {
+            "id": 4,
+            "title": "Deep Learning and Neural Networks",
+            "content": "Deep learning uses artificial neural networks to solve complex problems.",
+            "category": "ai",
+        },
+        {
+            "id": 5,
+            "title": "Database Management Systems",
+            "content": "Databases organize and store data efficiently for applications.",
+            "category": "programming",
+        },
+        {
+            "id": 6,
+            "title": "Natural Language Processing",
+            "content": "NLP helps computers understand and generate human language.",
+            "category": "ai",
+        },
+    ]
+
+
+class TestTopKEmbedding:
+    """Tests for TopK operation with embedding method."""
+
+    def test_topk_embedding_basic(self, sample_documents, runner, default_model, max_threads):
+        """Test basic topk embedding retrieval."""
+        config = {
+            "name": "test_topk_embedding",
+            "type": "topk",
+            "method": "embedding",
+            "k": 2,
+            "keys": ["title", "content"],
+            "query": "artificial intelligence and deep learning",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        assert len(results) == 2
+        assert cost > 0  # Embedding calls have cost
+        
+        # Should retrieve AI-related documents
+        ai_ids = {2, 4, 6}
+        result_ids = {doc["id"] for doc in results}
+        assert result_ids.issubset(ai_ids)
+
+    def test_topk_embedding_with_stratification(self, sample_documents, runner, default_model, max_threads):
+        """Test topk embedding with stratification."""
+        config = {
+            "name": "test_topk_stratified",
+            "type": "topk",
+            "method": "embedding",
+            "k": 2,  # Will get 2 from each category
+            "keys": ["content"],
+            "query": "modern development techniques",
+            "stratify_key": "category",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should get results from both categories
+        categories = {doc["category"] for doc in results}
+        assert "programming" in categories
+        assert "ai" in categories
+        assert cost > 0
+
+    def test_topk_embedding_percentage(self, sample_documents, runner, default_model, max_threads):
+        """Test topk with percentage instead of fixed count."""
+        config = {
+            "name": "test_topk_percentage",
+            "type": "topk",
+            "method": "embedding",
+            "k": 0.5,  # 50% of documents
+            "keys": ["title"],
+            "query": "programming",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should return 3 documents (50% of 6)
+        assert len(results) == 3
+        assert cost > 0
+
+    def test_topk_embedding_with_custom_model(self, sample_documents, runner, default_model, max_threads):
+        """Test topk with custom embedding model."""
+        config = {
+            "name": "test_topk_custom_model",
+            "type": "topk",
+            "method": "embedding",
+            "k": 2,
+            "keys": ["title", "content"],
+            "query": "data science",
+            "embedding_model": "text-embedding-3-large",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        assert len(results) == 2
+        assert cost > 0
+
+
+class TestTopKFTS:
+    """Tests for TopK operation with FTS method."""
+
+    def test_topk_fts_basic(self, sample_documents, runner, default_model, max_threads):
+        """Test basic topk FTS retrieval."""
+        config = {
+            "name": "test_topk_fts",
+            "type": "topk",
+            "method": "fts",
+            "k": 2,
+            "keys": ["title", "content"],
+            "query": "machine learning neural networks",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        assert len(results) == 2
+        assert cost == 0  # FTS doesn't use API calls
+        
+        # Should prioritize ML/DL documents
+        ml_ids = {2, 4}
+        result_ids = {doc["id"] for doc in results}
+        assert len(result_ids.intersection(ml_ids)) >= 1
+
+    def test_topk_fts_with_template(self, sample_documents, runner, default_model, max_threads):
+        """Test topk FTS with Jinja template query."""
+        docs = sample_documents.copy()
+        docs[0]["search_query"] = "JavaScript web development"
+        
+        config = {
+            "name": "test_topk_fts_template",
+            "type": "topk",
+            "method": "fts",
+            "k": 2,
+            "keys": ["title", "content"],
+            "query": "{{ input.search_query }}",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs)
+        
+        assert len(results) == 2
+        assert cost == 0
+        
+        # Should find JavaScript document
+        result_ids = [doc["id"] for doc in results]
+        assert 3 in result_ids
+
+    def test_topk_fts_stratified(self, sample_documents, runner, default_model, max_threads):
+        """Test topk FTS with stratification."""
+        config = {
+            "name": "test_topk_fts_stratified",
+            "type": "topk",
+            "method": "fts",
+            "k": 1,  # Get 1 from each category
+            "keys": ["content"],
+            "query": "learning",
+            "stratify_key": "category",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should get at least one from each category that has "learning"
+        assert len(results) >= 2
+        assert cost == 0
+        categories = {doc["category"] for doc in results}
+        assert len(categories) == 2
+
+    def test_topk_fts_multiple_stratify_keys(self, sample_documents, runner, default_model, max_threads):
+        """Test topk FTS with multiple stratification keys."""
+        # Add subcategory for testing
+        docs = sample_documents.copy()
+        for i, doc in enumerate(docs):
+            doc["subcategory"] = f"sub_{i % 2}"
+        
+        config = {
+            "name": "test_topk_multi_stratified",
+            "type": "topk",
+            "method": "fts",
+            "k": 1,
+            "keys": ["title", "content"],
+            "query": "programming",
+            "stratify_key": ["category", "subcategory"],
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs)
+        
+        assert len(results) > 0
+        assert cost == 0
+
+
+class TestTopKValidation:
+    """Tests for TopK operation validation."""
+
+    def test_invalid_k_value(self, runner, default_model, max_threads):
+        """Test that invalid k values raise errors."""
+        config = {
+            "name": "test_invalid_k",
+            "type": "topk",
+            "method": "embedding",
+            "k": -1,  # Invalid negative value
+            "keys": ["title"],
+            "query": "test",
+        }
+        
+        with pytest.raises(ValueError, match="'k' must be a positive number"):
+            TopKOperation(runner, config, default_model, max_threads)
+
+    def test_empty_keys(self, runner, default_model, max_threads):
+        """Test that empty keys list raises error."""
+        config = {
+            "name": "test_empty_keys",
+            "type": "topk",
+            "method": "fts",
+            "k": 5,
+            "keys": [],  # Empty keys
+            "query": "test",
+        }
+        
+        with pytest.raises(ValueError, match="'keys' cannot be empty"):
+            TopKOperation(runner, config, default_model, max_threads)
+
+    def test_empty_query(self, runner, default_model, max_threads):
+        """Test that empty query raises error."""
+        config = {
+            "name": "test_empty_query",
+            "type": "topk",
+            "method": "embedding",
+            "k": 5,
+            "keys": ["title"],
+            "query": "",  # Empty query
+        }
+        
+        with pytest.raises(ValueError, match="'query' cannot be empty"):
+            TopKOperation(runner, config, default_model, max_threads)
+
+    def test_invalid_stratify_key_type(self, runner, default_model, max_threads):
+        """Test that invalid stratify_key type raises error."""
+        from pydantic import ValidationError
+        
+        config = {
+            "name": "test_invalid_stratify",
+            "type": "topk",
+            "method": "fts",
+            "k": 5,
+            "keys": ["title"],
+            "query": "test",
+            "stratify_key": 123,  # Invalid type
+        }
+        
+        with pytest.raises(ValidationError):
+            TopKOperation(runner, config, default_model, max_threads)
+
+
+class TestTopKLLMCompare:
+    """Tests for TopK operation with llm_compare method."""
+
+    def test_topk_llm_compare_basic(self, sample_documents, runner, default_model, max_threads):
+        """Test basic topk LLM comparison."""
+        config = {
+            "name": "test_topk_llm",
+            "type": "topk",
+            "method": "llm_compare",
+            "k": 3,
+            "keys": ["title", "content"],
+            "query": "Rank by relevance to artificial intelligence and machine learning",
+            "model": "gpt-4o-mini",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        assert len(results) <= 3
+        assert cost > 0  # LLM calls have cost
+        
+        # Should prioritize AI-related documents
+        ai_ids = {2, 4, 6}
+        if len(results) > 0:
+            result_ids = {doc["id"] for doc in results}
+            # At least one should be AI-related
+            assert len(result_ids.intersection(ai_ids)) >= 1
+
+    def test_topk_llm_compare_percentage(self, sample_documents, runner, default_model, max_threads):
+        """Test llm_compare with percentage k value."""
+        config = {
+            "name": "test_topk_llm_percentage",
+            "type": "topk",
+            "method": "llm_compare",
+            "k": 0.5,  # 50% of documents
+            "keys": ["title", "content"],
+            "query": "Rank by technical complexity and implementation difficulty",
+            "model": "gpt-4o-mini",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should return 3 documents (50% of 6)
+        assert len(results) <= 3
+        assert cost > 0
+
+    def test_topk_llm_compare_with_batch_size(self, sample_documents, runner, default_model, max_threads):
+        """Test llm_compare with custom batch size."""
+        config = {
+            "name": "test_topk_llm_batch",
+            "type": "topk",
+            "method": "llm_compare",
+            "k": 2,
+            "keys": ["title"],
+            "query": "Rank by innovation and cutting-edge technology",
+            "model": "gpt-4o-mini",
+            "batch_size": 3,  # Small batch size for testing
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        assert len(results) <= 2
+        assert cost > 0
+
+    def test_topk_llm_compare_no_stratification(self, sample_documents, runner, default_model, max_threads):
+        """Test that llm_compare raises error with stratification."""
+        config = {
+            "name": "test_topk_llm_no_strat",
+            "type": "topk",
+            "method": "llm_compare",
+            "k": 2,
+            "keys": ["title"],
+            "query": "Rank by importance",
+            "model": "gpt-4o-mini",
+            "stratify_key": "category",  # Should raise error
+        }
+        
+        with pytest.raises(ValueError, match="stratify_key.*not supported.*llm_compare"):
+            TopKOperation(runner, config, default_model, max_threads)
+
+    def test_topk_llm_compare_missing_model(self, runner, default_model, max_threads):
+        """Test that llm_compare requires model parameter."""
+        config = {
+            "name": "test_topk_llm_no_model",
+            "type": "topk",
+            "method": "llm_compare",
+            "k": 2,
+            "keys": ["title"],
+            "query": "Rank by importance",
+            # Missing model parameter
+        }
+        
+        with pytest.raises(ValueError, match="'model' must be specified.*llm_compare"):
+            TopKOperation(runner, config, default_model, max_threads)
+
+    def test_topk_llm_compare_no_jinja(self, runner, default_model, max_threads):
+        """Test that llm_compare doesn't allow Jinja templates."""
+        config = {
+            "name": "test_topk_llm_no_jinja",
+            "type": "topk",
+            "method": "llm_compare",
+            "k": 2,
+            "keys": ["title"],
+            "query": "Rank by {{ input.criteria }}",  # Jinja template not allowed
+            "model": "gpt-4o-mini",
+        }
+        
+        with pytest.raises(ValueError, match="cannot contain Jinja templates.*llm_compare"):
+            TopKOperation(runner, config, default_model, max_threads)
+
+
+class TestTopKEdgeCases:
+    """Tests for TopK operation edge cases."""
+
+    def test_topk_empty_data(self, runner, default_model, max_threads):
+        """Test topk with empty input data."""
+        config = {
+            "name": "test_empty_data",
+            "type": "topk",
+            "method": "fts",
+            "k": 5,
+            "keys": ["title"],
+            "query": "test",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute([])
+        
+        assert len(results) == 0
+        assert cost == 0
+
+    def test_topk_k_exceeds_data(self, sample_documents, runner, default_model, max_threads):
+        """Test when k exceeds available documents."""
+        config = {
+            "name": "test_k_exceeds",
+            "type": "topk",
+            "method": "fts",
+            "k": 100,  # More than 6 documents
+            "keys": ["title"],
+            "query": "programming",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(sample_documents)
+        
+        # Should return all available documents
+        assert len(results) == len(sample_documents)
+        assert cost == 0
+
+    def test_topk_missing_keys_in_documents(self, runner, default_model, max_threads):
+        """Test behavior when specified keys don't exist in documents."""
+        docs = [
+            {"id": 1, "title": "Doc 1"},
+            {"id": 2, "title": "Doc 2"},
+            {"id": 3, "content": "Doc 3 content"},  # Missing title
+        ]
+        
+        config = {
+            "name": "test_missing_keys",
+            "type": "topk",
+            "method": "fts",
+            "k": 2,
+            "keys": ["title", "content"],
+            "query": "doc",
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        results, cost = operation.execute(docs)
+        
+        # Should handle missing keys gracefully
+        assert len(results) == 2
+        assert cost == 0
+
+    def test_topk_embedding_model_ignored_for_fts(self, sample_documents, runner, default_model, max_threads, capsys):
+        """Test that embedding_model is ignored for FTS method with warning."""
+        config = {
+            "name": "test_model_ignored",
+            "type": "topk",
+            "method": "fts",
+            "k": 2,
+            "keys": ["title"],
+            "query": "test",
+            "embedding_model": "some-other-model",  # Should be ignored
+            "bypass_cache": True,
+        }
+        
+        operation = TopKOperation(runner, config, default_model, max_threads)
+        captured = capsys.readouterr()
+        
+        # Should see warning about ignored embedding_model
+        assert "Warning" in captured.out
+        assert "embedding_model" in captured.out
+        
+        # Should still work
+        results, cost = operation.execute(sample_documents)
+        assert len(results) == 2
+        assert cost == 0

--- a/uv.lock
+++ b/uv.lock
@@ -480,6 +480,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyrate-limiter" },
     { name = "python-multipart" },
+    { name = "rank-bm25" },
     { name = "rapidfuzz" },
     { name = "rich" },
     { name = "scikit-learn" },
@@ -552,6 +553,7 @@ requires-dist = [
     { name = "python-docx", marker = "extra == 'parsing'", specifier = ">=1.1.2" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "python-pptx", marker = "extra == 'parsing'", specifier = ">=1.0.2" },
+    { name = "rank-bm25", specifier = ">=0.2.2" },
     { name = "rapidfuzz", specifier = ">=3.10.0" },
     { name = "rich", specifier = ">=13.7.1" },
     { name = "scikit-learn", specifier = ">=1.5.2" },
@@ -3118,6 +3120,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "rank-bm25"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/f9579384aa017d8b4c15613f86954b92a95a93d641cc849182467cf0bb3b/rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d", size = 8347, upload-time = "2022-02-16T12:10:52.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/21/f691fb2613100a62b3fa91e9988c991e9ca5b89ea31c0d3152a3210344f9/rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae", size = 8584, upload-time = "2022-02-16T12:10:50.626Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces a topk operation for document retrieval, extending the existing sample operation with semantic similarity and full-text search capabilities. The implementation supports both embedding-based retrieval and FTS via BM25, with optional stratified sampling.

### Changes

Added a new topk operation that provides a cleaner interface for retrieval use cases, wrapping the sample operation's new top_embedding and top_fts methods. The operation supports retrieving items by semantic similarity, full-text search, or LLM-based comparison.

The sample operation was extended to handle these retrieval methods while maintaining backward compatibility. Both operations now support stratified retrieval across multiple keys and flexible k-selection using counts or percentages.

### Test Plan
  - Run existing test suite to ensure no regressions
  - New tests cover embedding similarity, FTS, and stratified retrieval scenarios
  - Validated with various k values and query patterns