### PR TITLE
Fix gather operator doc typo

### DIFF
--- a/docs/examples/mining-product-reviews.md
+++ b/docs/examples/mining-product-reviews.md
@@ -306,7 +306,7 @@ These optimizations are crucial for handling the scale of our dataset, which inc
         split_key: concatenated_reviews
         method: token_count
         method_kwargs:
-          token_count: 87776
+          num_tokens: 87776
         optimize: false
 
       - name: gather_concatenated_reviews_identify_polarizing_themes

--- a/docs/operators/gather.md
+++ b/docs/operators/gather.md
@@ -74,7 +74,7 @@ Next, we split the document into manageable chunks:
   split_key: agreement_text
   method: token_count
   method_kwargs:
-    token_count: 1000
+    num_tokens: 1000
 ```
 
 ### Step 3: Extract Headers (Map operation)


### PR DESCRIPTION
Corrected `token_count` to `num_tokens` in `split` operator examples to fix a typo and ensure consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-23f538bd-5809-405c-9f4e-efa19b75d6e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23f538bd-5809-405c-9f4e-efa19b75d6e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

