### PR TITLE
Simplify MOAR interface and add Python API

### DIFF
--- a/docetl/__init__.py
+++ b/docetl/__init__.py
@@ -6,7 +6,7 @@ import litellm
 from docetl.runner import DSLRunner
 from docetl.optimizer import Optimizer
 from docetl.apis.pd_accessors import SemanticAccessor
-from docetl.moar.optimizer import MOARResult, FrontierPoint
+from docetl.moar.optimizer import MOARResult, OptimizedPipeline
 from docetl.utils_evaluation import register_eval
 
 # Drop unsupported params for models like gpt-5 that don't support temperature=0
@@ -20,6 +20,6 @@ __all__ = [
     "Optimizer",
     "SemanticAccessor",
     "MOARResult",
-    "FrontierPoint",
+    "OptimizedPipeline",
     "register_eval",
 ]

--- a/docetl/__init__.py
+++ b/docetl/__init__.py
@@ -6,7 +6,7 @@ import litellm
 from docetl.runner import DSLRunner
 from docetl.optimizer import Optimizer
 from docetl.apis.pd_accessors import SemanticAccessor
-from docetl.moar.optimizer import MOAROptimizer, MOARResult, FrontierPoint
+from docetl.moar.optimizer import MOARResult, FrontierPoint
 from docetl.utils_evaluation import register_eval
 
 # Drop unsupported params for models like gpt-5 that don't support temperature=0
@@ -19,7 +19,6 @@ __all__ = [
     "DSLRunner",
     "Optimizer",
     "SemanticAccessor",
-    "MOAROptimizer",
     "MOARResult",
     "FrontierPoint",
     "register_eval",

--- a/docetl/__init__.py
+++ b/docetl/__init__.py
@@ -6,6 +6,8 @@ import litellm
 from docetl.runner import DSLRunner
 from docetl.optimizer import Optimizer
 from docetl.apis.pd_accessors import SemanticAccessor
+from docetl.moar.optimizer import MOAROptimizer, MOARResult, FrontierPoint
+from docetl.utils_evaluation import register_eval
 
 # Drop unsupported params for models like gpt-5 that don't support temperature=0
 litellm.drop_params = True
@@ -13,4 +15,12 @@ litellm.drop_params = True
 # TODO: Remove after https://github.com/BerriAI/litellm/issues/7560 is fixed
 warnings.filterwarnings("ignore", category=UserWarning, module="pydantic._internal._config")
 
-__all__ = ["DSLRunner", "Optimizer", "SemanticAccessor"]
+__all__ = [
+    "DSLRunner",
+    "Optimizer",
+    "SemanticAccessor",
+    "MOAROptimizer",
+    "MOARResult",
+    "FrontierPoint",
+    "register_eval",
+]

--- a/docetl/api.py
+++ b/docetl/api.py
@@ -215,9 +215,11 @@ class Pipeline:
         **MOAR parameters** (``method="moar"``):
 
         Args:
-            eval_fn: Evaluation function ``(results_file_path: str) -> dict``
-                or path to a Python file with a ``@docetl.register_eval``
-                decorated function. **Required** for MOAR.
+            eval_fn: A callable that scores pipeline output. Accepts
+                ``(results_path) -> dict`` (1-arg) or
+                ``(dataset_path, results_path) -> dict`` (2-arg).
+                Also accepts a file path to a ``@register_eval``-decorated
+                function. **Required** for MOAR.
             metric_key: Key to extract from the eval function's return dict.
                 **Required** for MOAR.
             models: Model names to search over. ``None`` = auto-detect from
@@ -241,10 +243,13 @@ class Pipeline:
         Examples::
 
             # MOAR optimization (recommended)
-            result = pipeline.optimize(
-                eval_fn=lambda path: {"score": compute_score(path)},
-                metric_key="score",
-            )
+            def my_eval(results_path):
+                import json
+                with open(results_path) as f:
+                    results = json.load(f)
+                return {"score": sum(1 for r in results if r["correct"])}
+
+            result = pipeline.optimize(eval_fn=my_eval, metric_key="score")
 
             # Each frontier point is a runnable pipeline
             best = result.best()
@@ -261,8 +266,8 @@ class Pipeline:
             if eval_fn is None:
                 raise ValueError(
                     "eval_fn is required for MOAR optimization. "
-                    "Pass a callable (results_file_path: str) -> dict, "
-                    "or a path to a file with a @docetl.register_eval function."
+                    "Pass a callable, e.g.: "
+                    "eval_fn=lambda results_path: {'score': compute_score(results_path)}"
                 )
             if metric_key is None:
                 raise ValueError(

--- a/docetl/api.py
+++ b/docetl/api.py
@@ -190,102 +190,126 @@ class Pipeline:
 
     def optimize(
         self,
-        max_threads: int | None = None,
-        resume: bool = False,
-        save_path: str | None = None,
-    ) -> "Pipeline":
-        """
-        Optimize the pipeline using the Optimizer.
-
-        Args:
-            max_threads (int | None): Maximum number of threads to use for optimization.
-            model (str): The model to use for optimization. Defaults to "gpt-4o".
-            resume (bool): Whether to resume optimization from a previous state. Defaults to False.
-            timeout (int): Timeout for optimization in seconds. Defaults to 60.
-
-        Returns:
-            Pipeline: An optimized version of the pipeline.
-        """
-        config = self._to_dict()
-        runner = DSLRunner(
-            config,
-            base_name=os.path.join(os.getcwd(), self.name),
-            yaml_file_suffix=self.name,
-            max_threads=max_threads,
-        )
-        optimized_config, _ = runner.optimize(
-            resume=resume,
-            return_pipeline=False,
-            save_path=save_path,
-        )
-
-        updated_pipeline = Pipeline(
-            name=self.name,
-            datasets=self.datasets,
-            operations=self.operations,
-            steps=self.steps,
-            output=self.output,
-            default_model=self.default_model,
-            parsing_tools=self.parsing_tools,
-            optimizer_config=self.optimizer_config,
-        )
-        updated_pipeline._update_from_dict(optimized_config)
-        return updated_pipeline
-
-    def optimize_moar(
-        self,
-        eval_fn: Any,
-        metric_key: str,
+        method: str = "moar",
+        # MOAR parameters (used when method="moar")
+        eval_fn: Any = None,
+        metric_key: str | None = None,
         models: list[str] | None = None,
         agent_model: str | None = None,
         max_iterations: int = 20,
         save_dir: str | None = None,
         exploration_weight: float = 1.414,
         dataset_path: str | None = None,
-    ) -> "MOARResult":
+        # V1 parameters (used when method="v1")
+        max_threads: int | None = None,
+        resume: bool = False,
+        save_path: str | None = None,
+    ) -> "Pipeline | MOARResult":
         """
-        Optimize the pipeline using MOAR (Multi-Objective Agentic Rewrites).
+        Optimize the pipeline.
 
-        Auto-detects available models from environment API keys when *models*
-        is not provided.
+        Args:
+            method: ``"moar"`` (default) for multi-objective agentic rewrite
+                optimization, or ``"v1"`` for the legacy single-pass optimizer.
+
+        **MOAR parameters** (``method="moar"``):
 
         Args:
             eval_fn: Evaluation function ``(results_file_path: str) -> dict``
                 or path to a Python file with a ``@docetl.register_eval``
-                decorated function.
+                decorated function. **Required** for MOAR.
             metric_key: Key to extract from the eval function's return dict.
-            models: Model names to search over. ``None`` = auto-detect.
+                **Required** for MOAR.
+            models: Model names to search over. ``None`` = auto-detect from
+                environment API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.).
             agent_model: Model for the rewrite agent. ``None`` = auto-select.
             max_iterations: MCTS iterations (default 20).
             save_dir: Output directory. ``None`` = temp directory.
-            exploration_weight: UCB exploration constant.
+            exploration_weight: UCB exploration constant (default sqrt(2)).
             dataset_path: Explicit dataset path override.
 
+        **V1 parameters** (``method="v1"``):
+
+        Args:
+            max_threads: Maximum threads for optimization.
+            resume: Resume from a previous optimization state.
+            save_path: Path to save the optimized pipeline.
+
         Returns:
-            MOARResult with the Pareto frontier of optimized pipelines.
+            ``MOARResult`` when ``method="moar"``, ``Pipeline`` when ``method="v1"``.
 
-        Example::
+        Examples::
 
-            result = pipeline.optimize_moar(
+            # MOAR optimization (recommended)
+            result = pipeline.optimize(
                 eval_fn=lambda path: {"score": compute_score(path)},
                 metric_key="score",
             )
             print(result.best())
-        """
-        from docetl.moar.optimizer import MOAROptimizer
 
-        optimizer = MOAROptimizer(
-            pipeline=self,
-            eval_fn=eval_fn,
-            metric_key=metric_key,
-            models=models,
-            agent_model=agent_model,
-            max_iterations=max_iterations,
-            save_dir=save_dir,
-            exploration_weight=exploration_weight,
-            dataset_path=dataset_path,
-        )
-        return optimizer.optimize()
+            # V1 optimization (legacy)
+            optimized = pipeline.optimize(method="v1")
+            optimized.run()
+        """
+        if method == "moar":
+            if eval_fn is None:
+                raise ValueError(
+                    "eval_fn is required for MOAR optimization. "
+                    "Pass a callable (results_file_path: str) -> dict, "
+                    "or a path to a file with a @docetl.register_eval function."
+                )
+            if metric_key is None:
+                raise ValueError(
+                    "metric_key is required for MOAR optimization. "
+                    "This is the key in your eval function's return dict to optimize."
+                )
+
+            from docetl.moar.optimizer import MOAROptimizer
+
+            optimizer = MOAROptimizer(
+                pipeline=self,
+                eval_fn=eval_fn,
+                metric_key=metric_key,
+                models=models,
+                agent_model=agent_model,
+                max_iterations=max_iterations,
+                save_dir=save_dir,
+                exploration_weight=exploration_weight,
+                dataset_path=dataset_path,
+            )
+            return optimizer.optimize()
+
+        elif method == "v1":
+            config = self._to_dict()
+            runner = DSLRunner(
+                config,
+                base_name=os.path.join(os.getcwd(), self.name),
+                yaml_file_suffix=self.name,
+                max_threads=max_threads,
+            )
+            optimized_config, _ = runner.optimize(
+                resume=resume,
+                return_pipeline=False,
+                save_path=save_path,
+            )
+
+            updated_pipeline = Pipeline(
+                name=self.name,
+                datasets=self.datasets,
+                operations=self.operations,
+                steps=self.steps,
+                output=self.output,
+                default_model=self.default_model,
+                parsing_tools=self.parsing_tools,
+                optimizer_config=self.optimizer_config,
+            )
+            updated_pipeline._update_from_dict(optimized_config)
+            return updated_pipeline
+
+        else:
+            raise ValueError(
+                f"Unknown optimization method {method!r}. Use 'moar' or 'v1'."
+            )
 
     def run(self, max_threads: int | None = None) -> float:
         """

--- a/docetl/api.py
+++ b/docetl/api.py
@@ -232,6 +232,61 @@ class Pipeline:
         updated_pipeline._update_from_dict(optimized_config)
         return updated_pipeline
 
+    def optimize_moar(
+        self,
+        eval_fn: Any,
+        metric_key: str,
+        models: list[str] | None = None,
+        agent_model: str | None = None,
+        max_iterations: int = 20,
+        save_dir: str | None = None,
+        exploration_weight: float = 1.414,
+        dataset_path: str | None = None,
+    ) -> "MOARResult":
+        """
+        Optimize the pipeline using MOAR (Multi-Objective Agentic Rewrites).
+
+        Auto-detects available models from environment API keys when *models*
+        is not provided.
+
+        Args:
+            eval_fn: Evaluation function ``(results_file_path: str) -> dict``
+                or path to a Python file with a ``@docetl.register_eval``
+                decorated function.
+            metric_key: Key to extract from the eval function's return dict.
+            models: Model names to search over. ``None`` = auto-detect.
+            agent_model: Model for the rewrite agent. ``None`` = auto-select.
+            max_iterations: MCTS iterations (default 20).
+            save_dir: Output directory. ``None`` = temp directory.
+            exploration_weight: UCB exploration constant.
+            dataset_path: Explicit dataset path override.
+
+        Returns:
+            MOARResult with the Pareto frontier of optimized pipelines.
+
+        Example::
+
+            result = pipeline.optimize_moar(
+                eval_fn=lambda path: {"score": compute_score(path)},
+                metric_key="score",
+            )
+            print(result.best())
+        """
+        from docetl.moar.optimizer import MOAROptimizer
+
+        optimizer = MOAROptimizer(
+            pipeline=self,
+            eval_fn=eval_fn,
+            metric_key=metric_key,
+            models=models,
+            agent_model=agent_model,
+            max_iterations=max_iterations,
+            save_dir=save_dir,
+            exploration_weight=exploration_weight,
+            dataset_path=dataset_path,
+        )
+        return optimizer.optimize()
+
     def run(self, max_threads: int | None = None) -> float:
         """
         Run the pipeline using the DSLRunner.

--- a/docetl/api.py
+++ b/docetl/api.py
@@ -204,7 +204,7 @@ class Pipeline:
         max_threads: int | None = None,
         resume: bool = False,
         save_path: str | None = None,
-    ) -> "Pipeline | MOARResult":
+    ) -> "MOARResult | Pipeline":
         """
         Optimize the pipeline.
 
@@ -245,7 +245,13 @@ class Pipeline:
                 eval_fn=lambda path: {"score": compute_score(path)},
                 metric_key="score",
             )
-            print(result.best())
+
+            # Each frontier point is a runnable pipeline
+            best = result.best()
+            best.run()
+
+            # Inspect all explored plans as a DataFrame
+            df = result.to_df()
 
             # V1 optimization (legacy)
             optimized = pipeline.optimize(method="v1")

--- a/docetl/cli.py
+++ b/docetl/cli.py
@@ -141,14 +141,22 @@ def build(
         result = opt.optimize()
 
         typer.echo("\n✅ MOAR optimization completed successfully!")
-        if result.save_dir:
-            typer.echo(f"   Results saved to: {result.save_dir}")
+        typer.echo(f"   Frontier: {len(result.frontier)} pipelines")
         best = result.best()
         if best:
-            typer.echo(
-                f"   Frontier: {len(result.frontier)} points, "
-                f"best accuracy: {best.accuracy:.4f}"
-            )
+            typer.echo(f"   Best accuracy: {best.accuracy:.4f} (cost: ${best.cost:.4f})")
+        cheapest = result.cheapest()
+        if cheapest and cheapest is not best:
+            typer.echo(f"   Cheapest: ${cheapest.cost:.4f} (accuracy: {cheapest.accuracy:.4f})")
+        if result.save_dir:
+            typer.echo(f"\n   Optimized pipelines saved to: {result.save_dir}/")
+            for p in result.frontier:
+                tag = ""
+                if best and p is best:
+                    tag = " (best accuracy)"
+                elif cheapest and p is cheapest:
+                    tag = " (cheapest)"
+                typer.echo(f"     - {Path(p.yaml_path).name}{tag}")
     except Exception as e:
         typer.echo(f"Error running MOAR optimization: {e}", err=True)
         raise typer.Exit(1)

--- a/docetl/cli.py
+++ b/docetl/cli.py
@@ -164,18 +164,53 @@ def build(
             console.print(error_panel)
             raise typer.Exit(1)
 
-        # Run MOAR optimization
-        from docetl.moar.cli_helpers import run_moar_optimization
+        # Run MOAR optimization via MOAROptimizer
+        from docetl.moar.optimizer import MOAROptimizer
+        from docetl.utils_evaluation import load_custom_evaluate_func
 
         try:
-            results = run_moar_optimization(
-                yaml_path=str(yaml_file),
-                optimizer_config=optimizer_config,
+            save_dir = optimizer_config.get("save_dir")
+
+            # Resolve eval function from file
+            # We need dataset_path to wrap the eval function
+            dataset_path = optimizer_config.get("dataset_path")
+            if not dataset_path:
+                import yaml as yaml_lib2
+
+                with open(yaml_file, "r") as f2:
+                    cfg = yaml_lib2.safe_load(f2)
+                ds = cfg.get("datasets", {})
+                if ds:
+                    _, ds_cfg = next(iter(ds.items()))
+                    dataset_path = ds_cfg.get("path", "")
+
+            eval_fn = load_custom_evaluate_func(
+                optimizer_config["evaluation_file"],
+                dataset_path or "",
             )
+
+            opt = MOAROptimizer(
+                pipeline=str(yaml_file),
+                eval_fn=eval_fn,
+                metric_key=optimizer_config["metric_key"],
+                models=optimizer_config.get("available_models"),
+                agent_model=optimizer_config.get("rewrite_agent_model")
+                or optimizer_config.get("model"),
+                max_iterations=optimizer_config["max_iterations"],
+                save_dir=save_dir,
+                exploration_weight=optimizer_config.get("exploration_weight", 1.414),
+                dataset_path=optimizer_config.get("dataset_path"),
+            )
+            result = opt.optimize()
+
             typer.echo("\n✅ MOAR optimization completed successfully!")
-            typer.echo(f"   Results saved to: {optimizer_config.get('save_dir')}")
-            if results.get("evaluation_file"):
-                typer.echo(f"   Evaluation: {results['evaluation_file']}")
+            typer.echo(f"   Results saved to: {save_dir}")
+            typer.echo(
+                f"   Frontier: {len(result.frontier)} points, "
+                f"best accuracy: {result.best().accuracy:.4f}"
+                if result.best()
+                else ""
+            )
         except Exception as e:
             typer.echo(f"Error running MOAR optimization: {e}", err=True)
             raise typer.Exit(1)

--- a/docetl/cli.py
+++ b/docetl/cli.py
@@ -20,217 +20,138 @@ def build(
     yaml_file: Path = typer.Argument(
         ..., help="Path to the YAML file containing the pipeline configuration"
     ),
-    optimizer: str = typer.Option(
-        "moar",
-        "--optimizer",
-        "-o",
-        help="Optimizer to use: 'moar' (default) or 'v1' (deprecated)",
-    ),
     max_threads: int | None = typer.Option(
         None, help="Maximum number of threads to use for running operations"
     ),
-    resume: bool = typer.Option(
-        False, help="Resume optimization from a previous build that may have failed"
-    ),
-    save_path: Path = typer.Option(
-        None, help="Path to save the optimized pipeline configuration"
-    ),
 ):
     """
-    Build and optimize the configuration specified in the YAML file.
-    Any arguments passed here will override the values in the YAML file.
+    Optimize a pipeline using MOAR (Multi-Objective Agentic Rewrites).
+
+    Requires an optimizer_config section in the YAML with at least:
+      - evaluation_file: path to a Python file with a @docetl.register_eval function
+      - metric_key: key to extract from evaluation results
+
+    Models are auto-detected from API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY,
+    GEMINI_API_KEY, AZURE_API_KEY) unless available_models is set explicitly.
 
     Args:
-        yaml_file (Path): Path to the YAML file containing the pipeline configuration.
-        optimizer (str): Optimizer to use - 'moar' or 'v1' (required).
-        max_threads (int | None): Maximum number of threads to use for running operations.
-        resume (bool): Whether to resume optimization from a previous run. Defaults to False.
-        save_path (Path): Path to save the optimized pipeline configuration.
+        yaml_file (Path): Path to the YAML pipeline file.
+        max_threads (int | None): Maximum number of threads for operations.
     """
-    # Get the current working directory (where the user called the command)
     cwd = os.getcwd()
 
-    # Load .env file from the current working directory
     env_file = os.path.join(cwd, ".env")
     if os.path.exists(env_file):
         load_dotenv(env_file)
 
-    # Validate optimizer choice
-    if optimizer not in ["moar", "v1"]:
-        typer.echo(
-            f"Error: optimizer must be 'moar' or 'v1', got '{optimizer}'", err=True
-        )
-        raise typer.Exit(1)
-
-    # Load YAML to check for optimizer_config
     import yaml as yaml_lib
 
     with open(yaml_file, "r") as f:
         config = yaml_lib.safe_load(f)
 
-    if optimizer == "moar":
-        optimizer_config = config.get("optimizer_config", {})
-        if not optimizer_config:
-            example_yaml = """optimizer_config:
-  type: moar
-  save_dir: ./moar_results
-  available_models:
-    - gpt-5
-    - gpt-4o
-  evaluation_file: workloads/medical/evaluate_medications.py
-  metric_key: medication_extraction_score
-  max_iterations: 40
-  model: gpt-5"""
+    optimizer_config = config.get("optimizer_config", {})
+    if not optimizer_config:
+        example_yaml = """optimizer_config:
+  evaluation_file: evaluate.py
+  metric_key: score
+  save_dir: ./moar_results       # optional, defaults to temp dir
+  max_iterations: 20              # optional, defaults to 20
+  # available_models:             # optional, auto-detected from API keys
+  #   - gpt-4.1
+  #   - anthropic/claude-sonnet-4-6"""
 
-            error_panel = Panel(
-                f"[bold red]Error:[/bold red] optimizer_config section is required in YAML for MOAR optimizer.\n\n"
-                f"[bold]Example:[/bold]\n"
-                f"[dim]{example_yaml}[/dim]\n\n"
-                f"[yellow]Note:[/yellow] dataset_name is inferred from the 'datasets' section. "
-                f"dataset_path can optionally be specified in optimizer_config, otherwise it's inferred from the 'datasets' section.",
-                title="[bold red]Missing optimizer_config[/bold red]",
-                border_style="red",
-            )
-            console.print(error_panel)
-            raise typer.Exit(1)
+        error_panel = Panel(
+            f"[bold red]Error:[/bold red] optimizer_config section is required in YAML.\n\n"
+            f"[bold]Example:[/bold]\n"
+            f"[dim]{example_yaml}[/dim]",
+            title="[bold red]Missing optimizer_config[/bold red]",
+            border_style="red",
+        )
+        console.print(error_panel)
+        raise typer.Exit(1)
 
-        if optimizer_config.get("type") != "moar":
-            error_panel = Panel(
-                f"[bold red]Error:[/bold red] optimizer_config.type must be 'moar', got '[yellow]{optimizer_config.get('type')}[/yellow]'",
-                title="[bold red]Invalid optimizer type[/bold red]",
-                border_style="red",
-            )
-            console.print(error_panel)
-            raise typer.Exit(1)
+    required_fields = {
+        "evaluation_file": "Path to evaluation function file",
+        "metric_key": "Key to extract from evaluation results",
+    }
 
-        # Validate required fields in optimizer_config
-        required_fields = {
-            "save_dir": "Output directory for MOAR results",
-            "available_models": "List of model names to use",
-            "evaluation_file": "Path to evaluation function file",
-            "metric_key": "Key to extract from evaluation results",
-            "max_iterations": "Number of MOARSearch iterations",
-            "model": "LLM model name for directive instantiation",
-        }
+    missing_fields = [
+        field for field in required_fields if not optimizer_config.get(field)
+    ]
+    if missing_fields:
+        fields_table = Table(
+            show_header=True, header_style="bold cyan", box=None, padding=(0, 2)
+        )
+        fields_table.add_column("Field", style="yellow")
+        fields_table.add_column("Description", style="dim")
 
-        missing_fields = [
-            field for field in required_fields if not optimizer_config.get(field)
-        ]
-        if missing_fields:
-            # Create a table for required fields
-            fields_table = Table(
-                show_header=True, header_style="bold cyan", box=None, padding=(0, 2)
-            )
-            fields_table.add_column("Field", style="yellow")
-            fields_table.add_column("Description", style="dim")
+        for field, desc in required_fields.items():
+            style = "bold red" if field in missing_fields else "dim"
+            fields_table.add_row(f"[{style}]{field}[/{style}]", desc)
 
-            for field, desc in required_fields.items():
-                style = "bold red" if field in missing_fields else "dim"
-                fields_table.add_row(f"[{style}]{field}[/{style}]", desc)
+        missing_list = ", ".join(
+            [f"[bold red]{f}[/bold red]" for f in missing_fields]
+        )
 
-            # Create example YAML
-            example_yaml = """optimizer_config:
-  type: moar
-  save_dir: ./moar_results
-  available_models:
-    - gpt-5
-    - gpt-4o
-  evaluation_file: workloads/medical/evaluate_medications.py
-  metric_key: medication_extraction_score
-  max_iterations: 40
-  model: gpt-5"""
+        from rich.console import Group
 
-            missing_list = ", ".join(
-                [f"[bold red]{f}[/bold red]" for f in missing_fields]
-            )
+        error_group = Group(
+            f"[bold red]Missing required fields:[/bold red] {missing_list}\n",
+            "[bold]Required fields:[/bold]",
+            fields_table,
+        )
 
-            # Build error content with table rendered separately
-            from rich.console import Group
+        error_panel = Panel(
+            error_group,
+            title="[bold red]Missing Required Fields[/bold red]",
+            border_style="red",
+        )
+        console.print(error_panel)
+        raise typer.Exit(1)
 
-            error_group = Group(
-                f"[bold red]Missing required fields:[/bold red] {missing_list}\n",
-                "[bold]Required fields:[/bold]",
-                fields_table,
-                f"\n[bold]Example:[/bold]\n[dim]{example_yaml}[/dim]\n",
-                "[yellow]Note:[/yellow] dataset_name is inferred from the 'datasets' section. "
-                "dataset_path can optionally be specified in optimizer_config, otherwise it's inferred from the 'datasets' section.",
-            )
+    from docetl.moar.optimizer import MOAROptimizer
+    from docetl.utils_evaluation import load_custom_evaluate_func
 
-            error_panel = Panel(
-                error_group,
-                title="[bold red]Missing Required Fields[/bold red]",
-                border_style="red",
-            )
-            console.print(error_panel)
-            raise typer.Exit(1)
+    try:
+        # Resolve dataset path for wrapping the eval function
+        dataset_path = optimizer_config.get("dataset_path")
+        if not dataset_path:
+            ds = config.get("datasets", {})
+            if ds:
+                _, ds_cfg = next(iter(ds.items()))
+                dataset_path = ds_cfg.get("path", "")
 
-        # Run MOAR optimization via MOAROptimizer
-        from docetl.moar.optimizer import MOAROptimizer
-        from docetl.utils_evaluation import load_custom_evaluate_func
+        eval_fn = load_custom_evaluate_func(
+            optimizer_config["evaluation_file"],
+            dataset_path or "",
+        )
 
-        try:
-            save_dir = optimizer_config.get("save_dir")
+        opt = MOAROptimizer(
+            pipeline=str(yaml_file),
+            eval_fn=eval_fn,
+            metric_key=optimizer_config["metric_key"],
+            models=optimizer_config.get("available_models"),
+            agent_model=optimizer_config.get("rewrite_agent_model")
+            or optimizer_config.get("model"),
+            max_iterations=optimizer_config.get("max_iterations", 20),
+            save_dir=optimizer_config.get("save_dir"),
+            exploration_weight=optimizer_config.get("exploration_weight", 1.414),
+            dataset_path=optimizer_config.get("dataset_path"),
+        )
+        result = opt.optimize()
 
-            # Resolve eval function from file
-            # We need dataset_path to wrap the eval function
-            dataset_path = optimizer_config.get("dataset_path")
-            if not dataset_path:
-                import yaml as yaml_lib2
-
-                with open(yaml_file, "r") as f2:
-                    cfg = yaml_lib2.safe_load(f2)
-                ds = cfg.get("datasets", {})
-                if ds:
-                    _, ds_cfg = next(iter(ds.items()))
-                    dataset_path = ds_cfg.get("path", "")
-
-            eval_fn = load_custom_evaluate_func(
-                optimizer_config["evaluation_file"],
-                dataset_path or "",
-            )
-
-            opt = MOAROptimizer(
-                pipeline=str(yaml_file),
-                eval_fn=eval_fn,
-                metric_key=optimizer_config["metric_key"],
-                models=optimizer_config.get("available_models"),
-                agent_model=optimizer_config.get("rewrite_agent_model")
-                or optimizer_config.get("model"),
-                max_iterations=optimizer_config["max_iterations"],
-                save_dir=save_dir,
-                exploration_weight=optimizer_config.get("exploration_weight", 1.414),
-                dataset_path=optimizer_config.get("dataset_path"),
-            )
-            result = opt.optimize()
-
-            typer.echo("\n✅ MOAR optimization completed successfully!")
-            typer.echo(f"   Results saved to: {save_dir}")
+        typer.echo("\n✅ MOAR optimization completed successfully!")
+        if result.save_dir:
+            typer.echo(f"   Results saved to: {result.save_dir}")
+        best = result.best()
+        if best:
             typer.echo(
                 f"   Frontier: {len(result.frontier)} points, "
-                f"best accuracy: {result.best().accuracy:.4f}"
-                if result.best()
-                else ""
+                f"best accuracy: {best.accuracy:.4f}"
             )
-        except Exception as e:
-            typer.echo(f"Error running MOAR optimization: {e}", err=True)
-            raise typer.Exit(1)
-
-    else:  # v1 optimizer (deprecated)
-        console.print(
-            Panel(
-                "[bold yellow]Warning:[/bold yellow] The V1 optimizer is deprecated. "
-                "Please use MOAR optimizer instead: [bold]docetl build pipeline.yaml --optimizer moar[/bold]",
-                title="[bold yellow]Deprecated Optimizer[/bold yellow]",
-                border_style="yellow",
-            )
-        )
-        runner = DSLRunner.from_yaml(str(yaml_file), max_threads=max_threads)
-        runner.optimize(
-            save=True,
-            return_pipeline=False,
-            resume=resume,
-            save_path=save_path,
-        )
+    except Exception as e:
+        typer.echo(f"Error running MOAR optimization: {e}", err=True)
+        raise typer.Exit(1)
 
 
 @app.command()

--- a/docetl/moar/__init__.py
+++ b/docetl/moar/__init__.py
@@ -24,10 +24,17 @@ AVAILABLE_MODELS = [
 from .MOARSearch import MOARSearch  # noqa: E402
 from .Node import Node  # noqa: E402
 from .ParetoFrontier import ParetoFrontier  # noqa: E402
+from .models import detect_available_models, default_agent_model  # noqa: E402
+from .optimizer import MOAROptimizer, MOARResult, FrontierPoint  # noqa: E402
 
 __all__ = [
     "MOARSearch",
-    "Node", 
+    "Node",
     "ParetoFrontier",
-    "AVAILABLE_MODELS"
+    "AVAILABLE_MODELS",
+    "MOAROptimizer",
+    "MOARResult",
+    "FrontierPoint",
+    "detect_available_models",
+    "default_agent_model",
 ]

--- a/docetl/moar/__init__.py
+++ b/docetl/moar/__init__.py
@@ -25,7 +25,7 @@ from .MOARSearch import MOARSearch  # noqa: E402
 from .Node import Node  # noqa: E402
 from .ParetoFrontier import ParetoFrontier  # noqa: E402
 from .models import detect_available_models, default_agent_model  # noqa: E402
-from .optimizer import MOAROptimizer, MOARResult, FrontierPoint  # noqa: E402
+from .optimizer import MOAROptimizer, MOARResult, OptimizedPipeline  # noqa: E402
 
 __all__ = [
     "MOARSearch",
@@ -34,7 +34,7 @@ __all__ = [
     "AVAILABLE_MODELS",
     "MOAROptimizer",
     "MOARResult",
-    "FrontierPoint",
+    "OptimizedPipeline",
     "detect_available_models",
     "default_agent_model",
 ]

--- a/docetl/moar/models.py
+++ b/docetl/moar/models.py
@@ -1,0 +1,101 @@
+"""
+Auto-detection of available LLM models based on environment API keys.
+"""
+
+import os
+from typing import List, Optional
+
+
+PROVIDER_MODELS = {
+    "OPENAI_API_KEY": [
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
+        "gpt-4o",
+        "gpt-4o-mini",
+    ],
+    "ANTHROPIC_API_KEY": [
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-haiku-4-5-20251001",
+    ],
+    "GEMINI_API_KEY": [
+        "gemini/gemini-2.5-pro",
+        "gemini/gemini-2.5-flash",
+        "gemini/gemini-2.5-flash-lite",
+    ],
+    "AZURE_API_KEY": [
+        "azure/gpt-4.1",
+        "azure/gpt-4.1-mini",
+        "azure/gpt-4.1-nano",
+        "azure/gpt-4o",
+        "azure/gpt-4o-mini",
+    ],
+    "AZURE_OPENAI_API_KEY": [
+        "azure/gpt-4.1",
+        "azure/gpt-4.1-mini",
+        "azure/gpt-4.1-nano",
+        "azure/gpt-4o",
+        "azure/gpt-4o-mini",
+    ],
+}
+
+AGENT_MODEL_PREFERENCE = [
+    ("OPENAI_API_KEY", "gpt-4.1"),
+    ("ANTHROPIC_API_KEY", "anthropic/claude-sonnet-4-6"),
+    ("GEMINI_API_KEY", "gemini/gemini-2.5-pro"),
+    ("AZURE_API_KEY", "azure/gpt-4.1"),
+    ("AZURE_OPENAI_API_KEY", "azure/gpt-4.1"),
+]
+
+
+def detect_available_models() -> List[str]:
+    """
+    Return models for all providers whose API key is set in the environment.
+
+    Checks OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, AZURE_API_KEY,
+    and AZURE_OPENAI_API_KEY. De-duplicates models (Azure keys can overlap).
+
+    Raises:
+        ValueError: If no API keys are found in the environment.
+    """
+    seen = set()
+    models = []
+    for env_var, model_list in PROVIDER_MODELS.items():
+        if os.environ.get(env_var):
+            for m in model_list:
+                if m not in seen:
+                    seen.add(m)
+                    models.append(m)
+    if not models:
+        raise ValueError(
+            "No LLM API keys found in environment. "
+            "Set at least one of: OPENAI_API_KEY, ANTHROPIC_API_KEY, "
+            "GEMINI_API_KEY, AZURE_API_KEY, or AZURE_OPENAI_API_KEY."
+        )
+    return models
+
+
+def default_agent_model(models: Optional[List[str]] = None) -> str:
+    """
+    Pick the best available model for the MOAR rewrite agent.
+
+    If *models* is provided, returns the first model from the preference list
+    that appears in *models*. Otherwise checks environment variables directly.
+
+    Raises:
+        ValueError: If no suitable model can be determined.
+    """
+    if models:
+        for _, model in AGENT_MODEL_PREFERENCE:
+            if model in models:
+                return model
+        return models[0]
+
+    for env_var, model in AGENT_MODEL_PREFERENCE:
+        if os.environ.get(env_var):
+            return model
+
+    raise ValueError(
+        "Cannot determine a rewrite agent model. "
+        "Set at least one LLM API key in the environment."
+    )

--- a/docetl/moar/optimizer.py
+++ b/docetl/moar/optimizer.py
@@ -356,7 +356,15 @@ class MOAROptimizer:
         Returns:
             MOARResult with the Pareto frontier and all explored plans.
         """
+        import os
+
         from docetl.moar import MOARSearch
+
+        if os.environ.get("USE_FRONTEND") == "true":
+            DOCETL_CONSOLE.log(
+                "[bold yellow]Warning: MOAR optimization runs in CLI mode. "
+                "The interactive frontend/TUI is not used during optimization.[/bold yellow]"
+            )
 
         DOCETL_CONSOLE.log("[bold blue]MOAROptimizer: loading dataset...[/bold blue]")
         with open(self._dataset_path, "r") as f:

--- a/docetl/moar/optimizer.py
+++ b/docetl/moar/optimizer.py
@@ -1,19 +1,7 @@
 """
 Simplified Python API for MOAR optimization.
 
-Usage with a YAML file::
-
-    from docetl.moar import MOAROptimizer
-
-    optimizer = MOAROptimizer(
-        pipeline="pipeline.yaml",
-        eval_fn=lambda results_path: {"score": compute_score(results_path)},
-        metric_key="score",
-    )
-    results = optimizer.optimize()
-    print(results.best())
-
-Usage with the Pipeline Python API::
+Usage::
 
     from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
 
@@ -25,12 +13,17 @@ Usage with the Pipeline Python API::
         output=PipelineOutput(type="file", path="output.json"),
     )
 
-    optimizer = MOAROptimizer(
-        pipeline=pipeline,
+    result = pipeline.optimize(
         eval_fn=lambda results_path: {"score": compute_score(results_path)},
         metric_key="score",
     )
-    results = optimizer.optimize()
+
+    # Each point on the frontier is a runnable pipeline
+    best = result.best()
+    best.pipeline.run()
+
+    # Inspect the frontier as a DataFrame
+    result.to_df()
 """
 
 from __future__ import annotations
@@ -50,71 +43,95 @@ from docetl.reasoning_optimizer.directives import ALL_DIRECTIVES
 from docetl.utils_dataset import get_dataset_stats
 
 if TYPE_CHECKING:
+    import pandas as pd
     from docetl.api import Pipeline
 
 
 @dataclass
-class FrontierPoint:
-    """A single point on the Pareto frontier."""
+class OptimizedPipeline:
+    """A single optimized pipeline from the MOAR search.
 
-    yaml_path: str
+    Attributes:
+        pipeline: A runnable ``DSLRunner`` instance. Call ``pipeline.load_run_save()``
+            to execute, or use it as input for further processing.
+        cost: Dollar cost of running this pipeline on the sample dataset.
+        accuracy: Evaluation metric score for this pipeline.
+        yaml_path: Path to the YAML file on disk.
+        on_frontier: Whether this point is on the Pareto frontier.
+    """
+
+    pipeline: Any  # DSLRunner — avoid import at module level
     cost: float
     accuracy: float
-    node_id: int
+    yaml_path: str
     on_frontier: bool = True
 
+    def run(self) -> float:
+        """Execute this optimized pipeline. Returns the total cost."""
+        return self.pipeline.load_run_save()
+
     def __repr__(self) -> str:
+        status = "frontier" if self.on_frontier else "dominated"
         return (
-            f"FrontierPoint(cost={self.cost:.4f}, accuracy={self.accuracy:.4f}, "
-            f"yaml={self.yaml_path!r})"
+            f"OptimizedPipeline(cost=${self.cost:.4f}, accuracy={self.accuracy:.4f}, "
+            f"{status})"
         )
 
 
 @dataclass
 class MOARResult:
-    """Results returned by MOAROptimizer.optimize()."""
+    """Results from ``pipeline.optimize()``.
 
-    frontier: List[FrontierPoint] = field(default_factory=list)
-    all_plans: List[FrontierPoint] = field(default_factory=list)
+    Access optimized pipelines via ``best()``, ``cheapest()``, ``frontier``,
+    or inspect all explored plans with ``to_df()``.
+    """
+
+    frontier: List[OptimizedPipeline] = field(default_factory=list)
+    all_plans: List[OptimizedPipeline] = field(default_factory=list)
     total_search_cost: float = 0.0
     iterations: int = 0
     duration_seconds: float = 0.0
     save_dir: Optional[str] = None
 
-    def best(self) -> Optional[FrontierPoint]:
-        """Return the highest-accuracy point on the frontier."""
-        frontier = [p for p in self.frontier if p.on_frontier]
-        if not frontier:
+    def best(self) -> Optional[OptimizedPipeline]:
+        """Return the highest-accuracy pipeline on the frontier."""
+        if not self.frontier:
             return None
-        return max(frontier, key=lambda p: p.accuracy)
+        return max(self.frontier, key=lambda p: p.accuracy)
 
-    def cheapest(self) -> Optional[FrontierPoint]:
-        """Return the lowest-cost point on the frontier."""
-        frontier = [p for p in self.frontier if p.on_frontier]
-        if not frontier:
+    def cheapest(self) -> Optional[OptimizedPipeline]:
+        """Return the lowest-cost pipeline on the frontier."""
+        if not self.frontier:
             return None
-        return min(frontier, key=lambda p: p.cost)
+        return min(self.frontier, key=lambda p: p.cost)
 
-    def summary(self) -> str:
-        """Return a human-readable summary table."""
-        lines = [
-            f"MOAR Optimization Results ({self.iterations} iterations, "
-            f"{self.duration_seconds:.1f}s, ${self.total_search_cost:.2f} search cost)",
-            f"{'─' * 70}",
-            f"  {'#':<4} {'Cost':>10} {'Accuracy':>10} {'Frontier':>10}   YAML Path",
-            f"  {'─'*4} {'─'*10} {'─'*10} {'─'*10}   {'─'*30}",
-        ]
-        for i, p in enumerate(
-            sorted(self.all_plans, key=lambda x: x.accuracy, reverse=True), 1
-        ):
-            marker = "  *" if p.on_frontier else ""
-            lines.append(
-                f"  {i:<4} ${p.cost:>9.4f} {p.accuracy:>10.4f} {marker:>10}   {p.yaml_path}"
+    def to_df(self) -> "pd.DataFrame":
+        """Return all explored plans as a pandas DataFrame."""
+        import pandas as pd
+
+        rows = []
+        for p in sorted(self.all_plans, key=lambda x: x.accuracy, reverse=True):
+            rows.append(
+                {
+                    "cost": p.cost,
+                    "accuracy": p.accuracy,
+                    "on_frontier": p.on_frontier,
+                    "yaml_path": p.yaml_path,
+                }
             )
-        lines.append(f"\n  Frontier points marked with *")
+        df = pd.DataFrame(rows)
         if self.save_dir:
-            lines.append(f"  Full results saved to: {self.save_dir}")
-        return "\n".join(lines)
+            DOCETL_CONSOLE.log(f"[dim]All pipelines saved to: {self.save_dir}[/dim]")
+        return df
+
+    def __repr__(self) -> str:
+        best = self.best()
+        best_str = f", best accuracy={best.accuracy:.4f}" if best else ""
+        return (
+            f"MOARResult({len(self.frontier)} frontier points, "
+            f"{len(self.all_plans)} total{best_str}, "
+            f"save_dir={self.save_dir!r})"
+        )
 
 
 class MOAROptimizer:
@@ -364,6 +381,8 @@ class MOAROptimizer:
 
     def _build_result(self, moar: Any, duration: float) -> MOARResult:
         """Extract results from MOARSearch into a MOARResult."""
+        from docetl.runner import DSLRunner
+
         frontier_set = set(moar.pareto_frontier.frontier_plans)
 
         all_plans = []
@@ -371,11 +390,12 @@ class MOAROptimizer:
         for node in moar.pareto_frontier.plans:
             accuracy = moar.pareto_frontier.plans_accuracy.get(node, 0.0)
             on_frontier = node in frontier_set
-            point = FrontierPoint(
+            runner = DSLRunner.from_yaml(node.yaml_file_path)
+            point = OptimizedPipeline(
+                pipeline=runner,
                 yaml_path=node.yaml_file_path,
                 cost=node.cost,
                 accuracy=accuracy,
-                node_id=node.get_id(),
                 on_frontier=on_frontier,
             )
             all_plans.append(point)
@@ -426,7 +446,6 @@ class MOAROptimizer:
             pareto_file = self._save_dir / "pareto_frontier.json"
             pareto_data = [
                 {
-                    "node_id": p.node_id,
                     "yaml_path": p.yaml_path,
                     "cost": p.cost,
                     "accuracy": p.accuracy,

--- a/docetl/moar/optimizer.py
+++ b/docetl/moar/optimizer.py
@@ -13,10 +13,12 @@ Usage::
         output=PipelineOutput(type="file", path="output.json"),
     )
 
-    result = pipeline.optimize(
-        eval_fn=lambda results_path: {"score": compute_score(results_path)},
-        metric_key="score",
-    )
+    def my_eval(results_path):
+        with open(results_path) as f:
+            results = json.load(f)
+        return {"score": sum(1 for r in results if r["correct"])}
+
+    result = pipeline.optimize(eval_fn=my_eval, metric_key="score")
 
     # Each point on the frontier is a runnable pipeline
     best = result.best()
@@ -145,10 +147,11 @@ class MOAROptimizer:
         pipeline: A ``Pipeline`` object, a path to a YAML pipeline file (str or
             Path), or a raw config dict. When a ``Pipeline`` is given, it is
             serialized to a temporary YAML file automatically.
-        eval_fn: Evaluation function with signature
-            ``(results_file_path: str) -> dict[str, Any]``.
-            Alternatively, a path to a Python file containing a function
-            decorated with ``@docetl.register_eval``.
+        eval_fn: A callable that scores pipeline output. Two signatures are
+            supported: ``(results_path: str) -> dict`` (1-arg) or
+            ``(dataset_path: str, results_path: str) -> dict`` (2-arg, the
+            dataset path is curried automatically). Also accepts a file
+            path to a ``@register_eval``-decorated function (for CLI use).
         metric_key: Key to extract from the eval function's return dict.
         models: List of model names to search over. If ``None``, auto-detects
             from environment API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY,
@@ -266,8 +269,34 @@ class MOAROptimizer:
         eval_fn: Union[Callable, str, Path],
         dataset_path: Optional[Union[str, Path]],
     ) -> Callable[[str], Dict[str, Any]]:
-        """Accept a callable directly or load from a file path."""
+        """Normalize eval_fn to internal signature ``(results_path) -> dict``.
+
+        Accepts:
+        - A callable with 1 param: ``(results_path) -> dict`` — used as-is.
+        - A callable with 2 params: ``(dataset_path, results_path) -> dict``
+          — dataset_path is curried in automatically.
+        - A file path (str/Path) to a Python file with a ``@register_eval``
+          decorated function (legacy / CLI usage).
+        """
         if callable(eval_fn):
+            import inspect
+
+            sig = inspect.signature(eval_fn)
+            params = [
+                p
+                for p in sig.parameters.values()
+                if p.default is inspect.Parameter.empty
+            ]
+            if len(params) >= 2:
+                ds_path = str(Path(dataset_path).resolve()) if dataset_path else ""
+                if not ds_path:
+                    ds_path, _ = self._infer_dataset_info()
+                captured_ds_path = ds_path
+
+                def _wrapped(results_file_path: str) -> Dict[str, Any]:
+                    return eval_fn(captured_ds_path, results_file_path)
+
+                return _wrapped
             return eval_fn
 
         from docetl.utils_evaluation import load_custom_evaluate_func

--- a/docetl/moar/optimizer.py
+++ b/docetl/moar/optimizer.py
@@ -1,7 +1,7 @@
 """
 Simplified Python API for MOAR optimization.
 
-Usage::
+Usage with a YAML file::
 
     from docetl.moar import MOAROptimizer
 
@@ -12,6 +12,25 @@ Usage::
     )
     results = optimizer.optimize()
     print(results.best())
+
+Usage with the Pipeline Python API::
+
+    from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
+
+    pipeline = Pipeline(
+        name="my_pipeline",
+        datasets={"input": Dataset(type="file", path="data.json")},
+        operations=[MapOp(name="extract", type="map", prompt="...")],
+        steps=[PipelineStep(name="step1", input="input", operations=["extract"])],
+        output=PipelineOutput(type="file", path="output.json"),
+    )
+
+    optimizer = MOAROptimizer(
+        pipeline=pipeline,
+        eval_fn=lambda results_path: {"score": compute_score(results_path)},
+        metric_key="score",
+    )
+    results = optimizer.optimize()
 """
 
 from __future__ import annotations
@@ -21,7 +40,7 @@ import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import yaml
 
@@ -29,6 +48,9 @@ from docetl.console import DOCETL_CONSOLE
 from docetl.moar.models import default_agent_model, detect_available_models
 from docetl.reasoning_optimizer.directives import ALL_DIRECTIVES
 from docetl.utils_dataset import get_dataset_stats
+
+if TYPE_CHECKING:
+    from docetl.api import Pipeline
 
 
 @dataclass
@@ -103,7 +125,9 @@ class MOAROptimizer:
     models from environment API keys.
 
     Args:
-        pipeline: Path to the YAML pipeline file.
+        pipeline: A ``Pipeline`` object, a path to a YAML pipeline file (str or
+            Path), or a raw config dict. When a ``Pipeline`` is given, it is
+            serialized to a temporary YAML file automatically.
         eval_fn: Evaluation function with signature
             ``(results_file_path: str) -> dict[str, Any]``.
             Alternatively, a path to a Python file containing a function
@@ -118,14 +142,32 @@ class MOAROptimizer:
         save_dir: Directory for output files. If ``None``, uses a temp directory.
         exploration_weight: UCB exploration constant (default sqrt(2)).
         dataset_path: Explicit path to the sample dataset JSON. If ``None``,
-            inferred from the pipeline YAML's ``datasets`` section.
+            inferred from the pipeline's ``datasets`` section.
         dataset_name: Name of the dataset. If ``None``, inferred from the
-            pipeline YAML's ``datasets`` section.
+            pipeline's ``datasets`` section.
 
-    Example::
+    Examples::
 
+        # From a YAML file
         optimizer = MOAROptimizer(
             pipeline="pipeline.yaml",
+            eval_fn=lambda p: {"score": my_score(p)},
+            metric_key="score",
+        )
+        results = optimizer.optimize()
+
+        # From a Pipeline object
+        from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
+
+        pipeline = Pipeline(
+            name="my_pipeline",
+            datasets={"input": Dataset(type="file", path="data.json")},
+            operations=[MapOp(name="extract", type="map", prompt="Extract entities")],
+            steps=[PipelineStep(name="step1", input="input", operations=["extract"])],
+            output=PipelineOutput(type="file", path="output.json"),
+        )
+        optimizer = MOAROptimizer(
+            pipeline=pipeline,
             eval_fn=lambda p: {"score": my_score(p)},
             metric_key="score",
         )
@@ -135,7 +177,7 @@ class MOAROptimizer:
 
     def __init__(
         self,
-        pipeline: Union[str, Path],
+        pipeline: Union["Pipeline", str, Path, Dict[str, Any]],
         eval_fn: Union[Callable[[str], Dict[str, Any]], str, Path],
         metric_key: str,
         models: Optional[List[str]] = None,
@@ -146,7 +188,7 @@ class MOAROptimizer:
         dataset_path: Optional[Union[str, Path]] = None,
         dataset_name: Optional[str] = None,
     ):
-        self.pipeline_path = str(Path(pipeline).resolve())
+        self.pipeline_path = self._resolve_pipeline(pipeline, save_dir)
         self.metric_key = metric_key
         self.max_iterations = max_iterations
         self.exploration_weight = exploration_weight
@@ -176,6 +218,31 @@ class MOAROptimizer:
         self._dataset_path, self._dataset_name = self._resolve_dataset(
             dataset_path, dataset_name
         )
+
+    def _resolve_pipeline(
+        self,
+        pipeline: Union["Pipeline", str, Path, Dict[str, Any]],
+        save_dir: Optional[Union[str, Path]],
+    ) -> str:
+        """Convert pipeline input to a resolved YAML file path."""
+        from docetl.api import Pipeline as PipelineClass
+
+        if isinstance(pipeline, PipelineClass):
+            target_dir = Path(save_dir).resolve() if save_dir else Path(tempfile.mkdtemp(prefix="moar_pipeline_"))
+            target_dir.mkdir(parents=True, exist_ok=True)
+            yaml_path = target_dir / f"{pipeline.name}.yaml"
+            pipeline.to_yaml(str(yaml_path))
+            return str(yaml_path)
+
+        if isinstance(pipeline, dict):
+            target_dir = Path(save_dir).resolve() if save_dir else Path(tempfile.mkdtemp(prefix="moar_pipeline_"))
+            target_dir.mkdir(parents=True, exist_ok=True)
+            yaml_path = target_dir / "pipeline.yaml"
+            with open(yaml_path, "w") as f:
+                yaml.dump(pipeline, f, default_flow_style=False, sort_keys=False)
+            return str(yaml_path)
+
+        return str(Path(pipeline).resolve())
 
     def _resolve_eval_fn(
         self,

--- a/docetl/moar/optimizer.py
+++ b/docetl/moar/optimizer.py
@@ -1,0 +1,370 @@
+"""
+Simplified Python API for MOAR optimization.
+
+Usage::
+
+    from docetl.moar import MOAROptimizer
+
+    optimizer = MOAROptimizer(
+        pipeline="pipeline.yaml",
+        eval_fn=lambda results_path: {"score": compute_score(results_path)},
+        metric_key="score",
+    )
+    results = optimizer.optimize()
+    print(results.best())
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import yaml
+
+from docetl.console import DOCETL_CONSOLE
+from docetl.moar.models import default_agent_model, detect_available_models
+from docetl.reasoning_optimizer.directives import ALL_DIRECTIVES
+from docetl.utils_dataset import get_dataset_stats
+
+
+@dataclass
+class FrontierPoint:
+    """A single point on the Pareto frontier."""
+
+    yaml_path: str
+    cost: float
+    accuracy: float
+    node_id: int
+    on_frontier: bool = True
+
+    def __repr__(self) -> str:
+        return (
+            f"FrontierPoint(cost={self.cost:.4f}, accuracy={self.accuracy:.4f}, "
+            f"yaml={self.yaml_path!r})"
+        )
+
+
+@dataclass
+class MOARResult:
+    """Results returned by MOAROptimizer.optimize()."""
+
+    frontier: List[FrontierPoint] = field(default_factory=list)
+    all_plans: List[FrontierPoint] = field(default_factory=list)
+    total_search_cost: float = 0.0
+    iterations: int = 0
+    duration_seconds: float = 0.0
+    save_dir: Optional[str] = None
+
+    def best(self) -> Optional[FrontierPoint]:
+        """Return the highest-accuracy point on the frontier."""
+        frontier = [p for p in self.frontier if p.on_frontier]
+        if not frontier:
+            return None
+        return max(frontier, key=lambda p: p.accuracy)
+
+    def cheapest(self) -> Optional[FrontierPoint]:
+        """Return the lowest-cost point on the frontier."""
+        frontier = [p for p in self.frontier if p.on_frontier]
+        if not frontier:
+            return None
+        return min(frontier, key=lambda p: p.cost)
+
+    def summary(self) -> str:
+        """Return a human-readable summary table."""
+        lines = [
+            f"MOAR Optimization Results ({self.iterations} iterations, "
+            f"{self.duration_seconds:.1f}s, ${self.total_search_cost:.2f} search cost)",
+            f"{'─' * 70}",
+            f"  {'#':<4} {'Cost':>10} {'Accuracy':>10} {'Frontier':>10}   YAML Path",
+            f"  {'─'*4} {'─'*10} {'─'*10} {'─'*10}   {'─'*30}",
+        ]
+        for i, p in enumerate(
+            sorted(self.all_plans, key=lambda x: x.accuracy, reverse=True), 1
+        ):
+            marker = "  *" if p.on_frontier else ""
+            lines.append(
+                f"  {i:<4} ${p.cost:>9.4f} {p.accuracy:>10.4f} {marker:>10}   {p.yaml_path}"
+            )
+        lines.append(f"\n  Frontier points marked with *")
+        if self.save_dir:
+            lines.append(f"  Full results saved to: {self.save_dir}")
+        return "\n".join(lines)
+
+
+class MOAROptimizer:
+    """
+    Simplified interface for MOAR (Multi-Objective Agentic Rewrites) optimization.
+
+    Wraps ``MOARSearch`` with sensible defaults and auto-detection of available
+    models from environment API keys.
+
+    Args:
+        pipeline: Path to the YAML pipeline file.
+        eval_fn: Evaluation function with signature
+            ``(results_file_path: str) -> dict[str, Any]``.
+            Alternatively, a path to a Python file containing a function
+            decorated with ``@docetl.register_eval``.
+        metric_key: Key to extract from the eval function's return dict.
+        models: List of model names to search over. If ``None``, auto-detects
+            from environment API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY,
+            GEMINI_API_KEY, AZURE_API_KEY).
+        agent_model: Model for the MOAR rewrite agent LLM calls. If ``None``,
+            picks the best available model from *models*.
+        max_iterations: Maximum MCTS iterations (default 20).
+        save_dir: Directory for output files. If ``None``, uses a temp directory.
+        exploration_weight: UCB exploration constant (default sqrt(2)).
+        dataset_path: Explicit path to the sample dataset JSON. If ``None``,
+            inferred from the pipeline YAML's ``datasets`` section.
+        dataset_name: Name of the dataset. If ``None``, inferred from the
+            pipeline YAML's ``datasets`` section.
+
+    Example::
+
+        optimizer = MOAROptimizer(
+            pipeline="pipeline.yaml",
+            eval_fn=lambda p: {"score": my_score(p)},
+            metric_key="score",
+        )
+        results = optimizer.optimize()
+        print(results.best())
+    """
+
+    def __init__(
+        self,
+        pipeline: Union[str, Path],
+        eval_fn: Union[Callable[[str], Dict[str, Any]], str, Path],
+        metric_key: str,
+        models: Optional[List[str]] = None,
+        agent_model: Optional[str] = None,
+        max_iterations: int = 20,
+        save_dir: Optional[Union[str, Path]] = None,
+        exploration_weight: float = 1.414,
+        dataset_path: Optional[Union[str, Path]] = None,
+        dataset_name: Optional[str] = None,
+    ):
+        self.pipeline_path = str(Path(pipeline).resolve())
+        self.metric_key = metric_key
+        self.max_iterations = max_iterations
+        self.exploration_weight = exploration_weight
+
+        # Auto-detect models if not provided
+        if models is not None:
+            self.models = list(models)
+        else:
+            self.models = detect_available_models()
+
+        # Auto-detect agent model if not provided
+        self.agent_model = agent_model or default_agent_model(self.models)
+
+        # Resolve save directory
+        if save_dir is not None:
+            self._save_dir = Path(save_dir).resolve()
+            self._temp_dir = None
+        else:
+            self._temp_dir = tempfile.mkdtemp(prefix="moar_")
+            self._save_dir = Path(self._temp_dir)
+        self._save_dir.mkdir(parents=True, exist_ok=True)
+
+        # Resolve eval function
+        self._eval_fn = self._resolve_eval_fn(eval_fn, dataset_path)
+
+        # Resolve dataset info
+        self._dataset_path, self._dataset_name = self._resolve_dataset(
+            dataset_path, dataset_name
+        )
+
+    def _resolve_eval_fn(
+        self,
+        eval_fn: Union[Callable, str, Path],
+        dataset_path: Optional[Union[str, Path]],
+    ) -> Callable[[str], Dict[str, Any]]:
+        """Accept a callable directly or load from a file path."""
+        if callable(eval_fn):
+            return eval_fn
+
+        from docetl.utils_evaluation import load_custom_evaluate_func
+
+        eval_file = str(Path(eval_fn).resolve())
+        ds_path = str(Path(dataset_path).resolve()) if dataset_path else ""
+        if not ds_path:
+            ds_path, _ = self._infer_dataset_info()
+        return load_custom_evaluate_func(eval_file, ds_path)
+
+    def _infer_dataset_info(self) -> tuple[str, str]:
+        """Infer dataset path and name from the pipeline YAML."""
+        with open(self.pipeline_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        datasets = config.get("datasets", {})
+        if not datasets:
+            raise ValueError("Pipeline YAML must contain a 'datasets' section")
+
+        ds_name, ds_config = next(iter(datasets.items()))
+        ds_path = ds_config.get("path", "")
+        if not ds_path:
+            raise ValueError(f"Dataset '{ds_name}' must have a 'path' field")
+
+        p = Path(ds_path)
+        if not p.is_absolute():
+            yaml_dir = Path(self.pipeline_path).parent
+            candidate = yaml_dir / ds_path
+            if candidate.exists():
+                p = candidate
+            elif Path(ds_path).exists():
+                p = Path(ds_path)
+            else:
+                p = candidate
+        return str(p.resolve()), ds_name
+
+    def _resolve_dataset(
+        self,
+        dataset_path: Optional[Union[str, Path]],
+        dataset_name: Optional[str],
+    ) -> tuple[str, str]:
+        """Resolve dataset path and name, using explicit values or inference."""
+        inferred_path, inferred_name = self._infer_dataset_info()
+
+        if dataset_path is not None:
+            resolved_path = str(Path(dataset_path).resolve())
+        else:
+            resolved_path = inferred_path
+
+        resolved_name = dataset_name if dataset_name is not None else inferred_name
+        return resolved_path, resolved_name
+
+    def optimize(self) -> MOARResult:
+        """
+        Run full MOAR MCTS optimization.
+
+        Returns:
+            MOARResult with the Pareto frontier and all explored plans.
+        """
+        from docetl.moar import MOARSearch
+
+        DOCETL_CONSOLE.log("[bold blue]MOAROptimizer: loading dataset...[/bold blue]")
+        with open(self._dataset_path, "r") as f:
+            dataset_data = json.load(f)
+        sample_input = dataset_data[:5] if isinstance(dataset_data, list) else dataset_data
+
+        dataset_stats = get_dataset_stats(self.pipeline_path, self._dataset_name)
+        available_actions = set(ALL_DIRECTIVES)
+
+        DOCETL_CONSOLE.log(
+            f"[bold blue]MOAROptimizer: starting search "
+            f"({self.max_iterations} iterations, {len(self.models)} models)[/bold blue]"
+        )
+        DOCETL_CONSOLE.log(f"[dim]Models: {', '.join(self.models)}[/dim]")
+        DOCETL_CONSOLE.log(f"[dim]Agent model: {self.agent_model}[/dim]")
+        DOCETL_CONSOLE.log(f"[dim]Save dir: {self._save_dir}[/dim]")
+
+        start_time = datetime.now()
+
+        moar = MOARSearch(
+            root_yaml_path=self.pipeline_path,
+            available_actions=available_actions,
+            sample_input=sample_input,
+            dataset_stats=dataset_stats,
+            dataset_name=self._dataset_name,
+            available_models=self.models,
+            evaluate_func=self._eval_fn,
+            exploration_constant=self.exploration_weight,
+            max_iterations=self.max_iterations,
+            model=self.agent_model,
+            output_dir=str(self._save_dir),
+            build_first_layer=False,
+            custom_metric_key=self.metric_key,
+            sample_dataset_path=self._dataset_path,
+        )
+
+        moar.search()
+
+        end_time = datetime.now()
+        duration = (end_time - start_time).total_seconds()
+
+        result = self._build_result(moar, duration)
+
+        self._save_results(result, moar, start_time, end_time, duration)
+
+        DOCETL_CONSOLE.log(
+            f"[green]MOAROptimizer: completed in {duration:.1f}s, "
+            f"{len(result.frontier)} frontier points[/green]"
+        )
+        return result
+
+    def _build_result(self, moar: Any, duration: float) -> MOARResult:
+        """Extract results from MOARSearch into a MOARResult."""
+        frontier_set = set(moar.pareto_frontier.frontier_plans)
+
+        all_plans = []
+        frontier = []
+        for node in moar.pareto_frontier.plans:
+            accuracy = moar.pareto_frontier.plans_accuracy.get(node, 0.0)
+            on_frontier = node in frontier_set
+            point = FrontierPoint(
+                yaml_path=node.yaml_file_path,
+                cost=node.cost,
+                accuracy=accuracy,
+                node_id=node.get_id(),
+                on_frontier=on_frontier,
+            )
+            all_plans.append(point)
+            if on_frontier:
+                frontier.append(point)
+
+        return MOARResult(
+            frontier=frontier,
+            all_plans=all_plans,
+            total_search_cost=getattr(moar, "total_search_cost", 0.0),
+            iterations=moar.iteration_count,
+            duration_seconds=duration,
+            save_dir=str(self._save_dir),
+        )
+
+    def _save_results(
+        self,
+        result: MOARResult,
+        moar: Any,
+        start_time: datetime,
+        end_time: datetime,
+        duration: float,
+    ) -> None:
+        """Save experiment summary and Pareto frontier to disk."""
+        summary = {
+            "optimizer": "moar",
+            "input_pipeline": self.pipeline_path,
+            "agent_model": self.agent_model,
+            "models": self.models,
+            "max_iterations": self.max_iterations,
+            "exploration_weight": self.exploration_weight,
+            "metric_key": self.metric_key,
+            "save_dir": str(self._save_dir),
+            "dataset": self._dataset_name,
+            "start_time": start_time.isoformat(),
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration,
+            "total_search_cost": result.total_search_cost,
+            "num_frontier_points": len(result.frontier),
+            "num_plans_explored": len(result.all_plans),
+        }
+
+        summary_file = self._save_dir / "experiment_summary.json"
+        with open(summary_file, "w") as f:
+            json.dump(summary, f, indent=2)
+
+        if result.frontier:
+            pareto_file = self._save_dir / "pareto_frontier.json"
+            pareto_data = [
+                {
+                    "node_id": p.node_id,
+                    "yaml_path": p.yaml_path,
+                    "cost": p.cost,
+                    "accuracy": p.accuracy,
+                }
+                for p in result.frontier
+            ]
+            with open(pareto_file, "w") as f:
+                json.dump(pareto_data, f, indent=2)

--- a/docetl/moar/optimizer.py
+++ b/docetl/moar/optimizer.py
@@ -356,14 +356,16 @@ class MOAROptimizer:
         Returns:
             MOARResult with the Pareto frontier and all explored plans.
         """
-        import os
-
         from docetl.moar import MOARSearch
 
-        if os.environ.get("USE_FRONTEND") == "true":
+        with open(self.pipeline_path, "r") as f:
+            pipeline_config = yaml.safe_load(f)
+        if pipeline_config.get("interactive_ui", False):
             DOCETL_CONSOLE.log(
-                "[bold yellow]Warning: MOAR optimization runs in CLI mode. "
-                "The interactive frontend/TUI is not used during optimization.[/bold yellow]"
+                "[bold yellow]Warning: interactive_ui is enabled but MOAR "
+                "optimization does not use the interactive progress view. "
+                "The optimized pipelines can be run with interactive_ui "
+                "after optimization completes.[/bold yellow]"
             )
 
         DOCETL_CONSOLE.log("[bold blue]MOAROptimizer: loading dataset...[/bold blue]")

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -43,7 +43,74 @@ Pipeline(
 
 - `pipeline.run() -> float` — Execute the pipeline. Returns total cost.
 - `pipeline.run_with_stats() -> dict` — Execute the pipeline and return detailed statistics including cost and token usage broken down by model (prompt and completion tokens).
-- `pipeline.optimize(**kwargs) -> Pipeline` — Return an optimized copy of the pipeline.
+- `pipeline.optimize(**kwargs) -> MOARResult` — Run MOAR optimization and return results. See below.
+
+### pipeline.optimize()
+
+The single entry point for pipeline optimization. MOAR is the default (and recommended) method.
+
+```python
+result = pipeline.optimize(
+    eval_fn="evaluate.py",           # Required — path or callable
+    metric_key="score",              # Required — key in eval results dict
+    models=None,                     # Auto-detect from API keys
+    agent_model=None,                # Auto-select best available
+    max_iterations=20,               # Max search iterations
+    save_dir=None,                   # Defaults to temp dir
+    exploration_weight=1.414,        # UCB exploration constant
+    method="moar",                   # "moar" (default) or "v1" (legacy)
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `eval_fn` | `str \| Callable` | *required* | Path to `@register_eval` file, or a callable `(path) -> dict` |
+| `metric_key` | `str` | *required* | Key in evaluation results to optimize |
+| `models` | `list[str] \| None` | `None` | LiteLLM model names. Auto-detected from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AZURE_API_KEY`. |
+| `agent_model` | `str \| None` | `None` | Model for directive instantiation. Auto-selected. |
+| `max_iterations` | `int` | `20` | Maximum search iterations |
+| `save_dir` | `str \| None` | `None` | Results directory (temp dir if omitted) |
+| `exploration_weight` | `float` | `1.414` | UCB exploration constant |
+| `method` | `str` | `"moar"` | `"moar"` or `"v1"` (legacy) |
+
+**Returns:** `MOARResult`
+
+---
+
+## MOARResult
+
+Returned by `pipeline.optimize()`. Provides access to the Pareto frontier of optimized pipelines.
+
+| Method / Property | Return Type | Description |
+|-------------------|-------------|-------------|
+| `best()` | `OptimizedPipeline` | Highest-accuracy solution on the frontier |
+| `cheapest()` | `OptimizedPipeline` | Lowest-cost solution on the frontier |
+| `frontier` | `list[OptimizedPipeline]` | All Pareto-optimal solutions |
+| `to_df()` | `pandas.DataFrame` | DataFrame of all explored plans |
+
+```python
+result = pipeline.optimize(eval_fn="evaluate.py", metric_key="score")
+
+best = result.best()
+best.run()  # Execute the best pipeline
+
+df = result.to_df()  # Analyze all explored configurations
+```
+
+---
+
+## OptimizedPipeline
+
+A single optimized pipeline configuration, returned from `MOARResult`.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `pipeline` | `DSLRunner` | The underlying pipeline runner |
+| `cost` | `float` | Estimated cost per run |
+| `accuracy` | `float` | Evaluation metric score |
+| `yaml_path` | `str` | Path to the optimized YAML file |
+| `on_frontier` | `bool` | Whether this plan is Pareto-optimal |
+| `run()` | `float` | Execute the pipeline; returns cost |
 
 ---
 

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -50,8 +50,14 @@ Pipeline(
 The single entry point for pipeline optimization. MOAR is the default (and recommended) method.
 
 ```python
+def my_eval(results_path):
+    import json
+    with open(results_path) as f:
+        results = json.load(f)
+    return {"score": sum(1 for r in results if r.get("correct"))}
+
 result = pipeline.optimize(
-    eval_fn="evaluate.py",           # Required — path or callable
+    eval_fn=my_eval,                 # Required — a callable
     metric_key="score",              # Required — key in eval results dict
     models=None,                     # Auto-detect from API keys
     agent_model=None,                # Auto-select best available
@@ -64,7 +70,7 @@ result = pipeline.optimize(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `eval_fn` | `str \| Callable` | *required* | Path to `@register_eval` file, or a callable `(path) -> dict` |
+| `eval_fn` | `Callable` | *required* | A function `(results_path) -> dict` or `(dataset_path, results_path) -> dict`. Also accepts a file path string for CLI compatibility. |
 | `metric_key` | `str` | *required* | Key in evaluation results to optimize |
 | `models` | `list[str] \| None` | `None` | LiteLLM model names. Auto-detected from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AZURE_API_KEY`. |
 | `agent_model` | `str \| None` | `None` | Model for directive instantiation. Auto-selected. |
@@ -89,7 +95,7 @@ Returned by `pipeline.optimize()`. Provides access to the Pareto frontier of opt
 | `to_df()` | `pandas.DataFrame` | DataFrame of all explored plans |
 
 ```python
-result = pipeline.optimize(eval_fn="evaluate.py", metric_key="score")
+result = pipeline.optimize(eval_fn=my_eval, metric_key="score")
 
 best = result.best()
 best.run()  # Execute the best pipeline

--- a/docs/concepts/optimization.md
+++ b/docs/concepts/optimization.md
@@ -69,10 +69,7 @@ No `--optimizer` flag needed -- MOAR is the default.
 #### Python API (Recommended)
 
 ```python
-result = pipeline.optimize(
-    eval_fn="evaluate.py",
-    metric_key="score",
-)
+result = pipeline.optimize(eval_fn=my_eval_function, metric_key="score")
 best = result.best()
 best.run()
 ```

--- a/docs/concepts/optimization.md
+++ b/docs/concepts/optimization.md
@@ -56,31 +56,39 @@ The DocETL optimizer operates using the following mechanism:
 
 ### Using the Optimizer
 
-DocETL provides two optimizer options:
+MOAR is the default (and only) optimizer. Run it via CLI or Python API:
 
-#### MOAR Optimizer (Recommended)
-
-The MOAR optimizer uses Monte Carlo Tree Search to find Pareto-optimal solutions balancing accuracy and cost:
+#### CLI
 
 ```bash
-docetl build your_pipeline.yaml --optimizer moar
+docetl build your_pipeline.yaml
+```
+
+No `--optimizer` flag needed -- MOAR is the default.
+
+#### Python API (Recommended)
+
+```python
+result = pipeline.optimize(
+    eval_fn="evaluate.py",
+    metric_key="score",
+)
+best = result.best()
+best.run()
 ```
 
 See the [MOAR Optimizer Guide](../optimization/moar.md) for detailed instructions.
 
-#### V1 Optimizer (Deprecated)
+#### Legacy V1 Optimizer
 
 !!! warning "Deprecated"
     The V1 optimizer is deprecated and no longer recommended. Use MOAR instead.
 
-The V1 optimizer uses a greedy approach with validation. It's still available for backward compatibility:
+The V1 optimizer is still available for backward compatibility via `method="v1"` in the Python API:
 
-```bash
-docetl build your_pipeline.yaml --optimizer v1
+```python
+optimized_pipeline = pipeline.optimize(method="v1")
 ```
-
-!!! warning "Not Recommended"
-    The V1 optimizer should not be used for new projects. Use MOAR instead.
 
 <!-- ### Automatic Entity Resolution
 

--- a/docs/optimization/moar.md
+++ b/docs/optimization/moar.md
@@ -30,10 +30,7 @@ When optimizing pipelines, you trade off cost and accuracy. MOAR explores many d
 3. **Run optimization** — Call `pipeline.optimize()` with your eval function:
 
     ```python
-    result = pipeline.optimize(
-        eval_fn="evaluate.py",
-        metric_key="score",
-    )
+    result = pipeline.optimize(eval_fn=evaluate, metric_key="score")
     ```
 
     Or via CLI: `docetl build pipeline.yaml`

--- a/docs/optimization/moar.md
+++ b/docs/optimization/moar.md
@@ -25,10 +25,27 @@ When optimizing pipelines, you trade off cost and accuracy. MOAR explores many d
 
 ## Basic Workflow
 
-1. **Create your pipeline YAML** - Define your DocETL pipeline
-2. **Write an evaluation function** - Create a Python function to measure accuracy
-3. **Configure MOAR** - Set up `optimizer_config` in your YAML
-4. **Run optimization** - Execute `docetl build pipeline.yaml --optimizer moar`
-5. **Review results** - Choose from the cost-accuracy frontier
+1. **Create your pipeline** — Define your DocETL pipeline in Python or YAML
+2. **Write an evaluation function** — Create a Python function to measure accuracy
+3. **Run optimization** — Call `pipeline.optimize()` with your eval function:
+
+    ```python
+    result = pipeline.optimize(
+        eval_fn="evaluate.py",
+        metric_key="score",
+    )
+    ```
+
+    Or via CLI: `docetl build pipeline.yaml`
+
+4. **Review results** — Choose from the cost-accuracy frontier:
+
+    ```python
+    best = result.best()   # Highest accuracy
+    best.run()             # Execute it
+
+    cheap = result.cheapest()  # Lowest cost
+    df = result.to_df()        # All explored plans
+    ```
 
 Ready to get started? Head to the [Getting Started guide](moar/getting-started.md).

--- a/docs/optimization/moar/configuration.md
+++ b/docs/optimization/moar/configuration.md
@@ -7,8 +7,14 @@ Complete reference for all MOAR configuration options, covering both the Python 
 When calling `pipeline.optimize()`, MOAR is the default method:
 
 ```python
+def my_eval(results_path):
+    import json
+    with open(results_path) as f:
+        results = json.load(f)
+    return {"score": sum(1 for r in results if r.get("correct"))}
+
 result = pipeline.optimize(
-    eval_fn="evaluate.py",        # Required
+    eval_fn=my_eval,              # Required — a callable
     metric_key="score",           # Required
     models=None,                  # Optional — auto-detected from API keys
     agent_model=None,             # Optional — auto-selected best available
@@ -23,7 +29,7 @@ result = pipeline.optimize(
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `eval_fn` | `str \| Callable` | Path to Python file containing `@register_eval` decorated function, or a callable |
+| `eval_fn` | `Callable` | A function that scores pipeline output. 1-arg: `(results_path) -> dict`. 2-arg: `(dataset_path, results_path) -> dict` (dataset path is curried automatically). Also accepts a file path string for CLI compatibility. |
 | `metric_key` | `str` | Key in evaluation results dictionary to use as accuracy metric |
 
 ### Optional Parameters

--- a/docs/optimization/moar/configuration.md
+++ b/docs/optimization/moar/configuration.md
@@ -1,32 +1,106 @@
 # MOAR Configuration Reference
 
-Complete reference for all MOAR configuration options.
+Complete reference for all MOAR configuration options, covering both the Python API and YAML configuration.
 
-## Required Fields
+## Python API Parameters
 
-All fields in `optimizer_config` are required (no defaults):
+When calling `pipeline.optimize()`, MOAR is the default method:
+
+```python
+result = pipeline.optimize(
+    eval_fn="evaluate.py",        # Required
+    metric_key="score",           # Required
+    models=None,                  # Optional — auto-detected from API keys
+    agent_model=None,             # Optional — auto-selected best available
+    max_iterations=20,            # Optional
+    save_dir=None,                # Optional — defaults to temp dir
+    exploration_weight=1.414,     # Optional
+    method="moar",                # Optional — default, use "v1" for legacy
+)
+```
+
+### Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `eval_fn` | `str \| Callable` | Path to Python file containing `@register_eval` decorated function, or a callable |
+| `metric_key` | `str` | Key in evaluation results dictionary to use as accuracy metric |
+
+### Optional Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `models` | `list[str] \| None` | `None` (auto-detect) | LiteLLM model names to explore. Auto-detected from environment API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AZURE_API_KEY`). |
+| `agent_model` | `str \| None` | `None` (auto-select) | LLM model for directive instantiation during search. Auto-selects best available. |
+| `max_iterations` | `int` | `20` | Maximum number of MOARSearch iterations to run |
+| `save_dir` | `str \| None` | `None` (temp dir) | Directory where MOAR results will be saved |
+| `exploration_weight` | `float` | `1.414` | UCB exploration constant (higher = more exploration) |
+| `method` | `str` | `"moar"` | Optimization method. Use `"v1"` for the legacy V1 optimizer. |
+
+## YAML Configuration
+
+In YAML, add an `optimizer_config` section. Only `evaluation_file` and `metric_key` are required:
+
+### Required Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `type` | `str` | Must be `"moar"` |
-| `save_dir` | `str` | Directory where MOAR results will be saved |
-| `available_models` | `list[str]` | List of LiteLLM model names to explore (e.g., `["gpt-4o-mini", "gpt-4o"]`). Make sure your API keys are set in your environment for these models. |
 | `evaluation_file` | `str` | Path to Python file containing `@register_eval` decorated function |
 | `metric_key` | `str` | Key in evaluation results dictionary to use as accuracy metric |
-| `max_iterations` | `int` | Maximum number of MOARSearch iterations to run |
-| `rewrite_agent_model` | `str` | LLM model to use for directive instantiation during search |
 
-!!! warning "All Fields Required"
-    MOAR will error if any required field is missing. There are no defaults.
-
-## Optional Fields
+### Optional Fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `dataset_path` | `str` | Inferred from `datasets` | Path to dataset file to use for optimization. Use a sample/hold-out dataset to avoid optimizing on your test set. |
+| `available_models` | `list[str]` | Auto-detected | LiteLLM model names to explore. Auto-detected from API keys if omitted. |
+| `rewrite_agent_model` | `str` | Auto-selected | LLM model for directive instantiation during search |
+| `model` | `str` | Auto-selected | Alias for `rewrite_agent_model` |
+| `max_iterations` | `int` | `20` | Maximum number of MOARSearch iterations |
+| `save_dir` | `str` | Temp dir | Directory where MOAR results will be saved |
+| `type` | `str` | `"moar"` | No longer required. Use `"v1"` for legacy optimizer. |
+| `dataset_path` | `str` | Inferred from `datasets` | Path to dataset file for optimization. Use a sample/hold-out dataset. |
 | `exploration_weight` | `float` | `1.414` | UCB exploration constant (higher = more exploration) |
-| `build_first_layer` | `bool` | `False` | Whether to build initial model-specific nodes |
 | `ground_truth_path` | `str` | `None` | Path to ground truth file (for evaluation) |
+
+### Minimal YAML Example
+
+```yaml
+optimizer_config:
+  evaluation_file: evaluate_medications.py
+  metric_key: medication_extraction_score
+```
+
+### Full YAML Example
+
+```yaml
+optimizer_config:
+  evaluation_file: evaluate_medications.py
+  metric_key: medication_extraction_score
+  available_models:
+    - gpt-4o-mini
+    - gpt-4o
+    - gpt-5.1-mini
+    - gpt-5.1
+  max_iterations: 40
+  rewrite_agent_model: gpt-5.1
+  save_dir: results/moar_optimization
+  dataset_path: data/sample.json
+  exploration_weight: 1.414
+```
+
+## Model Auto-Detection
+
+When `models` (Python) or `available_models` (YAML) is omitted, MOAR auto-detects available models from your environment API keys:
+
+| Environment Variable | Models Detected |
+|---------------------|----------------|
+| `OPENAI_API_KEY` | OpenAI models (gpt-4o-mini, gpt-4o, etc.) |
+| `ANTHROPIC_API_KEY` | Anthropic models (claude-sonnet, claude-opus, etc.) |
+| `GEMINI_API_KEY` | Google Gemini models |
+| `AZURE_API_KEY` | Azure OpenAI models |
+
+!!! tip "Explicit Model Lists"
+    You can always override auto-detection by providing an explicit model list. This is useful when you want to restrict the search to specific models.
 
 ## Dataset Path
 
@@ -41,8 +115,9 @@ datasets:
     type: file
 
 optimizer_config:
-  # dataset_path not specified - will use data/full_dataset.json
-  # ... other config ...
+  # dataset_path not specified — will use data/full_dataset.json
+  evaluation_file: evaluate.py
+  metric_key: score
 ```
 
 ### Using Sample/Hold-Out Datasets
@@ -53,64 +128,21 @@ optimizer_config:
 ```yaml
 optimizer_config:
   dataset_path: data/sample_dataset.json  # Use sample/hold-out for optimization
-  # ... other config ...
+  evaluation_file: evaluate.py
+  metric_key: score
 
 datasets:
   transcripts:
     path: data/full_dataset.json  # Full dataset for final pipeline
 ```
 
-The optimizer will use the sample dataset, but your final pipeline uses the full dataset. This ensures you don't overfit to your test set during optimization.
-
-## Model Configuration
-
-### Available Models
-
-!!! info "LiteLLM Model Names"
-    Use LiteLLM model names (e.g., `gpt-4o-mini`, `gpt-4o`, `gpt-5.1`). Make sure your API keys are set in your environment.
-
-```yaml
-available_models:  # LiteLLM model names - ensure API keys are set
-  - gpt-5.1-nano      # Cheapest, lower accuracy
-  - gpt-5.1-mini      # Low cost, decent accuracy
-  - gpt-5.1           # Balanced
-  - gpt-4o             # Higher cost, better accuracy
-```
-
-### Model for Directive Instantiation
-
-The `rewrite_agent_model` field specifies which LLM to use for generating optimization directives during the search process. This doesn't affect the models tested in `available_models`.
-
-!!! tip "Cost Consideration"
-    Use a cheaper model (like `gpt-4o-mini`) for directive instantiation to reduce search costs.
-
 ## Iteration Count
 
 The `max_iterations` parameter controls how many pipeline configurations MOAR explores:
 
-- **10-20 iterations**: Quick exploration, good for testing
-- **40 iterations**: Recommended for most use cases
+- **10-20 iterations**: Quick exploration, good for testing (default is 20)
+- **40 iterations**: Recommended for most production use cases
 - **100+ iterations**: For complex pipelines or when you need the absolute best results
 
 !!! note "Time vs Quality"
     More iterations give better results but take longer and cost more.
-
-## Complete Example
-
-```yaml
-optimizer_config:
-  type: moar
-  save_dir: results/moar_optimization
-  available_models:
-    - gpt-4o-mini
-    - gpt-4o
-    - gpt-5.1-mini
-    - gpt-5.1
-  evaluation_file: evaluate_medications.py
-  metric_key: medication_extraction_score
-  max_iterations: 40
-  rewrite_agent_model: gpt-5.1
-  dataset_path: data/sample.json  # Optional
-  exploration_weight: 1.414  # Optional
-```
-

--- a/docs/optimization/moar/evaluation.md
+++ b/docs/optimization/moar/evaluation.md
@@ -4,64 +4,90 @@ How to write evaluation functions for MOAR optimization.
 
 ## How Evaluation Functions Work
 
-Your evaluation function receives the pipeline output and computes metrics by comparing it to the original dataset. MOAR uses one specific metric from your returned dictionary (specified by `metric_key`) to optimize for accuracy.
-
-!!! info "Function Signature"
-    Your function must have exactly this signature:
-    ```python
-    def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str, Any]:
-    ```
+Your evaluation function reads the pipeline output and computes metrics. MOAR uses one specific metric from your returned dictionary (specified by `metric_key`) to optimize for accuracy.
 
 ### What You Receive
 
-- **`results_file_path`**: Path to JSON file containing your pipeline's output
-- **`dataset_file_path`**: Path to JSON file containing the original dataset
+- **`results_path`**: Path to JSON file containing your pipeline's output
+- Optionally, **`dataset_path`**: Path to JSON file containing the original dataset (if you use a 2-argument signature)
 
 ### What You Return
 
-A dictionary with numeric metrics. The key specified in `optimizer_config.metric_key` will be used as the accuracy metric for optimization.
+A dictionary with numeric metrics. The key specified by `metric_key` will be used as the accuracy metric for optimization.
 
 !!! tip "Using Original Input Data"
     Pipeline output includes the original input data. For example, if your dataset has a `src` attribute, it will be available in the output. You can use this directly for comparison without loading the dataset file separately.
 
-## Basic Example
+## Python API (Recommended)
+
+Pass any callable directly to `pipeline.optimize()`:
 
 ```python
 import json
-from typing import Any, Dict
-from docetl.utils_evaluation import register_eval
 
-@register_eval
-def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str, Any]:
-    # Load pipeline output
-    with open(results_file_path, 'r') as f:
+def evaluate(results_path):
+    with open(results_path) as f:
         output = json.load(f)
     
     total_correct = 0
     for result in output:
-        # For example, if your dataset has a 'src' attribute, it's available in the output
         original_text = result.get("src", "").lower()
-        # Replace "your_extraction_key" with the actual key from your pipeline output
-        extracted_items = result.get("your_extraction_key", [])
-        
-        # Check if extracted items appear in original text
-        for item in extracted_items:
+        for item in result.get("your_extraction_key", []):
             if str(item).lower() in original_text:
                 total_correct += 1
     
     return {
-        "extraction_score": total_correct,  # This key is used if metric_key="extraction_score"
+        "extraction_score": total_correct,
+        "total_extracted": sum(len(r.get("your_extraction_key", [])) for r in output),
+    }
+
+result = pipeline.optimize(eval_fn=evaluate, metric_key="extraction_score")
+```
+
+If you need access to the original dataset, use a two-argument signature — the dataset path is passed automatically:
+
+```python
+def evaluate(dataset_path, results_path):
+    with open(results_path) as f:
+        output = json.load(f)
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+    # compare output to dataset...
+    return {"score": computed_score}
+```
+
+## CLI (File-Based)
+
+For CLI usage, create a Python file with a `@register_eval` decorated function:
+
+```python
+# evaluate.py
+import json
+from docetl.utils_evaluation import register_eval
+
+@register_eval
+def evaluate_results(dataset_file_path: str, results_file_path: str) -> dict:
+    with open(results_file_path) as f:
+        output = json.load(f)
+    
+    total_correct = 0
+    for result in output:
+        original_text = result.get("src", "").lower()
+        for item in result.get("your_extraction_key", []):
+            if str(item).lower() in original_text:
+                total_correct += 1
+    
+    return {
+        "extraction_score": total_correct,
         "total_extracted": sum(len(r.get("your_extraction_key", [])) for r in output),
     }
 ```
 
-## Requirements
-
-!!! warning "Critical Requirements"
-    - The function must be decorated with `@docetl.register_eval`
+!!! warning "CLI Requirements"
+    - The function must be decorated with `@register_eval`
     - It must take exactly two arguments: `dataset_file_path` and `results_file_path`
     - It must return a dictionary with numeric metrics
-    - The `metric_key` in your `optimizer_config` must match one of the keys in this dictionary
+    - The `metric_key` must match one of the keys in this dictionary
     - Only one function per file can be decorated with `@register_eval`
 
 ## Performance Considerations
@@ -75,67 +101,49 @@ def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str
 
 ## Common Evaluation Patterns
 
-### Pattern 1: Extraction Verification with Recall
+### Pattern 1: Extraction Verification
 
-Check if extracted items appear in the document text and compute recall:
+Check if extracted items appear in the document text:
 
 ```python
-@register_eval
-def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str, Any]:
-    with open(results_file_path, 'r') as f:
+def evaluate(results_path):
+    with open(results_path) as f:
         output = json.load(f)
     
-    # For example, if your dataset has a 'src' attribute, it's available in the output
     total_correct = 0
     total_extracted = 0
-    total_expected = 0
     
     for result in output:
-        # Replace "src" with the actual key from your dataset
         original_text = result.get("src", "").lower()
-        extracted_items = result.get("your_extraction_key", [])  # Replace with your key
-        
-        # Count correct extractions (items that appear in text)
-        for item in extracted_items:
+        for item in result.get("your_extraction_key", []):
             total_extracted += 1
             if str(item).lower() in original_text:
                 total_correct += 1
-        
-        # Count expected items (if you have ground truth)
-        # total_expected += len(expected_items)
     
     precision = total_correct / total_extracted if total_extracted > 0 else 0.0
-    recall = total_correct / total_expected if total_expected > 0 else 0.0
     
     return {
-        "extraction_score": total_correct,  # Use this as metric_key
+        "extraction_score": total_correct,
         "precision": precision,
-        "recall": recall,
     }
 ```
 
 ### Pattern 2: Comparing Against Ground Truth
 
-Load ground truth from the dataset file and compare:
+Use a two-argument signature to access the dataset:
 
 ```python
-@register_eval
-def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str, Any]:
-    with open(results_file_path, 'r') as f:
+def evaluate(dataset_path, results_path):
+    with open(results_path) as f:
         predictions = json.load(f)
-    
-    with open(dataset_file_path, 'r') as f:
+    with open(dataset_path) as f:
         ground_truth = json.load(f)
     
-    # Compare predictions with ground truth
-    # Adjust keys based on your data structure
-    correct = 0
+    correct = sum(
+        1 for pred, truth in zip(predictions, ground_truth)
+        if pred.get("predicted_label") == truth.get("true_label")
+    )
     total = len(predictions)
-    
-    for pred, truth in zip(predictions, ground_truth):
-        # Example: compare classification labels
-        if pred.get("predicted_label") == truth.get("true_label"):
-            correct += 1
     
     return {
         "accuracy": correct / total if total > 0 else 0.0,
@@ -144,39 +152,27 @@ def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str
     }
 ```
 
-### Pattern 3: External Evaluation (File or API)
+### Pattern 3: Using a Closure
 
-Load additional data or call an API for evaluation:
+Capture external state (ground truth, config, etc.) via a closure:
 
 ```python
-import requests
-from pathlib import Path
-
-@register_eval
-def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str, Any]:
-    with open(results_file_path, 'r') as f:
-        output = json.load(f)
-    
-    # Option A: Load ground truth from a separate file
-    ground_truth_path = Path(dataset_file_path).parent / "ground_truth.json"
-    with open(ground_truth_path, 'r') as f:
+def make_eval(ground_truth_path):
+    with open(ground_truth_path) as f:
         ground_truth = json.load(f)
-    
-    # Option B: Call an API for evaluation
-    # response = requests.post("https://api.example.com/evaluate", json=output)
-    # api_score = response.json()["score"]
-    
-    # Evaluate using ground truth
-    scores = []
-    for result, truth in zip(output, ground_truth):
-        # Your evaluation logic here
-        score = compute_score(result, truth)
-        scores.append(score)
-    
-    return {
-        "average_score": sum(scores) / len(scores) if scores else 0.0,
-        "scores": scores,
-    }
+
+    def evaluate(results_path):
+        with open(results_path) as f:
+            output = json.load(f)
+        scores = [compute_score(r, t) for r, t in zip(output, ground_truth)]
+        return {"average_score": sum(scores) / len(scores) if scores else 0.0}
+
+    return evaluate
+
+result = pipeline.optimize(
+    eval_fn=make_eval("ground_truth.json"),
+    metric_key="average_score",
+)
 ```
 
 ## Testing Your Function
@@ -185,7 +181,7 @@ def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str
     Test your evaluation function independently before running MOAR:
     
     ```python
-    result = evaluate_results("dataset.json", "results.json")
+    result = evaluate("results.json")
     print(result)  # Check that your metric_key is present
     ```
 

--- a/docs/optimization/moar/examples.md
+++ b/docs/optimization/moar/examples.md
@@ -9,6 +9,48 @@ This example extracts medications from medical transcripts and evaluates extract
 !!! note "Metric Key"
     The `metric_key` in the `optimizer_config` section specifies which key from your evaluation function's return dictionary will be used as the accuracy metric. In this example, `metric_key: medication_extraction_score` means MOAR will optimize using the `medication_extraction_score` value returned by the evaluation function.
 
+### Python API
+
+```python
+from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
+
+pipeline = Pipeline(
+    name="medication_extraction",
+    datasets={"transcripts": Dataset(type="file", path="workloads/medical/raw.json")},
+    operations=[
+        MapOp(
+            name="extract_medications",
+            type="map",
+            output={"schema": {"medication": "list[str]"}},
+            prompt=(
+                "Analyze the following transcript of a conversation between a doctor and a patient:\n"
+                "{{ input.src }}\n"
+                "Extract and list all medications mentioned in the transcript.\n"
+                "If no medications are mentioned, return an empty list."
+            ),
+        ),
+    ],
+    steps=[PipelineStep(name="medication_extraction", input="transcripts", operations=["extract_medications"])],
+    output=PipelineOutput(type="file", path="workloads/medical/extracted_medications_results.json"),
+    default_model="gpt-4o-mini",
+)
+
+# Optimize — only eval_fn and metric_key are required
+result = pipeline.optimize(
+    eval_fn="workloads/medical/evaluate_medications.py",
+    metric_key="medication_extraction_score",
+)
+
+# Run the best pipeline
+best = result.best()
+print(f"Accuracy: {best.accuracy}, Cost: ${best.cost:.4f}")
+best.run()
+
+# Or explore the full frontier
+for plan in result.frontier:
+    print(f"Cost: ${plan.cost:.4f}, Accuracy: {plan.accuracy}")
+```
+
 ### pipeline.yaml
 
 ```yaml
@@ -21,7 +63,6 @@ default_model: gpt-4o-mini
 bypass_cache: true
 
 optimizer_config:
-  type: moar
   dataset_path: workloads/medical/raw_sample.json  # Use sample for faster optimization
   save_dir: workloads/medical/moar_results
   available_models:  # LiteLLM model names - ensure API keys are set in your environment
@@ -110,10 +151,10 @@ def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str
     }
 ```
 
-### Running the Optimization
+### Running the Optimization via CLI
 
 ```bash
-docetl build workloads/medical/pipeline_medication_extraction.yaml --optimizer moar
+docetl build workloads/medical/pipeline_medication_extraction.yaml
 ```
 
 !!! tip "Using Sample Datasets"
@@ -127,7 +168,8 @@ docetl build workloads/medical/pipeline_medication_extraction.yaml --optimizer m
     - Returns multiple metrics, with `medication_extraction_score` as the primary one
 
 !!! info "Configuration"
+    - Only `evaluation_file` and `metric_key` are required in the YAML `optimizer_config`
+    - `available_models` is optional -- auto-detected from API keys if omitted
     - Uses a sample dataset for optimization (`dataset_path`)
-    - Includes multiple models in `available_models` to explore trade-offs
     - Sets `max_iterations` to 40 for a good balance of exploration and time
 

--- a/docs/optimization/moar/examples.md
+++ b/docs/optimization/moar/examples.md
@@ -12,6 +12,7 @@ This example extracts medications from medical transcripts and evaluates extract
 ### Python API
 
 ```python
+import json
 from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
 
 pipeline = Pipeline(
@@ -35,9 +36,25 @@ pipeline = Pipeline(
     default_model="gpt-4o-mini",
 )
 
+# Define evaluation function
+def evaluate_medications(results_path):
+    with open(results_path) as f:
+        output = json.load(f)
+    correct = sum(
+        1 for r in output
+        for med in r.get("medication", [])
+        if str(med).lower().strip() in r.get("src", "").lower()
+    )
+    total = sum(len(r.get("medication", [])) for r in output)
+    return {
+        "medication_extraction_score": correct,
+        "total_extracted": total,
+        "precision": correct / total if total > 0 else 0.0,
+    }
+
 # Optimize — only eval_fn and metric_key are required
 result = pipeline.optimize(
-    eval_fn="workloads/medical/evaluate_medications.py",
+    eval_fn=evaluate_medications,
     metric_key="medication_extraction_score",
 )
 
@@ -103,7 +120,9 @@ pipeline:
     path: workloads/medical/extracted_medications_results.json
 ```
 
-### evaluate_medications.py
+### evaluate_medications.py (for CLI)
+
+When using the CLI, create a file with a `@register_eval` decorated function:
 
 ```python
 import json
@@ -112,44 +131,30 @@ from docetl.utils_evaluation import register_eval
 
 @register_eval
 def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str, Any]:
-    """
-    Evaluate medication extraction results.
-    
-    Checks if each extracted medication appears verbatim in the original transcript.
-    In this example, the dataset has a 'src' attribute with the original input text.
-    """
-    # Load pipeline output
     with open(results_file_path, 'r') as f:
         output = json.load(f)
     
-    total_correct_medications = 0
-    total_extracted_medications = 0
+    total_correct = 0
+    total_extracted = 0
     
-    # Evaluate each result
     for result in output:
-        # In this example, the dataset has a 'src' attribute with the original transcript
         original_transcript = result.get("src", "").lower()
-        extracted_medications = result.get("medication", [])
-        
-        # Check each extracted medication
-        for medication in extracted_medications:
-            total_extracted_medications += 1
-            medication_lower = str(medication).lower().strip()
-            
-            # Check if medication appears in transcript
-            if medication_lower in original_transcript:
-                total_correct_medications += 1
+        for medication in result.get("medication", []):
+            total_extracted += 1
+            if str(medication).lower().strip() in original_transcript:
+                total_correct += 1
     
-    # Calculate metrics
-    precision = total_correct_medications / total_extracted_medications if total_extracted_medications > 0 else 0.0
+    precision = total_correct / total_extracted if total_extracted > 0 else 0.0
     
     return {
-        "medication_extraction_score": total_correct_medications,  # This is used as the accuracy metric
-        "total_correct_medications": total_correct_medications,
-        "total_extracted_medications": total_extracted_medications,
+        "medication_extraction_score": total_correct,
+        "total_extracted": total_extracted,
         "precision": precision,
     }
 ```
+
+!!! tip "Python API vs CLI"
+    In the Python API, you pass the evaluation function directly — no file or `@register_eval` needed. The file-based approach is only required for CLI usage.
 
 ### Running the Optimization via CLI
 
@@ -163,8 +168,8 @@ docetl build workloads/medical/pipeline_medication_extraction.yaml
 ## Key Points
 
 !!! info "Evaluation Function"
-    - In this example, uses the `src` attribute from output items (no need to load dataset separately)
-    - Checks if extracted medications appear verbatim in the transcript
+    - Python API: pass a callable directly — no file or decorator needed
+    - CLI: use a `@register_eval` decorated function in a `.py` file
     - Returns multiple metrics, with `medication_extraction_score` as the primary one
 
 !!! info "Configuration"

--- a/docs/optimization/moar/getting-started.md
+++ b/docs/optimization/moar/getting-started.md
@@ -2,37 +2,61 @@
 
 This guide walks you through running your first MOAR optimization step by step.
 
-## Step 1: Create Your Pipeline YAML
+## Step 1: Create Your Pipeline
 
-Start with a standard DocETL pipeline YAML file:
+Start with a standard DocETL pipeline. You can define it in Python or YAML.
 
-```yaml
-datasets:
-  transcripts:
-    path: data/transcripts.json
-    type: file
+=== "Python"
 
-default_model: gpt-4o-mini
+    ```python
+    from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
 
-operations:
-  - name: extract_medications
-    type: map
-    output:
-      schema:
-        medication: list[str]
-    prompt: |
-      Extract all medications mentioned in: {{ input.src }}
+    pipeline = Pipeline(
+        name="medication_extraction",
+        datasets={"transcripts": Dataset(type="file", path="data/transcripts.json")},
+        operations=[
+            MapOp(
+                name="extract_medications",
+                type="map",
+                output={"schema": {"medication": "list[str]"}},
+                prompt="Extract all medications mentioned in: {{ input.src }}",
+            ),
+        ],
+        steps=[PipelineStep(name="extraction", input="transcripts", operations=["extract_medications"])],
+        output=PipelineOutput(type="file", path="results.json"),
+        default_model="gpt-4o-mini",
+    )
+    ```
 
-pipeline:
-  steps:
-    - name: medication_extraction
-      input: transcripts
-      operations:
-        - extract_medications
-  output:
-    type: file
-    path: results.json
-```
+=== "YAML"
+
+    ```yaml
+    datasets:
+      transcripts:
+        path: data/transcripts.json
+        type: file
+
+    default_model: gpt-4o-mini
+
+    operations:
+      - name: extract_medications
+        type: map
+        output:
+          schema:
+            medication: list[str]
+        prompt: |
+          Extract all medications mentioned in: {{ input.src }}
+
+    pipeline:
+      steps:
+        - name: medication_extraction
+          input: transcripts
+          operations:
+            - extract_medications
+      output:
+        type: file
+        path: results.json
+    ```
 
 !!! note "Standard Pipeline"
     Your pipeline doesn't need any special configuration for MOAR. Just create a normal DocETL pipeline.
@@ -71,81 +95,121 @@ def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str
     total_count = len(output)
     
     for idx, result in enumerate(output):
-        # Compare result with original data
-        # For example, if your dataset has a 'src' attribute, it's available in the output
         original_text = result.get("src", "").lower()
         extracted_items = result.get("medication", [])
         
-        # Check if extracted items appear in original text
         for item in extracted_items:
             if item.lower() in original_text:
                 correct_count += 1
     
-    # Return dictionary of metrics
     return {
-        "medication_extraction_score": correct_count,  # This key will be used if metric_key matches
+        "medication_extraction_score": correct_count,
         "total_extracted": total_count,
         "precision": correct_count / total_count if total_count > 0 else 0.0,
     }
 ```
 
 !!! warning "Important Requirements"
-    - The function must be decorated with `@docetl.register_eval`
+    - The function must be decorated with `@register_eval`
     - It must take exactly two arguments: `dataset_file_path` and `results_file_path`
     - It must return a dictionary with numeric metrics
-    - The `metric_key` in your `optimizer_config` must match one of the keys in this dictionary
+    - The `metric_key` must match one of the keys in this dictionary
     - Only one function per file can be decorated with `@register_eval`
 
 For more details on evaluation functions, see the [Evaluation Functions guide](evaluation.md).
 
-## Step 3: Configure the Optimizer
+## Step 3: Run Optimization
 
-Add an `optimizer_config` section to your YAML. The `metric_key` specifies which key from your evaluation function's return dictionary will be used as the accuracy metric for optimization:
+=== "Python API (recommended)"
 
-```yaml
-optimizer_config:
-  type: moar
-  save_dir: results/moar_optimization
-  available_models:  # LiteLLM model names - ensure API keys are set in your environment
-    - gpt-4o-mini
-    - gpt-4o
-    - gpt-5.1-mini
-    - gpt-5.1
-  evaluation_file: evaluate_medications.py
-  metric_key: medication_extraction_score  # This must match a key in your evaluation function's return dictionary
-  max_iterations: 40
-  rewrite_agent_model: gpt-5.1
-  dataset_path: data/transcripts_sample.json  # Optional: use sample/hold-out dataset
-```
+    `pipeline.optimize()` is the single entry point. Only `eval_fn` and `metric_key` are required -- everything else has smart defaults.
 
-!!! tip "Using Sample Datasets"
-    Use `dataset_path` to specify a sample or hold-out dataset for optimization. This prevents optimizing on your test set. The main pipeline will still use the full dataset from the `datasets` section.
+    ```python
+    result = pipeline.optimize(
+        eval_fn="evaluate_medications.py",
+        metric_key="medication_extraction_score",
+    )
+    ```
 
-For complete configuration details, see the [Configuration Reference](configuration.md).
+    You can also pass a callable directly:
 
-## Step 4: Run the Optimizer
+    ```python
+    result = pipeline.optimize(
+        eval_fn=lambda path: {"score": compute_score(path)},
+        metric_key="score",
+    )
+    ```
 
-Run MOAR optimization using the CLI:
+    All optional parameters:
 
-```bash
-docetl build pipeline.yaml --optimizer moar
-```
+    ```python
+    result = pipeline.optimize(
+        eval_fn="evaluate_medications.py",
+        metric_key="medication_extraction_score",
+        models=None,              # auto-detect from API keys
+        agent_model=None,         # auto-select best available
+        max_iterations=20,        # search budget
+        save_dir=None,            # defaults to temp dir
+        exploration_weight=1.414, # UCB exploration constant
+    )
+    ```
 
-!!! success "What Happens Next"
-    MOAR will:
-    1. Explore different pipeline configurations
-    2. Evaluate each configuration using your evaluation function
-    3. Build a cost-accuracy frontier of optimal solutions
-    4. Save results to your `save_dir`
+    !!! tip "Auto-Detection"
+        Models are auto-detected from your environment API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AZURE_API_KEY`). The agent model is auto-selected as the best available model. No need to specify these unless you want to override the defaults.
 
-## Step 5: Review Results
+=== "CLI"
 
-After optimization completes, check your `save_dir` for:
+    Add an `optimizer_config` to your YAML. Only `evaluation_file` and `metric_key` are required:
 
-- **`experiment_summary.json`** - High-level summary of the run
-- **`pareto_frontier.json`** - List of optimal solutions
-- **`evaluation_metrics.json`** - Detailed evaluation results
-- **`pipeline_*.yaml`** - Optimized pipeline configurations
+    ```yaml
+    optimizer_config:
+      evaluation_file: evaluate_medications.py
+      metric_key: medication_extraction_score
+    ```
+
+    Then run:
+
+    ```bash
+    docetl build pipeline.yaml
+    ```
+
+    MOAR is the default optimizer -- no flag needed.
+
+## Step 4: Review Results
+
+=== "Python API"
+
+    `optimize()` returns a `MOARResult` object. Results are runnable pipelines, not just data points:
+
+    ```python
+    # Get the best pipeline by accuracy
+    best = result.best()       # Returns an OptimizedPipeline
+    print(f"Accuracy: {best.accuracy}, Cost: ${best.cost:.4f}")
+    best.run()                 # Execute the optimized pipeline
+
+    # Get the cheapest pipeline on the frontier
+    cheap = result.cheapest()  # Returns an OptimizedPipeline
+    cheap.run()
+
+    # View all frontier solutions
+    for plan in result.frontier:
+        print(f"Accuracy: {plan.accuracy}, Cost: ${plan.cost:.4f}, On frontier: {plan.on_frontier}")
+
+    # Get a DataFrame of all explored plans
+    df = result.to_df()
+    print(df)
+    ```
+
+    Each `OptimizedPipeline` has `.pipeline` (DSLRunner), `.cost`, `.accuracy`, `.yaml_path`, `.on_frontier`, and `.run()`.
+
+=== "CLI"
+
+    After optimization completes, check your `save_dir` for:
+
+    - **`experiment_summary.json`** — High-level summary of the run
+    - **`pareto_frontier.json`** — List of optimal solutions
+    - **`evaluation_metrics.json`** — Detailed evaluation results
+    - **`pipeline_*.yaml`** — Optimized pipeline configurations
 
 For details on interpreting results, see [Understanding Results](results.md).
 
@@ -154,4 +218,3 @@ For details on interpreting results, see [Understanding Results](results.md).
 - Learn about [configuration options](configuration.md)
 - See [complete examples](examples.md)
 - Read [troubleshooting tips](troubleshooting.md)
-

--- a/docs/optimization/moar/getting-started.md
+++ b/docs/optimization/moar/getting-started.md
@@ -61,60 +61,78 @@ Start with a standard DocETL pipeline. You can define it in Python or YAML.
 !!! note "Standard Pipeline"
     Your pipeline doesn't need any special configuration for MOAR. Just create a normal DocETL pipeline.
 
-## Step 2: Create an Evaluation Function
+## Step 2: Write an Evaluation Function
 
-Create a Python file with an evaluation function. This function will be called for each pipeline configuration that MOAR explores.
+Write a Python function that scores pipeline output. MOAR calls this function for each pipeline configuration it explores.
 
 !!! info "How Evaluation Works"
-    - Your function receives the pipeline output and the original dataset
-    - You compute evaluation metrics by comparing the output to the dataset
+    - Your function receives the path to the pipeline's output JSON file
+    - You load the results file and compute evaluation metrics
     - You return a dictionary of metrics
     - MOAR uses one specific key from this dictionary (specified by `metric_key`) as the accuracy metric to optimize
 
-```python
-# evaluate_medications.py
-import json
-from typing import Any, Dict
-from docetl.utils_evaluation import register_eval
+=== "Python API"
 
-@register_eval
-def evaluate_results(dataset_file_path: str, results_file_path: str) -> Dict[str, Any]:
-    """
-    Evaluate pipeline output against the original dataset.
-    """
-    # Load pipeline output
-    with open(results_file_path, 'r') as f:
-        output = json.load(f)
-    
-    # Load original dataset for comparison
-    with open(dataset_file_path, 'r') as f:
-        dataset = json.load(f)
-    
-    # Compute your evaluation metrics
-    correct_count = 0
-    total_count = len(output)
-    
-    for idx, result in enumerate(output):
-        original_text = result.get("src", "").lower()
-        extracted_items = result.get("medication", [])
-        
-        for item in extracted_items:
-            if item.lower() in original_text:
-                correct_count += 1
-    
-    return {
-        "medication_extraction_score": correct_count,
-        "total_extracted": total_count,
-        "precision": correct_count / total_count if total_count > 0 else 0.0,
-    }
-```
+    Just define a regular Python function:
 
-!!! warning "Important Requirements"
-    - The function must be decorated with `@register_eval`
-    - It must take exactly two arguments: `dataset_file_path` and `results_file_path`
-    - It must return a dictionary with numeric metrics
-    - The `metric_key` must match one of the keys in this dictionary
-    - Only one function per file can be decorated with `@register_eval`
+    ```python
+    import json
+
+    def evaluate(results_path):
+        with open(results_path) as f:
+            output = json.load(f)
+
+        correct_count = 0
+        for result in output:
+            original_text = result.get("src", "").lower()
+            for item in result.get("medication", []):
+                if item.lower() in original_text:
+                    correct_count += 1
+
+        return {
+            "medication_extraction_score": correct_count,
+            "total_extracted": len(output),
+        }
+    ```
+
+    If you need access to the original dataset, use a two-argument signature — the dataset path is passed automatically:
+
+    ```python
+    def evaluate(dataset_path, results_path):
+        with open(results_path) as f:
+            output = json.load(f)
+        with open(dataset_path) as f:
+            dataset = json.load(f)
+        # compare output to dataset...
+        return {"medication_extraction_score": computed_score}
+    ```
+
+=== "CLI (file-based)"
+
+    For CLI usage, create a Python file with a `@register_eval` decorated function:
+
+    ```python
+    # evaluate_medications.py
+    import json
+    from docetl.utils_evaluation import register_eval
+
+    @register_eval
+    def evaluate_results(dataset_file_path: str, results_file_path: str) -> dict:
+        with open(results_file_path) as f:
+            output = json.load(f)
+
+        correct_count = 0
+        for result in output:
+            original_text = result.get("src", "").lower()
+            for item in result.get("medication", []):
+                if item.lower() in original_text:
+                    correct_count += 1
+
+        return {
+            "medication_extraction_score": correct_count,
+            "total_extracted": len(output),
+        }
+    ```
 
 For more details on evaluation functions, see the [Evaluation Functions guide](evaluation.md).
 
@@ -122,21 +140,12 @@ For more details on evaluation functions, see the [Evaluation Functions guide](e
 
 === "Python API (recommended)"
 
-    `pipeline.optimize()` is the single entry point. Only `eval_fn` and `metric_key` are required -- everything else has smart defaults.
+    `pipeline.optimize()` is the single entry point. Pass your evaluation function and the metric key — everything else has smart defaults.
 
     ```python
     result = pipeline.optimize(
-        eval_fn="evaluate_medications.py",
+        eval_fn=evaluate,
         metric_key="medication_extraction_score",
-    )
-    ```
-
-    You can also pass a callable directly:
-
-    ```python
-    result = pipeline.optimize(
-        eval_fn=lambda path: {"score": compute_score(path)},
-        metric_key="score",
     )
     ```
 
@@ -144,7 +153,7 @@ For more details on evaluation functions, see the [Evaluation Functions guide](e
 
     ```python
     result = pipeline.optimize(
-        eval_fn="evaluate_medications.py",
+        eval_fn=evaluate,
         metric_key="medication_extraction_score",
         models=None,              # auto-detect from API keys
         agent_model=None,         # auto-select best available

--- a/docs/optimization/moar/results.md
+++ b/docs/optimization/moar/results.md
@@ -9,10 +9,7 @@ When using the Python API, `pipeline.optimize()` returns a `MOARResult` object w
 ### MOARResult
 
 ```python
-result = pipeline.optimize(
-    eval_fn="evaluate.py",
-    metric_key="score",
-)
+result = pipeline.optimize(eval_fn=evaluate, metric_key="score")
 
 result.best()      # OptimizedPipeline with highest accuracy on the frontier
 result.cheapest()  # OptimizedPipeline with lowest cost on the frontier
@@ -60,7 +57,7 @@ best.pipeline           # DSLRunner instance
 
 ```python
 # Choose based on your priorities
-result = pipeline.optimize(eval_fn="evaluate.py", metric_key="score")
+result = pipeline.optimize(eval_fn=evaluate, metric_key="score")
 
 # Highest accuracy
 best = result.best()

--- a/docs/optimization/moar/results.md
+++ b/docs/optimization/moar/results.md
@@ -2,16 +2,94 @@
 
 What MOAR outputs and how to interpret the results.
 
-## Output Files
+## Python API Results
 
-After running MOAR optimization, you'll find several files in your `save_dir`:
+When using the Python API, `pipeline.optimize()` returns a `MOARResult` object with methods to access optimized pipelines.
 
-- **`experiment_summary.json`** - High-level summary
-- **`pareto_frontier.json`** - Optimal solutions
-- **`evaluation_metrics.json`** - Detailed evaluation results
-- **`pipeline_*.yaml`** - Optimized pipeline configurations
+### MOARResult
 
-## experiment_summary.json
+```python
+result = pipeline.optimize(
+    eval_fn="evaluate.py",
+    metric_key="score",
+)
+
+result.best()      # OptimizedPipeline with highest accuracy on the frontier
+result.cheapest()  # OptimizedPipeline with lowest cost on the frontier
+result.frontier    # list[OptimizedPipeline] — all Pareto-optimal solutions
+result.to_df()     # pandas DataFrame of all explored plans
+```
+
+| Method / Property | Return Type | Description |
+|-------------------|-------------|-------------|
+| `best()` | `OptimizedPipeline` | The frontier solution with the highest accuracy |
+| `cheapest()` | `OptimizedPipeline` | The frontier solution with the lowest cost |
+| `frontier` | `list[OptimizedPipeline]` | All Pareto-optimal solutions, sorted by cost |
+| `to_df()` | `pandas.DataFrame` | DataFrame of all explored plans with cost, accuracy, and metadata |
+
+### OptimizedPipeline
+
+Each result on the frontier is an `OptimizedPipeline` that you can inspect and run directly:
+
+```python
+best = result.best()
+
+# Inspect
+print(best.cost)        # Estimated cost per run
+print(best.accuracy)    # Evaluation metric score
+print(best.yaml_path)   # Path to the optimized YAML file
+print(best.on_frontier) # True if on the Pareto frontier
+
+# Run
+best.run()              # Execute the optimized pipeline
+
+# Access the underlying DSLRunner
+best.pipeline           # DSLRunner instance
+```
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| `pipeline` | `DSLRunner` | The underlying pipeline runner |
+| `cost` | `float` | Estimated cost per run |
+| `accuracy` | `float` | Evaluation metric score |
+| `yaml_path` | `str` | Path to the optimized YAML configuration |
+| `on_frontier` | `bool` | Whether this plan is on the Pareto frontier |
+| `run()` | `float` | Execute the pipeline; returns execution cost |
+
+### Working with Results
+
+```python
+# Choose based on your priorities
+result = pipeline.optimize(eval_fn="evaluate.py", metric_key="score")
+
+# Highest accuracy
+best = result.best()
+print(f"Best accuracy: {best.accuracy}, cost: ${best.cost:.4f}")
+best.run()
+
+# Lowest cost
+cheap = result.cheapest()
+print(f"Cheapest cost: ${cheap.cost:.4f}, accuracy: {cheap.accuracy}")
+
+# Explore the full frontier
+for plan in result.frontier:
+    print(f"Cost: ${plan.cost:.4f}, Accuracy: {plan.accuracy}")
+
+# Analyze all explored configurations as a DataFrame
+df = result.to_df()
+print(df[["cost", "accuracy", "on_frontier"]].sort_values("accuracy", ascending=False))
+```
+
+## CLI Output Files
+
+After running `docetl build pipeline.yaml`, you'll find several files in your `save_dir`:
+
+- **`experiment_summary.json`** — High-level summary
+- **`pareto_frontier.json`** — Optimal solutions
+- **`evaluation_metrics.json`** — Detailed evaluation results
+- **`pipeline_*.yaml`** — Optimized pipeline configurations
+
+### experiment_summary.json
 
 High-level summary of the optimization run:
 
@@ -37,7 +115,7 @@ High-level summary of the optimization run:
     - `total_nodes_explored`: Total configurations tested
     - `total_search_cost`: Total cost of the optimization search
 
-## pareto_frontier.json
+### pareto_frontier.json
 
 List of Pareto-optimal solutions (the cost-accuracy frontier):
 
@@ -67,11 +145,11 @@ List of Pareto-optimal solutions (the cost-accuracy frontier):
 
 Each solution includes a `yaml_path` pointing to the optimized pipeline configuration.
 
-## evaluation_metrics.json
+### evaluation_metrics.json
 
 Detailed evaluation results for all explored configurations. This file contains comprehensive metrics for every pipeline configuration tested during optimization.
 
-## Pipeline Configurations
+### Pipeline Configurations
 
 Each solution on the Pareto frontier has a corresponding YAML file (e.g., `pipeline_5.yaml`) containing the optimized pipeline configuration. You can:
 
@@ -83,11 +161,9 @@ Each solution on the Pareto frontier has a corresponding YAML file (e.g., `pipel
 
 After reviewing the results:
 
-1. **Review the Pareto frontier** - See available options
-2. **Choose a solution** - Based on your accuracy/cost priorities
-3. **Test the chosen pipeline** - Run it on your full dataset
-4. **Integrate into production** - Use the optimized configuration
+1. **Choose a solution** — Use `result.best()` / `result.cheapest()` in Python, or review `pareto_frontier.json` from the CLI
+2. **Run the chosen pipeline** — Call `.run()` on the `OptimizedPipeline`, or run the YAML with `docetl run`
+3. **Integrate into production** — Use the optimized configuration
 
 !!! success "Success"
     You now have multiple optimized pipeline options to choose from, each representing a different point on the cost-accuracy trade-off curve.
-

--- a/docs/optimization/python-api.md
+++ b/docs/optimization/python-api.md
@@ -1,87 +1,114 @@
 # Optimizing Pipelines with the Python API
 
-You may have your pipelines defined in Python instead of YAML and want to optimize them. Here's an example of how to use the Python API to define, optimize, and run a document processing pipeline similar to the medical transcripts example we saw earlier.
+Use `pipeline.optimize()` to find cost-accuracy trade-offs for your pipeline. MOAR explores different configurations (models, validation steps, operation rewrites) and returns a frontier of optimized pipelines.
+
+## Quick Example
 
 ```python
-from docetl.api import Pipeline, Dataset, MapOp, UnnestOp, ResolveOp, ReduceOp, PipelineStep, PipelineOutput
+from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
 
-# Define datasets
-datasets = {
-    "transcripts": Dataset(type="file", path="medical_transcripts.json"),
-}
-
-# Define operations
-operations = [
-    MapOp(
-        name="extract_medications",
-        type="map",
-        optimize=True,  # This operation will be optimized
-        output={"schema": {"medication": "list[str]"}},
-        prompt="Analyze the transcript: {{ input.src }}\nList all medications mentioned.",
-    ),
-    UnnestOp(
-        name="unnest_medications",
-        type="unnest",
-        unnest_key="medication"
-    ),
-    ResolveOp(
-        name="resolve_medications",
-        type="resolve",
-        blocking_keys=["medication"],
-        optimize=True,  # This operation will be optimized
-        output={"schema": {"medication": "str"}},
-        comparison_prompt="Compare medications:\n1: {{ input1.medication }}\n2: {{ input2.medication }}\nAre these the same or closely related?",
-        resolution_prompt="Standardize the name for:\n{% for entry in inputs %}\n- {{ entry.medication }}\n{% endfor %}"
-    ),
-    ReduceOp(
-        name="summarize_prescriptions",
-        type="reduce",
-        reduce_key=["medication"],
-        output={"schema": {"side_effects": "str", "uses": "str"}},
-        prompt="Summarize side effects and uses of {{ reduce_key }} from:\n{% for value in inputs %}\nTranscript {{ loop.index }}: {{ value.src }}\n{% endfor %}",
-        optimize=True,  # This operation will be optimized
-    )
-]
-
-# Define pipeline steps
-steps = [
-    PipelineStep(name="medical_info_extraction", input="transcripts", operations=["extract_medications", "unnest_medications", "resolve_medications", "summarize_prescriptions"])
-]
-
-# Define pipeline output
-output = PipelineOutput(type="file", path="medication_summaries.json")
-
-# Create the pipeline
 pipeline = Pipeline(
-    name="medical_transcripts_pipeline",
-    datasets=datasets,
-    operations=operations,
-    steps=steps,
-    output=output,
+    name="medication_extraction",
+    datasets={"transcripts": Dataset(type="file", path="medical_transcripts.json")},
+    operations=[
+        MapOp(
+            name="extract_medications",
+            type="map",
+            output={"schema": {"medication": "list[str]"}},
+            prompt="Analyze the transcript: {{ input.src }}\nList all medications mentioned.",
+        ),
+    ],
+    steps=[PipelineStep(name="extraction", input="transcripts", operations=["extract_medications"])],
+    output=PipelineOutput(type="file", path="medication_summaries.json"),
     default_model="gpt-4o-mini",
-    system_prompt={
-        "dataset_description": "a collection of medical conversation transcripts",
-        "persona": "a healthcare analyst extracting and summarizing medication information",
-    }
 )
 
-# Optimize the pipeline
-optimized_pipeline = pipeline.optimize(model="gpt-4o-mini")
+# Optimize — models auto-detected from API keys
+result = pipeline.optimize(
+    eval_fn="evaluate_medications.py",
+    metric_key="medication_extraction_score",
+)
 
-# Run the optimized pipeline
-result = optimized_pipeline.run()
+# Run the best pipeline
+best = result.best()
+print(f"Best accuracy: {best.accuracy}, cost: ${best.cost:.4f}")
+best.run()
 
-print(f"Pipeline execution completed. Total cost: ${result:.2f}")
+# Or inspect all options as a DataFrame
+df = result.to_df()
+print(df)
 ```
 
-This example demonstrates how to create a pipeline that processes medical transcripts, extracts medication information, resolves similar medications, and summarizes prescription details.
+## Evaluation Function
 
-!!! note "Optimization"
+Create a Python file with a function decorated with `@register_eval`:
 
-    Notice that some operations have `optimize=True` set. DocETL will only optimize operations with this flag set to `True`. In this example, the `extract_medications`, `resolve_medications`, and `summarize_prescriptions` operations will be optimized.
+```python
+# evaluate_medications.py
+import json
+from docetl.utils_evaluation import register_eval
 
-!!! tip "Optimization Model"
+@register_eval
+def evaluate_results(dataset_file_path: str, results_file_path: str) -> dict:
+    with open(results_file_path, 'r') as f:
+        output = json.load(f)
+    with open(dataset_file_path, 'r') as f:
+        dataset = json.load(f)
 
-    We use `pipeline.optimize(model="gpt-4o-mini")` to optimize the pipeline using the GPT-4o-mini model for the agents. This allows you to specify which model to use for optimization, which can be particularly useful when you want to balance between performance and cost.
+    correct = sum(
+        1 for r in output
+        for med in r.get("medication", [])
+        if med.lower() in r.get("src", "").lower()
+    )
+    return {"medication_extraction_score": correct}
+```
 
-The pipeline is optimized before execution to improve performance and accuracy. By setting `optimize=True` for specific operations, you have fine-grained control over which parts of your pipeline undergo optimization.
+Or pass a callable directly:
+
+```python
+result = pipeline.optimize(
+    eval_fn=lambda path: {"score": my_scoring_function(path)},
+    metric_key="score",
+)
+```
+
+## Configuration Options
+
+All parameters beyond `eval_fn` and `metric_key` are optional:
+
+```python
+result = pipeline.optimize(
+    eval_fn="evaluate.py",
+    metric_key="score",
+    models=["gpt-4o", "gpt-4o-mini"],   # Override auto-detection
+    agent_model="gpt-4o",                # Override auto-selection
+    max_iterations=40,                   # Default: 20
+    save_dir="./moar_results",           # Default: temp dir
+    exploration_weight=1.414,            # UCB constant
+)
+```
+
+See the [Configuration Reference](moar/configuration.md) for details.
+
+## Working with Results
+
+```python
+result = pipeline.optimize(eval_fn="evaluate.py", metric_key="score")
+
+# Best accuracy on the frontier
+best = result.best()
+best.run()
+
+# Cheapest option on the frontier
+cheap = result.cheapest()
+cheap.run()
+
+# Browse the full frontier
+for plan in result.frontier:
+    print(f"Cost: ${plan.cost:.4f}, Accuracy: {plan.accuracy:.4f}")
+
+# Analyze as a DataFrame
+df = result.to_df()
+```
+
+See [Understanding Results](moar/results.md) for more details.

--- a/docs/optimization/python-api.md
+++ b/docs/optimization/python-api.md
@@ -7,6 +7,9 @@ Use `pipeline.optimize()` to find cost-accuracy trade-offs for your pipeline. MO
 ```python
 from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
 
+import json
+from docetl.api import Pipeline, Dataset, MapOp, PipelineStep, PipelineOutput
+
 pipeline = Pipeline(
     name="medication_extraction",
     datasets={"transcripts": Dataset(type="file", path="medical_transcripts.json")},
@@ -23,9 +26,20 @@ pipeline = Pipeline(
     default_model="gpt-4o-mini",
 )
 
+# Define your evaluation function
+def evaluate(results_path):
+    with open(results_path) as f:
+        output = json.load(f)
+    correct = sum(
+        1 for r in output
+        for med in r.get("medication", [])
+        if med.lower() in r.get("src", "").lower()
+    )
+    return {"medication_extraction_score": correct}
+
 # Optimize — models auto-detected from API keys
 result = pipeline.optimize(
-    eval_fn="evaluate_medications.py",
+    eval_fn=evaluate,
     metric_key="medication_extraction_score",
 )
 
@@ -41,19 +55,12 @@ print(df)
 
 ## Evaluation Function
 
-Create a Python file with a function decorated with `@register_eval`:
+Pass any callable that reads the results file and returns a dict of metrics:
 
 ```python
-# evaluate_medications.py
-import json
-from docetl.utils_evaluation import register_eval
-
-@register_eval
-def evaluate_results(dataset_file_path: str, results_file_path: str) -> dict:
-    with open(results_file_path, 'r') as f:
+def evaluate(results_path):
+    with open(results_path) as f:
         output = json.load(f)
-    with open(dataset_file_path, 'r') as f:
-        dataset = json.load(f)
 
     correct = sum(
         1 for r in output
@@ -61,16 +68,24 @@ def evaluate_results(dataset_file_path: str, results_file_path: str) -> dict:
         if med.lower() in r.get("src", "").lower()
     )
     return {"medication_extraction_score": correct}
+
+result = pipeline.optimize(eval_fn=evaluate, metric_key="medication_extraction_score")
 ```
 
-Or pass a callable directly:
+If you need access to the original dataset, use a two-argument signature — the dataset path is passed automatically:
 
 ```python
-result = pipeline.optimize(
-    eval_fn=lambda path: {"score": my_scoring_function(path)},
-    metric_key="score",
-)
+def evaluate(dataset_path, results_path):
+    with open(results_path) as f:
+        output = json.load(f)
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+    # compare output to dataset...
+    return {"score": computed_score}
 ```
+
+!!! tip "File paths for CLI"
+    The CLI still uses file-based evaluation via `@register_eval`. See the [Evaluation Functions guide](moar/evaluation.md) for that workflow.
 
 ## Configuration Options
 
@@ -78,7 +93,7 @@ All parameters beyond `eval_fn` and `metric_key` are optional:
 
 ```python
 result = pipeline.optimize(
-    eval_fn="evaluate.py",
+    eval_fn=evaluate,                    # Your evaluation function
     metric_key="score",
     models=["gpt-4o", "gpt-4o-mini"],   # Override auto-detection
     agent_model="gpt-4o",                # Override auto-selection
@@ -100,7 +115,7 @@ See the [Configuration Reference](moar/configuration.md) for details.
 ## Working with Results
 
 ```python
-result = pipeline.optimize(eval_fn="evaluate.py", metric_key="score")
+result = pipeline.optimize(eval_fn=evaluate, metric_key="score")
 
 # Best accuracy on the frontier
 best = result.best()

--- a/docs/optimization/python-api.md
+++ b/docs/optimization/python-api.md
@@ -85,8 +85,15 @@ result = pipeline.optimize(
     max_iterations=40,                   # Default: 20
     save_dir="./moar_results",           # Default: temp dir
     exploration_weight=1.414,            # UCB constant
+    method="moar",                       # Default; use "v1" for legacy
 )
 ```
+
+!!! tip "Legacy V1 Optimizer"
+    To use the legacy V1 optimizer instead of MOAR, pass `method="v1"`:
+    ```python
+    optimized_pipeline = pipeline.optimize(method="v1")
+    ```
 
 See the [Configuration Reference](moar/configuration.md) for details.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -251,6 +251,7 @@ def test_pipeline_optimization(
     )
 
     optimized_pipeline = pipeline.optimize(
+        method="v1",
         max_threads=64
     )
 


### PR DESCRIPTION
Closes #479 

MOAR was only usable through YAML config + CLI. This PR makes it a first-class Python API — you pass a function, get back runnable pipelines:

```python
def evaluate(results_path):
    with open(results_path) as f:
        output = json.load(f)
    correct = sum(
        1 for r in output
        for med in r.get("medications", [])
        if med.lower() in r.get("text", "").lower()
    )
    return {"score": correct}

result = pipeline.optimize(eval_fn=evaluate, metric_key="score")

best = result.best()      # OptimizedPipeline — has .run(), .cost, .accuracy
best.run()

cheap = result.cheapest()
cheap.run()

df = result.to_df()        # pandas DataFrame of all explored plans
```

That's it. Models are auto-detected from your API keys. No YAML config needed.

## What changed

**`Pipeline.optimize()`** — single entry point. `method="moar"` (default) or `method="v1"` (legacy). Two required args: `eval_fn` (a callable) and `metric_key`.

**`eval_fn` is a function, not a file path.** 1-arg `(results_path) -> dict` or 2-arg `(dataset_path, results_path) -> dict`. File paths still work for CLI.

**Results are runnable.** `result.best()` returns an `OptimizedPipeline` with `.run()`, `.cost`, `.accuracy`, `.yaml_path`. `result.to_df()` gives a DataFrame.

**Models auto-detect** from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AZURE_API_KEY`. Override with `models=[...]` if you want.

**CLI simplified.** `docetl build pipeline.yaml` — no `--optimizer` flag. Only 2 required YAML fields: `evaluation_file` and `metric_key`.

**`interactive_ui` warning.** If `interactive_ui: true` is set in the pipeline config, MOAR logs a warning that the interactive progress view is not used during optimization (it can be used when running the optimized pipelines afterward).

## Docs updated

All 9 doc files rewritten to match the new API:

- `docs/optimization/python-api.md` — callable `eval_fn` as primary, 1-arg and 2-arg examples
- `docs/optimization/moar.md` — workflow snippet uses `eval_fn=evaluate`
- `docs/optimization/moar/getting-started.md` — tabbed Python API (callable) vs CLI (file-based)
- `docs/optimization/moar/configuration.md` — `eval_fn` type is `Callable`, both signatures documented
- `docs/optimization/moar/evaluation.md` — Python API (callable) first, CLI (`@register_eval`) second, all patterns use plain functions
- `docs/optimization/moar/examples.md` — Python example uses inline function, CLI section labeled "for CLI"
- `docs/optimization/moar/results.md` — examples use `eval_fn=evaluate`
- `docs/api-reference/python.md` — `eval_fn` type is `Callable`, concrete function example
- `docs/concepts/optimization.md` — removed `--optimizer` flag references

## Example run

8 clinical notes, ground-truth medication+condition extraction, 10 iterations:

```
MOAROptimizer: starting search (10 iterations, 5 models)
  Models: gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-4o, gpt-4o-mini
  Agent model: gpt-4.1

MOAROptimizer: completed in 252.9s, 6 frontier points
```

```python
>>> result
MOARResult(6 frontier points, 17 total, best accuracy=0.9917)

>>> result.best()
OptimizedPipeline(cost=$0.0023, accuracy=0.9917, frontier)

>>> result.cheapest()
OptimizedPipeline(cost=$0.0005, accuracy=0.8916, frontier)
```

Pareto frontier — real cost vs accuracy tradeoffs:

```
  [1] Cost: $0.0005  Score: 0.8916  med_extraction_gpt-4.1-nano.yaml
  [2] Cost: $0.0008  Score: 0.9438  med_extraction_gpt-4o-mini.yaml
  [3] Cost: $0.0008  Score: 0.9625  med_extraction_10.yaml
  [4] Cost: $0.0022  Score: 0.9729  med_extraction_9.yaml
  [5] Cost: $0.0022  Score: 0.9854  med_extraction_17.yaml
  [6] Cost: $0.0023  Score: 0.9917  med_extraction_15.yaml
```

```python
>>> result.to_df()
        cost  accuracy  on_frontier
0   0.002262    0.9917         True
1   0.002224    0.9854         True
2   0.002220    0.9729         True
3   0.005720    0.9708        False
4   0.013708    0.9679        False
5   0.002241    0.9667        False
6   0.017183    0.9646        False
7   0.000813    0.9625         True
8   0.014369    0.9604        False
9   0.004857    0.9563        False
10  0.001571    0.9521        False
11  0.003163    0.9504        False
12  0.002185    0.9464        False
13  0.000808    0.9438         True
14  0.000859    0.9289        False
15  0.007998    0.9182        False
16  0.000531    0.8916         True
```

## New files

- `docetl/moar/models.py` — model auto-detection from env vars
- `docetl/moar/optimizer.py` — `MOAROptimizer`, `MOARResult`, `OptimizedPipeline`

## Test plan

- [x] 10-iteration optimization on 8 clinical notes — 17 plans explored, 6 frontier points, scores 0.89–0.99
- [x] Callable eval_fn (1-arg and 2-arg signatures)
- [x] Model auto-detection from `OPENAI_API_KEY`
- [x] `result.best()`, `.cheapest()`, `.frontier`, `.to_df()`
- [x] Fixed existing `test_pipeline_optimization` to use `method="v1"`
- [x] Rebased on main (includes PR #488 interactive_ui)

https://claude.ai/code/session_01LB3n8SC74QGsG1ikd4UinH