### PR TITLE
Added libgl1 and libglib2.0-0 library install to Dockerfile as required by OpenCV (Docling)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ FROM python:3.11-slim AS runtime
 # Install Node.js
 RUN apt-get update && apt-get install -y \
     curl \
+    libgl1 \
+    libglib2.0-0 \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Added libs required by OpenCV to Dockerfile
- libgl1
- libglib2.0-0 

Fixes the problem on Mac M3 Pro.
<img width="863" height="190" alt="image" src="https://github.com/user-attachments/assets/241449e4-8f27-4727-98d1-eed346c65d19" />
