### PR TITLE
[WIP] Add support for video data

### DIFF
--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import requests
-from jinja2 import Template
+from jinja2 import Environment, Template
 from litellm.utils import ModelResponse
 from pydantic import Field, field_validator, model_validator
 from tqdm import tqdm
@@ -16,6 +16,7 @@ from tqdm import tqdm
 from docetl.base_schemas import Tool, ToolFunction
 from docetl.operations.base import BaseOperation
 from docetl.operations.utils import RichLoopBar, strict_render, validate_output_types
+from docetl.operations.utils.validation import rendered_prompt_to_content_parts
 from docetl.operations.utils.api import OutputMode
 from docetl.utils import has_jinja_syntax, prompt_user_for_non_jinja_confirmation
 
@@ -75,7 +76,11 @@ class MapOperation(BaseOperation):
                     # We'll mark it for later processing
                     return v
                 try:
-                    Template(v)
+                    from docetl.operations.utils.validation import _as_video_filter
+
+                    env = Environment()
+                    env.filters["as_video"] = _as_video_filter
+                    env.parse(v)
                 except Exception as e:
                     raise ValueError(
                         f"Invalid Jinja2 template in 'prompt': {str(e)}"
@@ -336,7 +341,20 @@ Reference anchors:"""
                 and "retrieval_context" not in self.config["prompt"]
                 else rendered
             )
-            messages = [{"role": "user", "content": prompt}]
+
+            # Convert rendered prompt to multimodal content parts if it
+            # contains video placeholders (from the ``| as_video`` filter).
+            content_parts = rendered_prompt_to_content_parts(prompt)
+            if isinstance(content_parts, list):
+                model = self.config.get("model", self.default_model)
+                if "gemini" not in model.lower():
+                    raise ValueError(
+                        f"Video content requires a Gemini model, but got '{model}'. "
+                        f"Please set 'model' to a Gemini model "
+                        f"(e.g. 'gemini/gemini-3.1-flash-lite-preview')."
+                    )
+
+            messages = [{"role": "user", "content": content_parts}]
             if self.config.get("pdf_url_key", None):
                 # Append the pdf to the prompt
                 try:

--- a/docetl/operations/utils/validation.py
+++ b/docetl/operations/utils/validation.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any
 
 from asteval import Interpreter
@@ -10,6 +11,57 @@ from rich.prompt import Prompt
 from docetl.utils import has_jinja_syntax
 
 aeval = Interpreter()
+
+# Unique delimiter for video placeholders injected by the as_video filter.
+_VIDEO_DELIM = "<<<DOCETL_VIDEO:"
+_VIDEO_END = ">>>"
+_VIDEO_PATTERN = re.compile(re.escape(_VIDEO_DELIM) + r"(.+?)" + re.escape(_VIDEO_END))
+
+
+def _as_video_filter(value: Any) -> str:
+    """Jinja filter that emits a placeholder for a Video-typed value."""
+    if isinstance(value, dict) and value.get("__docetl_type__") == "Video":
+        return f"{_VIDEO_DELIM}{value['source']}{_VIDEO_END}"
+    raise ValueError(
+        f"as_video filter expects a Video object "
+        f"({{'__docetl_type__': 'Video', 'source': '...'}}), got: {value}"
+    )
+
+
+def rendered_prompt_to_content_parts(rendered: str) -> list[dict[str, Any]] | str:
+    """Convert a rendered prompt string into LiteLLM multimodal content parts.
+
+    If the rendered string contains no video placeholders, returns the string
+    unchanged.  Otherwise returns a list of content dicts suitable for
+    ``messages[0]["content"]``.
+    """
+    if _VIDEO_DELIM not in rendered:
+        return rendered
+
+    parts: list[dict[str, Any]] = []
+    last_end = 0
+    for m in _VIDEO_PATTERN.finditer(rendered):
+        # Text before this video placeholder
+        text_segment = rendered[last_end : m.start()]
+        if text_segment.strip():
+            parts.append({"type": "text", "text": text_segment})
+        video_url = m.group(1)
+        parts.append(
+            {
+                "type": "file",
+                "file": {
+                    "file_id": video_url,
+                    "format": "video/mp4",
+                },
+            }
+        )
+        last_end = m.end()
+    # Trailing text after the last placeholder
+    trailing = rendered[last_end:]
+    if trailing.strip():
+        parts.append({"type": "text", "text": trailing})
+
+    return parts
 
 
 def strict_render(template: Template | str, context: dict[str, Any]) -> str:
@@ -29,6 +81,7 @@ def strict_render(template: Template | str, context: dict[str, Any]) -> str:
     """
     # Create strict environment
     env = Environment(undefined=StrictUndefined)
+    env.filters["as_video"] = _as_video_filter
 
     # Only process string templates for non-Jinja syntax check
     if isinstance(template, str):


### PR DESCRIPTION
## Data type syntax
```json
[ ...
  {"video_content": {"__docetl_type__": "Video", "source": "xxxx.mp4"}}
... ]
```
Check list:
- [ ] other video-related data types: VideoView (video with timestamp range), EntityView (crop-over-time of entity in the video).
- [ ] Other operators support for video data.