### PR TITLE
chore: bump version to 0.3.0 for PyPI release

### DIFF
--- a/docetl/__init__.py
+++ b/docetl/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 
 import sys
 import types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "docetl"
-version = "0.2.6"
+version = "0.3.0"
 description = "ETL with LLM operations."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1013,7 +1013,7 @@ wheels = [
 
 [[package]]
 name = "docetl"
-version = "0.2.6"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "asteval" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Version Bump: 0.2.6 → 0.3.0

Bumps the version across all three locations that must stay in sync:
- `pyproject.toml`
- `docetl/__init__.py`
- `uv.lock`

### Why 0.3.0?

There are **32 commits** since the last release (0.2.6, Dec 28 2025) with significant new features and improvements:

#### Major Features
- **PySpark-like Frame API** (`read_json()`, `.map()`, `.reduce()`, `.collect()`, etc.) and runner architecture refactor (#495)
- **Agentic LLM tool support** — OpenAI Agents SDK integration with tools in map/filter/reduce (#499)
- **Model cascades (BARGAIN)** — statistical proxy/oracle cascades to cut LLM cost on binary operators (#491, #494)
- **Interactive TUI progress view** for pipeline runs (#488)
- **MOAR simplification** — simplified interface with Python API (#490)

#### Improvements
- Token usage tracking in pipeline runner (#480)
- Embedding blocking threshold optimization (#473)
- Fast decomposition for map operations in DocWrangler (#472)
- Resolve operator MOAR directives (#470)
- Web search/fetch operations via Playwright
- DocWrangler UI improvements (table styling, error reporting, shareable workspace)

#### Fixes
- Pin `pyrate-limiter<4` to prevent breaking import changes (#483)
- Fix broken doc links (#476)
- Binary file handling bugfix
- Non-blocking pipeline queries fix for web GUI

### Release Process

After merging this PR, create a GitHub Release with tag `0.3.0` to trigger the PyPI publish workflow (`.github/workflows/release.yml`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99dbe6a4-3390-42ba-9ee6-345b267d8b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99dbe6a4-3390-42ba-9ee6-345b267d8b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

