### PR TITLE
fix broken links in python api documentation

### DIFF
--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -1,207 +1,357 @@
-# Python API
+# Python API Reference
 
-## Operations
-
-::: docetl.schemas.MapOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.ResolveOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.ReduceOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.ParallelMapOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.FilterOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.EquijoinOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.SplitOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.GatherOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.UnnestOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.SampleOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.ClusterOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.CodeMapOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.CodeReduceOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.CodeFilterOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-::: docetl.schemas.ExtractOp
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
-
-### Callable support for code ops
-
-Code operations (`code_map`, `code_reduce`, `code_filter`) accept either a string containing Python code that defines a `transform` function, or a regular Python function. When you pass a function, it does not need to be named `transform`; DocETL binds it internally.
-
-Example:
+The Python API lets you define, optimize, and run DocETL pipelines programmatically. All classes are importable from `docetl.api`.
 
 ```python
-from docetl.api import CodeMapOp
-
-def my_map(doc: dict) -> dict:
-    return {"double": doc["x"] * 2}
-
-code_map = CodeMapOp(name="double_x", type="code_map", code=my_map)
+from docetl.api import (
+    Pipeline, Dataset, PipelineStep, PipelineOutput,
+    MapOp, ReduceOp, ResolveOp, FilterOp, ParallelMapOp,
+    EquijoinOp, SplitOp, GatherOp, UnnestOp, SampleOp,
+    CodeMapOp, CodeReduceOp, CodeFilterOp, ExtractOp,
+)
 ```
 
-- Map: `fn(doc: dict) -> dict`
-- Filter: `fn(doc: dict) -> bool`
-- Reduce: `fn(group: list[dict]) -> dict`
+---
 
-See also: [Code Operators](../operators/code.md), [Extract Operator](../operators/extract.md)
+## Pipeline
 
-## Dataset and Pipeline
+The main class for defining and running a complete document processing pipeline.
 
-::: docetl.schemas.Dataset
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
+```python
+Pipeline(
+    name: str,
+    datasets: dict[str, Dataset],
+    operations: list[OpType],
+    steps: list[PipelineStep],
+    output: PipelineOutput,
+    default_model: str | None = None,
+    parsing_tools: list[ParsingTool] = [],
+)
+```
 
-::: docetl.schemas.ParsingTool
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Name of the pipeline. |
+| `datasets` | `dict[str, Dataset]` | Datasets keyed by name. |
+| `operations` | `list[OpType]` | List of operation definitions. |
+| `steps` | `list[PipelineStep]` | Ordered steps to execute. |
+| `output` | `PipelineOutput` | Output configuration. |
+| `default_model` | `str \| None` | Default LLM model for all operations. |
+| `parsing_tools` | `list[ParsingTool]` | Custom parsing functions. Can be `ParsingTool` objects or plain Python functions. |
 
+**Methods:**
 
-::: docetl.schemas.PipelineStep
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
+- `pipeline.run() -> float` — Execute the pipeline. Returns total cost.
+- `pipeline.optimize(**kwargs) -> Pipeline` — Return an optimized copy of the pipeline.
 
-::: docetl.schemas.PipelineOutput
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
+---
 
-::: docetl.api.Pipeline
-    options:
-        show_root_heading: true
-        heading_level: 3
-        show_if_no_docstring: false
-        docstring_options:
-            ignore_init_summary: false
-            trim_doctest_flags: true
+## Dataset
+
+```python
+Dataset(
+    type: "file" | "memory",
+    path: str | list[dict] | pd.DataFrame,
+    source: str = "local",
+    parsing: list[dict[str, str]] | None = None,
+)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | `"file"` or `"memory"` | `"file"` to load from disk, `"memory"` for in-memory data. |
+| `path` | `str \| list[dict] \| DataFrame` | File path (for `"file"` type) or data (for `"memory"` type). |
+| `source` | `str` | Source identifier. Defaults to `"local"`. |
+| `parsing` | `list[dict]` | Parsing instructions. Each dict has `input_key`, `function`, and `output_key`. |
+
+---
+
+## PipelineStep
+
+```python
+PipelineStep(
+    name: str,
+    input: str | None,
+    operations: list[str | dict],
+)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Step name. |
+| `input` | `str \| None` | Name of a dataset or previous step to use as input. |
+| `operations` | `list[str \| dict]` | Operation names (or dicts for more complex configs) to run in this step. |
+
+---
+
+## PipelineOutput
+
+```python
+PipelineOutput(
+    type: str,
+    path: str,
+    intermediate_dir: str | None = None,
+)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | `str` | Output type (e.g., `"file"`). |
+| `path` | `str` | Path to write output. |
+| `intermediate_dir` | `str \| None` | Directory for intermediate results. |
+
+---
+
+## LLM-Powered Operations
+
+All operations share these base fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | *required* | Unique operation name. |
+| `type` | `str` | *required* | Operation type (must match the Op class). |
+| `skip_on_error` | `bool` | `False` | Skip documents that cause errors. |
+
+### MapOp
+
+Applies an LLM prompt to each document independently.
+
+```python
+MapOp(name="...", type="map", prompt="...", output={"schema": {...}})
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prompt` | `str` | — | Jinja2 template. Use `{{ input.key }}` to access fields. |
+| `output` | `dict` | — | Output schema, e.g. `{"schema": {"field": "string"}}`. |
+| `model` | `str` | `None` | Override the default model. |
+| `drop_keys` | `list[str]` | `None` | Keys to drop from output. |
+| `batch_size` | `int` | `None` | Process documents in batches. |
+| `batch_prompt` | `str` | `None` | Jinja2 template for batch processing. Uses `{{ inputs }}`. |
+| `timeout` | `int` | `None` | Timeout in seconds per LLM call. |
+| `optimize` | `bool` | `None` | Mark for optimization. |
+| `limit` | `int` | `None` | Max documents to process. |
+| `litellm_completion_kwargs` | `dict` | `{}` | Extra kwargs passed to litellm. |
+| `enable_observability` | `bool` | `False` | Enable observability logging. |
+
+### ReduceOp
+
+Groups documents by key(s) and reduces each group with an LLM.
+
+```python
+ReduceOp(name="...", type="reduce", reduce_key="key", prompt="...", output={"schema": {...}})
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `reduce_key` | `str \| list[str]` | *required* | Key(s) to group by. Use `"_all"` for a single group. |
+| `prompt` | `str` | *required* | Jinja2 template. Use `{% for item in inputs %}` to iterate. |
+| `output` | `dict` | *required* | Output schema. |
+| `model` | `str` | `None` | Override the default model. |
+| `input` | `dict` | `None` | Input schema constraints. |
+| `pass_through` | `bool` | `None` | Pass through non-reduced keys. |
+| `associative` | `bool` | `None` | Whether reduce is associative (enables parallelism). |
+| `fold_prompt` | `str` | `None` | Prompt for incremental fold operations. |
+| `fold_batch_size` | `int` | `None` | Batch size for fold. |
+| `merge_prompt` | `str` | `None` | Prompt for merging fold results. |
+| `merge_batch_size` | `int` | `None` | Batch size for merge. |
+| `optimize` | `bool` | `None` | Mark for optimization. |
+| `timeout` | `int` | `None` | Timeout in seconds. |
+| `limit` | `int` | `None` | Max groups to process. |
+| `litellm_completion_kwargs` | `dict` | `{}` | Extra kwargs passed to litellm. |
+
+### ResolveOp
+
+Deduplicates/resolves entities by comparing pairs of documents.
+
+```python
+ResolveOp(name="...", type="resolve", comparison_prompt="...", resolution_prompt="...")
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `comparison_prompt` | `str` | *required* | Jinja2 template comparing `{{ input1 }}` and `{{ input2 }}`. |
+| `resolution_prompt` | `str` | `None` | Prompt for resolving matched pairs. |
+| `output` | `dict` | `None` | Output schema. |
+| `embedding_model` | `str` | `None` | Model for blocking embeddings. |
+| `comparison_model` | `str` | `None` | Model for comparisons. |
+| `resolution_model` | `str` | `None` | Model for resolution. |
+| `blocking_keys` | `list[str]` | `None` | Keys to use for blocking. |
+| `blocking_threshold` | `float` | `None` | Similarity threshold for blocking (0–1). |
+| `blocking_target_recall` | `float` | `None` | Target recall for blocking (0–1). |
+| `blocking_conditions` | `list[str]` | `None` | Custom blocking conditions. |
+| `optimize` | `bool` | `None` | Mark for optimization. |
+| `timeout` | `int` | `None` | Timeout in seconds. |
+| `litellm_completion_kwargs` | `dict` | `{}` | Extra kwargs passed to litellm. |
+
+### FilterOp
+
+Filters documents using an LLM prompt that returns a boolean.
+
+```python
+FilterOp(name="...", type="filter", prompt="...", output={"schema": {...}})
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prompt` | `str` | *required* | Jinja2 template. Use `{{ input.key }}`. |
+| `output` | `dict` | *required* | Must include a boolean field in schema. |
+
+### ParallelMapOp
+
+Runs multiple prompts on each document in parallel.
+
+```python
+ParallelMapOp(name="...", type="parallel_map", prompts=[...], output={"schema": {...}})
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prompts` | `list[dict]` | — | List of prompt configurations. |
+| `output` | `dict` | — | Combined output schema. |
+| `drop_keys` | `list[str]` | `None` | Keys to drop from output. |
+
+### EquijoinOp
+
+Joins two datasets by comparing document pairs with an LLM.
+
+```python
+EquijoinOp(name="...", type="equijoin", comparison_prompt="...")
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `comparison_prompt` | `str` | *required* | Jinja2 template comparing `{{ left }}` and `{{ right }}`. |
+| `output` | `dict` | `None` | Output schema. |
+| `blocking_keys` | `dict[str, list[str]]` | `None` | Keys for blocking per dataset. |
+| `blocking_threshold` | `float` | `None` | Similarity threshold. |
+| `blocking_conditions` | `list[str]` | `None` | Custom blocking conditions. |
+| `limits` | `dict[str, int]` | `None` | Max matches per side. |
+| `comparison_model` | `str` | `None` | Model for comparisons. |
+| `embedding_model` | `str` | `None` | Model for embeddings. |
+| `optimize` | `bool` | `None` | Mark for optimization. |
+| `timeout` | `int` | `None` | Timeout in seconds. |
+| `litellm_completion_kwargs` | `dict` | `{}` | Extra kwargs passed to litellm. |
+
+### ExtractOp
+
+Extracts specific information from documents with line-level precision.
+
+```python
+ExtractOp(name="...", type="extract", prompt="...", document_keys=["content"])
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prompt` | `str` | *required* | Extraction prompt. |
+| `document_keys` | `list[str]` | *required* | Keys containing document text. |
+| `model` | `str` | `None` | Override the default model. |
+| `format_extraction` | `bool` | `True` | Format extracted content. |
+| `extraction_key_suffix` | `str` | `None` | Suffix for extraction output keys. |
+| `extraction_method` | `"line_number" \| "regex"` | `"line_number"` | Extraction method. |
+| `timeout` | `int` | `None` | Timeout in seconds. |
+| `limit` | `int` | `None` | Max documents to process. |
+| `litellm_completion_kwargs` | `dict` | `{}` | Extra kwargs passed to litellm. |
+
+---
+
+## Auxiliary Operations
+
+### SplitOp
+
+Splits documents into chunks.
+
+```python
+SplitOp(name="...", type="split", split_key="content", method="token_count", method_kwargs={"num_tokens": 500})
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `split_key` | `str` | *required* | Key containing text to split. |
+| `method` | `str` | *required* | Split method (e.g., `"token_count"`, `"delimiter"`). |
+| `method_kwargs` | `dict` | *required* | Arguments for the split method. |
+| `model` | `str` | `None` | Model for token counting. |
+
+### GatherOp
+
+Adds surrounding context to chunks created by split.
+
+```python
+GatherOp(name="...", type="gather", content_key="...", doc_id_key="...", order_key="...")
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `content_key` | `str` | *required* | Key with chunk content. |
+| `doc_id_key` | `str` | *required* | Key identifying the source document. |
+| `order_key` | `str` | *required* | Key for chunk ordering. |
+| `peripheral_chunks` | `dict` | `None` | Configuration for surrounding context. |
+| `doc_header_key` | `str` | `None` | Key for document headers. |
+
+### UnnestOp
+
+Flattens a list-valued field into separate documents.
+
+```python
+UnnestOp(name="...", type="unnest", unnest_key="items")
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `unnest_key` | `str` | *required* | Key containing the list to unnest. |
+| `keep_empty` | `bool` | `None` | Keep documents with empty lists. |
+| `expand_fields` | `list[str]` | `None` | Additional fields to expand. |
+| `recursive` | `bool` | `None` | Recursively unnest nested lists. |
+| `depth` | `int` | `None` | Max recursion depth. |
+
+### SampleOp
+
+Samples a subset of documents.
+
+```python
+SampleOp(name="...", type="sample", method="uniform", samples=100)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `method` | `str` | *required* | One of `"uniform"`, `"outliers"`, `"custom"`, `"first"`, `"top_embedding"`, `"top_fts"`. |
+| `samples` | `int \| float \| list` | `None` | Number of samples or fraction. |
+| `stratify_key` | `str \| list[str]` | `None` | Key(s) for stratified sampling. |
+| `samples_per_group` | `bool` | `False` | Apply sample count per group. |
+| `method_kwargs` | `dict` | `{}` | Extra arguments for the sampling method. |
+| `random_state` | `int` | `None` | Random seed for reproducibility. |
+
+---
+
+## Code Operations
+
+Code operations run Python functions instead of LLM calls. The `code` parameter accepts either a string containing Python code that defines a `transform` function, or a regular Python function.
+
+```python
+def my_transform(doc: dict) -> dict:
+    return {"doubled": doc["value"] * 2}
+
+op = CodeMapOp(name="double", type="code_map", code=my_transform)
+```
+
+### CodeMapOp
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `code` | `str \| Callable` | *required* | `fn(doc: dict) -> dict` |
+| `drop_keys` | `list[str]` | `None` | Keys to drop from output. |
+| `limit` | `int` | `None` | Max documents to process. |
+
+### CodeReduceOp
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `code` | `str \| Callable` | *required* | `fn(group: list[dict]) -> dict` |
+| `limit` | `int` | `None` | Max groups to process. |
+
+### CodeFilterOp
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `code` | `str \| Callable` | *required* | `fn(doc: dict) -> bool` |
+| `limit` | `int` | `None` | Max documents to process. |

--- a/docs/playground/index.md
+++ b/docs/playground/index.md
@@ -1,20 +1,20 @@
-# Playground
+# DocWrangler
 
-The DocETL Playground is an integrated development environment (IDE) for building and testing document processing pipelines. Built with Next.js and TypeScript, it provides a real-time interface to develop, test and refine your pipelines through a FastAPI backend.
+[DocWrangler](https://arxiv.org/abs/2504.14764) is a playground for prototyping DocETL pipelines. It provides an integrated development environment (IDE) for building and testing document processing pipelines, with a real-time interface to develop, test and refine your pipelines through a FastAPI backend.
 
-## Why a Playground? 🤔
+## Why DocWrangler?
 
-This **interactive playground** streamlines development from prototype to production! **Our (in-progress) user studies show 100% of developers** found building pipelines significantly faster and easier with our playground vs traditional approaches.
+DocWrangler streamlines development from prototype to production. User studies show developers found building pipelines significantly faster and easier with DocWrangler vs traditional approaches.
 
-Building complex LLM pipelines for your data often requires experimentation and iteration. The IDE lets you:
+Building complex LLM pipelines for your data often requires experimentation and iteration. DocWrangler lets you:
 
 - 🚀 Test prompts and see results instantly
 - ✨ Refine operations based on sample outputs  
 - 🔄 Build complex pipelines step-by-step
 
-## Public Playground
+## Public Instance
 
-You can access our hosted playground at [docetl.org/playground](https://docetl.org/playground). You'll need to provide your own LLM API keys to use the service. The chatbot and prompt engineering assistants are powered by OpenAI models, so you'll need to provide an OpenAI API key.
+You can access our hosted DocWrangler at [docetl.org/playground](https://docetl.org/playground). You'll need to provide your own LLM API keys to use the service. The chatbot and prompt engineering assistants are powered by OpenAI models, so you'll need to provide an OpenAI API key.
 
 !!! note "Data Storage Notice"
 
@@ -117,7 +117,7 @@ make install-ui   # Install UI dependencies
 make run-ui-dev
 ```
 
-5. Navigate to http://localhost:3000/playground to access the playground.
+5. Navigate to http://localhost:3000/playground to access DocWrangler.
 
 ### Setting up the AI Assistant
 
@@ -127,7 +127,7 @@ To use the assistant, you need to set your OpenAI API key in the `.env.local` fi
 
 !!! tip "Self-hosting with UI API key management"
 
-    If you want to host your own version of DocETL for your organization while allowing users to set their API keys through the UI, you'll need to set up encryption. Add the following to both `.env` and `website/.env.local`:
+    If you want to host your own version of DocWrangler for your organization while allowing users to set their API keys through the UI, you'll need to set up encryption. Add the following to both `.env` and `website/.env.local`:
     ```bash
     DOCETL_ENCRYPTION_KEY=your_secret_key_here
     ```
@@ -136,4 +136,4 @@ To use the assistant, you need to set your OpenAI API key in the `.env.local` fi
 
 ## Complex Tutorial
 
-See this [YouTube video](https://www.youtube.com/watch?v=IlgueVqtHGo) for a more in depth tutorial on how to use the playground.
+See this [YouTube video](https://www.youtube.com/watch?v=IlgueVqtHGo) for a more in depth tutorial on how to use DocWrangler.

--- a/docs/playground/tutorial.md
+++ b/docs/playground/tutorial.md
@@ -1,6 +1,6 @@
 # Simple Tutorial: Extracting Funny Quotes from Presidential Debates
 
-In this tutorial, we'll walk through using the DocETL playground to extract funny or memorable quotes from presidential debate transcripts. We'll see how to:
+In this tutorial, we'll walk through using DocWrangler to extract funny or memorable quotes from presidential debate transcripts. We'll see how to:
 
 1. Upload and explore data
 2. Run a basic pipeline with sampling
@@ -16,11 +16,11 @@ In this tutorial, we'll walk through using the DocETL playground to extract funn
 
 First, download the presidential debates dataset from [here](https://raw.githubusercontent.com/ucbepic/docetl/refs/heads/main/example_data/debates/data.json).
 
-Once downloaded, use the left sidebar's upload button to load the data into the playground. The data contains transcripts from various presidential debates.
+Once downloaded, use the left sidebar's upload button to load the data into DocWrangler. The data contains transcripts from various presidential debates.
 
 You can view the data by clicking the "toggle dataset view" button in the top right corner of the screen:
 
-![Dataset View](../../assets/tutorial/dataset-view.png)
+![Dataset View](../assets/tutorial/dataset-view.png)
 
 ## Step 2: Add a Map Operation
 
@@ -28,7 +28,7 @@ The pipeline is set to run on a sample of 5 documents, as indicated by the sampl
 
 We'll add a map operation that processes each debate transcript to extract logical fallacies. Click the "Add Operation" button in the top right corner of the screen, and select "Map" under the LLM section. You can set the operation name to "extract_fallacies", and write a prompt and output schema. 
 
-![Operation Details](../../assets/tutorial/operation-details.png)
+![Operation Details](../assets/tutorial/operation-details.png)
 
 ## Step 3: Run the Pipeline and Check Outputs
 
@@ -37,7 +37,7 @@ Click the "Run" button to execute the pipeline. The outputs panel will show two 
 - **Console**: Displays progress information and any potential errors
 - **Table**: Shows the extracted funny quotes from each document in a table, as well as the other key/value pairs in the document. Here's what the table looks like after running the pipeline:
 
-![Pipeline Outputs](../../assets/tutorial/initial-outputs.png)
+![Pipeline Outputs](../assets/tutorial/initial-outputs.png)
 
 You can resize the rows and columns in the table by clicking and dragging the edges of the table cells, as in the image above. You can also rezise the outputs panel by clicking and dragging the top edge of the panel.
 
@@ -55,15 +55,15 @@ We can modify the prompt to request additional context based on what we observe 
 
 Here's an example of what giving notes might look like:
 
-![Feedback](../../assets/tutorial/add-notes.png)
+![Feedback](../assets/tutorial/add-notes.png)
 
 Once you've added enough notes (3-5 or more), you can click on the "Improve Prompt" button in the top right corner of the operation card. This will invoke the DocWrangler Prompt Improvement Assistant, which will suggest edits to your prompt:
 
-![Prompt Improvement](../../assets/tutorial/prompt-improvement.png)
+![Prompt Improvement](../assets/tutorial/prompt-improvement.png)
 
 Once you're satisfied with the new prompt, click "Save" to update the operation, and then you can rerun the pipeline to see the new outputs.
 
-![Prompt v2](../../assets/tutorial/prompt-v2.png)
+![Prompt v2](../assets/tutorial/prompt-v2.png)
 
 !!! note "Caching Behavior"
 

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -76,7 +76,7 @@ This example demonstrates how to create a simple pipeline that processes input d
 
 ## API Reference
 
-For a complete reference of all available classes and their methods, please refer to the [Python API Reference](api-reference/python.md).
+For a complete reference of all available classes and their methods, please refer to the [API Reference](../api-reference/python.md).
 
 The API Reference provides detailed information about each class, including:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,9 +45,10 @@ nav:
           - TopK: operators/topk.md
           - Code: operators/code.md
       - APIs:
-          - Python API Guide: 
+          - Python API Guide:
               - Overview: python/index.md
               - Examples: python/examples.md
+              - API Reference: api-reference/python.md
           - Pandas Integration:
               - Overview: pandas/index.md
               - Operations: pandas/operations.md
@@ -85,10 +86,9 @@ nav:
           - CLI Interface: api-reference/cli.md
           - Operations: api-reference/operations.md
           - Optimizers: api-reference/optimizers.md
-          - Python API: api-reference/python.md
   
   - Tools & Resources:
-      - UI Playground:
+      - DocWrangler:
           - Setup: playground/index.md
           - Tutorial: playground/tutorial.md
       - Community:


### PR DESCRIPTION
As title. Also creates some other copy changes, like renaming "UI playground" to "DocWrangler".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (API reference rewrite, nav/link fixes, and copy updates) with no runtime impact; main risk is minor doc inaccuracies or remaining broken links.
> 
> **Overview**
> Replaces the autogenerated `mkdocstrings`-based Python API reference with a hand-written, structured reference (constructor signatures, parameter tables, and op field summaries) to improve readability and avoid broken doc generation.
> 
> Updates docs navigation and links so the Python guide correctly points to `api-reference/python.md` and surfaces the API reference under the Python API Guide in `mkdocs.yml`. Renames the “UI Playground” docs section and copy to **DocWrangler**, and fixes tutorial image paths so assets resolve under the new structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c603a986368df042bdd31ace539d2dcf3d6493. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->