### PR TITLE
Make error toasts copyable

### DIFF
--- a/website/src/components/ui/toast.tsx
+++ b/website/src/components/ui/toast.tsx
@@ -1,4 +1,5 @@
 "use client";
+/* eslint-disable react/prop-types */
 
 import * as React from "react";
 import { Cross2Icon } from "@radix-ui/react-icons";
@@ -106,7 +107,7 @@ const ToastDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
-    className={cn("text-sm opacity-90", className)}
+    className={cn("text-sm opacity-90 select-text", className)}
     {...props}
   />
 ));

--- a/website/src/components/ui/toaster.tsx
+++ b/website/src/components/ui/toaster.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import React from "react";
 import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Copy } from "lucide-react";
 import {
   Toast,
   ToastClose,
@@ -16,14 +19,32 @@ export function Toaster() {
   return (
     <ToastProvider>
       {toasts.map(function ({ id, title, description, action, ...props }) {
+        const descId = `toast-desc-${id}`;
         return (
           <Toast key={id} {...props}>
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && (
-                <ToastDescription>{description}</ToastDescription>
+                <ToastDescription id={descId}>{description}</ToastDescription>
               )}
             </div>
+            {description && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={() => {
+                  const el = document.getElementById(descId);
+                  const text = el?.textContent ?? "";
+                  if (text) {
+                    navigator.clipboard.writeText(text);
+                  }
+                }}
+                title="Copy message"
+              >
+                <Copy size={12} />
+              </Button>
+            )}
             {action}
             <ToastClose />
           </Toast>


### PR DESCRIPTION
Allow copying error messages from toasts to the clipboard.
<img width="524" height="467" alt="Screenshot 2025-09-23 at 5 20 25 PM" src="https://github.com/user-attachments/assets/344badc6-c16b-4542-9c45-4dbae869c5bf" />


---
<a href="https://cursor.com/background-agent?bcId=bc-c7f4dc34-8ece-4eb9-b044-3e0fdd623df6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7f4dc34-8ece-4eb9-b044-3e0fdd623df6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

