### PR TITLE
add reduce to pandas api

### DIFF
--- a/docetl/operations/reduce.py
+++ b/docetl/operations/reduce.py
@@ -20,7 +20,6 @@ from jinja2 import Template
 from pydantic import Field, field_validator, model_validator
 
 from docetl.operations.base import BaseOperation
-from docetl.utils import has_jinja_syntax, prompt_user_for_non_jinja_confirmation
 from docetl.operations.clustering_utils import (
     cluster_documents,
     get_embeddings_for_clustering,
@@ -33,7 +32,11 @@ from docetl.operations.utils import (
 
 # Import OutputMode enum for structured output checks
 from docetl.operations.utils.api import OutputMode
-from docetl.utils import completion_cost
+from docetl.utils import (
+    completion_cost,
+    has_jinja_syntax,
+    prompt_user_for_non_jinja_confirmation,
+)
 
 
 class ReduceOperation(BaseOperation):
@@ -776,6 +779,7 @@ class ReduceOperation(BaseOperation):
 
         end_time = time.time()
         self._update_fold_time(end_time - start_time)
+        fold_cost = response.total_cost
 
         if response.validated:
             structured_mode = (
@@ -844,6 +848,7 @@ class ReduceOperation(BaseOperation):
 
         end_time = time.time()
         self._update_merge_time(end_time - start_time)
+        merge_cost = response.total_cost
 
         if response.validated:
             structured_mode = (


### PR DESCRIPTION
As title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `df.semantic.reduce()` convenience wrapper around `agg()` and consolidates imports while explicitly tracking fold/merge LLM costs in the reduce operation.
> 
> - **Pandas API**:
>   - Add `semantic.reduce(prompt, output|output_schema, reduce_keys, **kwargs)` as a thin wrapper over `agg()` for common reductions; includes docs and examples.
> - **Reduce Operation**:
>   - Consolidate utility imports from `docetl.utils`.
>   - Explicitly record `response.total_cost` for fold and merge steps (`fold_cost`, `merge_cost`) to track LLM costs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1933752706c9ba5b77ca7a349fd7b6dd6e7472d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->