### PR TITLE
Document MOAR rewrite directive extensibility

### DIFF
--- a/docs/assets/moar-chaining-rewrite.svg
+++ b/docs/assets/moar-chaining-rewrite.svg
@@ -1,57 +1,72 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="420" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">
-  <title id="title">Before and after a chaining rewrite</title>
-  <desc id="desc">The original pipeline maps a discharge summary directly to treatments. The rewritten pipeline first identifies new conditions, then extracts treatments using both the summary and the new conditions.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="940" height="570" viewBox="0 0 940 570" role="img" aria-labelledby="title desc">
+  <title id="title">A map operation before and after a chaining rewrite</title>
+  <desc id="desc">Before the rewrite, one map identifies new diagnoses and associates treatments in a single model call. After the rewrite, one map identifies new conditions and a second map extracts treatments using the summary and the new conditions.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
     </marker>
     <style>
-      .heading { font: 600 18px Inter, Arial, sans-serif; fill: #0f172a; }
-      .text { font: 500 15px Inter, Arial, sans-serif; fill: #0f172a; text-anchor: middle; }
-      .code-label { font: 500 13px Inter, Arial, sans-serif; fill: #0f172a; text-anchor: middle; }
-      .detail { font: 400 13px Inter, Arial, sans-serif; fill: #334155; text-anchor: middle; }
-      .edge-label { font: 500 12px Inter, Arial, sans-serif; fill: #475569; text-anchor: middle; }
-      .node { fill: #f8fafc; stroke: #64748b; stroke-width: 2; }
+      .panel { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 2; }
+      .eyebrow { font: 700 12px Inter, Arial, sans-serif; fill: #64748b; letter-spacing: 1.2px; }
+      .heading { font: 650 21px Inter, Arial, sans-serif; fill: #0f172a; }
+      .node-text { font: 600 14px Inter, Arial, sans-serif; fill: #0f172a; text-anchor: middle; }
+      .detail { font: 400 13px Inter, Arial, sans-serif; fill: #475569; text-anchor: middle; }
+      .step { font: 700 10px Inter, Arial, sans-serif; fill: #0369a1; letter-spacing: 1px; }
+      .bullet { font: 400 13px Inter, Arial, sans-serif; fill: #334155; }
+      .input { fill: #ffffff; stroke: #94a3b8; stroke-width: 2; }
       .operation { fill: #e0f2fe; stroke: #0284c7; stroke-width: 2; }
       .intermediate { fill: #fef3c7; stroke: #d97706; stroke-width: 2; }
       .output { fill: #dcfce7; stroke: #16a34a; stroke-width: 2; }
-      .arrow { fill: none; stroke: #475569; stroke-width: 2; marker-end: url(#arrow); }
-      .reused { fill: none; stroke: #64748b; stroke-width: 1.75; stroke-dasharray: 6 5; marker-end: url(#arrow); }
+      .arrow { fill: none; stroke: #64748b; stroke-width: 2; marker-end: url(#arrow); }
+      .divider { stroke: #bae6fd; stroke-width: 1.5; }
     </style>
   </defs>
 
-  <rect width="960" height="420" rx="16" fill="#ffffff"/>
+  <rect class="panel" x="15" y="15" width="440" height="540" rx="18"/>
+  <text class="eyebrow" x="45" y="52">BEFORE</text>
+  <text class="heading" x="45" y="80">One complex map</text>
 
-  <text class="heading" x="30" y="38">Before: one complex map</text>
-  <rect class="node" x="40" y="70" width="150" height="64" rx="10"/>
-  <text class="text" x="115" y="108">summary</text>
-  <path class="arrow" d="M 190 102 L 285 102"/>
-  <rect class="operation" x="285" y="62" width="380" height="80" rx="10"/>
-  <text class="text" x="475" y="91">extract_new_treatments</text>
-  <text class="detail" x="475" y="116">identify new diagnoses and associate treatments</text>
-  <path class="arrow" d="M 665 102 L 765 102"/>
-  <rect class="output" x="765" y="70" width="155" height="64" rx="10"/>
-  <text class="text" x="842.5" y="108">treatments</text>
+  <rect class="input" x="150" y="105" width="170" height="52" rx="10"/>
+  <text class="node-text" x="235" y="137">summary</text>
+  <path class="arrow" d="M 235 157 L 235 192"/>
 
-  <line x1="30" y1="188" x2="930" y2="188" stroke="#cbd5e1" stroke-width="2"/>
+  <rect class="operation" x="75" y="192" width="320" height="178" rx="12"/>
+  <text class="node-text" x="235" y="224">extract_new_treatments</text>
+  <line class="divider" x1="100" y1="242" x2="370" y2="242"/>
+  <text class="detail" x="235" y="268">One model call must:</text>
+  <circle cx="112" cy="298" r="4" fill="#0284c7"/>
+  <text class="bullet" x="126" y="303">identify newly diagnosed conditions</text>
+  <circle cx="112" cy="330" r="4" fill="#0284c7"/>
+  <text class="bullet" x="126" y="335">associate treatments with each condition</text>
 
-  <text class="heading" x="30" y="228">After: chaining rewrite</text>
-  <rect class="node" x="20" y="270" width="120" height="64" rx="10"/>
-  <text class="text" x="80" y="308">summary</text>
-  <path class="arrow" d="M 140 302 L 190 302"/>
-  <rect class="operation" x="190" y="270" width="190" height="64" rx="10"/>
-  <text class="code-label" x="285" y="307">identify_new_conditions</text>
-  <path class="arrow" d="M 380 302 L 425 302"/>
-  <rect class="intermediate" x="425" y="270" width="165" height="64" rx="10"/>
-  <text class="code-label" x="507.5" y="307">new_conditions</text>
-  <path class="arrow" d="M 590 302 L 625 302"/>
-  <rect class="operation" x="625" y="270" width="175" height="64" rx="10"/>
-  <text class="code-label" x="712.5" y="307">extract_treatments</text>
-  <path class="arrow" d="M 800 302 L 825 302"/>
-  <rect class="output" x="825" y="270" width="115" height="64" rx="10"/>
-  <text class="text" x="882.5" y="308">treatments</text>
+  <path class="arrow" d="M 235 370 L 235 410"/>
+  <rect class="output" x="150" y="410" width="170" height="52" rx="10"/>
+  <text class="node-text" x="235" y="442">treatments</text>
 
-  <path class="reused" d="M 80 334 C 80 390, 650 390, 690 334"/>
-  <rect x="258" y="365" width="270" height="23" rx="4" fill="#ffffff"/>
-  <text class="edge-label" x="386" y="382">summary is also available to the second map</text>
+  <rect class="panel" x="485" y="15" width="440" height="540" rx="18"/>
+  <text class="eyebrow" x="515" y="52">AFTER</text>
+  <text class="heading" x="515" y="80">Two dependent maps</text>
+
+  <rect class="input" x="620" y="105" width="170" height="52" rx="10"/>
+  <text class="node-text" x="705" y="137">summary</text>
+  <path class="arrow" d="M 705 157 L 705 184"/>
+
+  <rect class="operation" x="555" y="184" width="300" height="78" rx="12"/>
+  <text class="step" x="575" y="207">STEP 1</text>
+  <text class="node-text" x="705" y="228">identify_new_conditions</text>
+  <text class="detail" x="705" y="248">reads summary</text>
+
+  <path class="arrow" d="M 705 262 L 705 290"/>
+  <rect class="intermediate" x="610" y="290" width="190" height="52" rx="10"/>
+  <text class="node-text" x="705" y="322">new_conditions</text>
+  <path class="arrow" d="M 705 342 L 705 370"/>
+
+  <rect class="operation" x="555" y="370" width="300" height="78" rx="12"/>
+  <text class="step" x="575" y="393">STEP 2</text>
+  <text class="node-text" x="705" y="414">extract_treatments</text>
+  <text class="detail" x="705" y="434">reads summary + new_conditions</text>
+
+  <path class="arrow" d="M 705 448 L 705 476"/>
+  <rect class="output" x="620" y="476" width="170" height="52" rx="10"/>
+  <text class="node-text" x="705" y="508">treatments</text>
 </svg>

--- a/docs/assets/moar-chaining-rewrite.svg
+++ b/docs/assets/moar-chaining-rewrite.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="420" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">
+  <title id="title">Before and after a chaining rewrite</title>
+  <desc id="desc">The original pipeline maps a discharge summary directly to treatments. The rewritten pipeline first identifies new conditions, then extracts treatments using both the summary and the new conditions.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+    <style>
+      .heading { font: 600 18px Inter, Arial, sans-serif; fill: #0f172a; }
+      .text { font: 500 15px Inter, Arial, sans-serif; fill: #0f172a; text-anchor: middle; }
+      .code-label { font: 500 13px Inter, Arial, sans-serif; fill: #0f172a; text-anchor: middle; }
+      .detail { font: 400 13px Inter, Arial, sans-serif; fill: #334155; text-anchor: middle; }
+      .edge-label { font: 500 12px Inter, Arial, sans-serif; fill: #475569; text-anchor: middle; }
+      .node { fill: #f8fafc; stroke: #64748b; stroke-width: 2; }
+      .operation { fill: #e0f2fe; stroke: #0284c7; stroke-width: 2; }
+      .intermediate { fill: #fef3c7; stroke: #d97706; stroke-width: 2; }
+      .output { fill: #dcfce7; stroke: #16a34a; stroke-width: 2; }
+      .arrow { fill: none; stroke: #475569; stroke-width: 2; marker-end: url(#arrow); }
+      .reused { fill: none; stroke: #64748b; stroke-width: 1.75; stroke-dasharray: 6 5; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <rect width="960" height="420" rx="16" fill="#ffffff"/>
+
+  <text class="heading" x="30" y="38">Before: one complex map</text>
+  <rect class="node" x="40" y="70" width="150" height="64" rx="10"/>
+  <text class="text" x="115" y="108">summary</text>
+  <path class="arrow" d="M 190 102 L 285 102"/>
+  <rect class="operation" x="285" y="62" width="380" height="80" rx="10"/>
+  <text class="text" x="475" y="91">extract_new_treatments</text>
+  <text class="detail" x="475" y="116">identify new diagnoses and associate treatments</text>
+  <path class="arrow" d="M 665 102 L 765 102"/>
+  <rect class="output" x="765" y="70" width="155" height="64" rx="10"/>
+  <text class="text" x="842.5" y="108">treatments</text>
+
+  <line x1="30" y1="188" x2="930" y2="188" stroke="#cbd5e1" stroke-width="2"/>
+
+  <text class="heading" x="30" y="228">After: chaining rewrite</text>
+  <rect class="node" x="20" y="270" width="120" height="64" rx="10"/>
+  <text class="text" x="80" y="308">summary</text>
+  <path class="arrow" d="M 140 302 L 190 302"/>
+  <rect class="operation" x="190" y="270" width="190" height="64" rx="10"/>
+  <text class="code-label" x="285" y="307">identify_new_conditions</text>
+  <path class="arrow" d="M 380 302 L 425 302"/>
+  <rect class="intermediate" x="425" y="270" width="165" height="64" rx="10"/>
+  <text class="code-label" x="507.5" y="307">new_conditions</text>
+  <path class="arrow" d="M 590 302 L 625 302"/>
+  <rect class="operation" x="625" y="270" width="175" height="64" rx="10"/>
+  <text class="code-label" x="712.5" y="307">extract_treatments</text>
+  <path class="arrow" d="M 800 302 L 825 302"/>
+  <rect class="output" x="825" y="270" width="115" height="64" rx="10"/>
+  <text class="text" x="882.5" y="308">treatments</text>
+
+  <path class="reused" d="M 80 334 C 80 390, 650 390, 690 334"/>
+  <rect x="258" y="365" width="270" height="23" rx="4" fill="#ffffff"/>
+  <text class="edge-label" x="386" y="382">summary is also available to the second map</text>
+</svg>

--- a/docs/developer-reference/moar-extensibility.md
+++ b/docs/developer-reference/moar-extensibility.md
@@ -60,10 +60,26 @@ The operation combines two dependent decisions:
 
 Chaining can ask the agent to produce a decomposition such as:
 
-```text
-summary -> identify_new_conditions -> new_conditions
-summary + new_conditions -> extract_treatments -> treatments
+```mermaid
+flowchart TB
+    subgraph before["Before: one complex map"]
+        direction LR
+        S1["summary"] --> O["extract_new_treatments<br/>Identify new diagnoses and<br/>associate their treatments"]
+        O --> T1["treatments"]
+    end
+
+    subgraph after["After: chaining rewrite"]
+        direction LR
+        S2["summary"] --> C["identify_new_conditions"]
+        C --> N["new_conditions"]
+        S2 --> E["extract_treatments"]
+        N --> E
+        E --> T2["treatments"]
+    end
 ```
+
+Both plans accept `summary` and produce `treatments`. The rewritten plan makes
+`new_conditions` an explicit intermediate result that the second map can use.
 
 The developer implements the general strategy. The rewrite agent supplies the
 task-specific steps.

--- a/docs/developer-reference/moar-extensibility.md
+++ b/docs/developer-reference/moar-extensibility.md
@@ -1,0 +1,410 @@
+# Extending MOAR with rewrite directives
+
+A rewrite directive teaches MOAR one abstract way to transform a pipeline. The
+directive does not hardcode the rewrite for a particular pipeline. It describes
+when a transformation is useful, defines the structured configuration that the
+rewrite agent must generate, validates that configuration, and applies it to the
+pipeline.
+
+The built-in `chaining` directive is a compact example. It replaces one complex
+operation with a sequence of simpler map operations:
+
+```text
+Op  =>  Map* -> Op
+```
+
+The rewrite agent decides what the intermediate tasks and prompts should be.
+DocETL constructs the resulting pipeline, rejects invalid candidates, and MOAR
+measures whether the candidate improves the cost and accuracy frontier.
+
+This guide follows the implementation in
+[`docetl/reasoning_optimizer/directives/chaining.py`](https://github.com/ucbepic/docetl/blob/main/docetl/reasoning_optimizer/directives/chaining.py).
+
+## Directive lifecycle
+
+MOAR uses a directive in five stages:
+
+1. The search agent reads `name`, `formal_description`, `nl_description`, and
+   `when_to_use`, then selects a directive and one or more target operations.
+2. The directive asks the rewrite agent for a typed instantiate schema.
+3. The schema and directive code validate the proposed configuration.
+4. `apply()` returns a new operation list, and DocETL statically validates the
+   complete candidate pipeline before executing it.
+5. MOAR runs the candidate and evaluates its accuracy and cost.
+
+Keep the boundary between stages explicit. The schema describes what the agent
+may propose; `apply()` is deterministic pipeline construction.
+
+## Example: decompose a complex extraction
+
+Suppose a map operation must identify newly diagnosed conditions and associate
+treatments with them in one call:
+
+```yaml
+- name: extract_new_treatments
+  type: map
+  prompt: |
+    From this discharge summary, extract every treatment
+    prescribed specifically for a newly diagnosed condition.
+
+    {{ input.summary }}
+  output:
+    schema:
+      treatments: list[str]
+```
+
+The operation combines two dependent decisions:
+
+1. Which conditions are newly diagnosed?
+2. Which treatments were prescribed for those conditions?
+
+Chaining can ask the agent to produce a decomposition such as:
+
+```text
+summary -> identify_new_conditions -> new_conditions
+summary + new_conditions -> extract_treatments -> treatments
+```
+
+The developer implements the general strategy. The rewrite agent supplies the
+task-specific steps.
+
+## 1. Define the instantiate schema
+
+Add the Pydantic models that describe the agent's output to
+`docetl/reasoning_optimizer/instantiate_schemas.py`:
+
+```python
+class MapOpConfig(BaseModel):
+    name: str
+    prompt: str
+    output_keys: list[str]
+
+
+class ChainingInstantiateSchema(BaseModel):
+    new_ops: list[MapOpConfig]
+```
+
+For the medical operation, a valid agent response can be represented as:
+
+```python
+ChainingInstantiateSchema(
+    new_ops=[
+        MapOpConfig(
+            name="identify_new_conditions",
+            prompt="""
+            Read this discharge summary:
+
+            {{ input.summary }}
+
+            List only conditions explicitly described as newly diagnosed.
+            """,
+            output_keys=["new_conditions"],
+        ),
+        MapOpConfig(
+            name="extract_treatments",
+            prompt="""
+            Read this discharge summary:
+
+            {{ input.summary }}
+
+            Newly diagnosed conditions:
+            {{ input.new_conditions }}
+
+            List the treatments prescribed for each new condition.
+            """,
+            output_keys=["treatments"],
+        ),
+    ]
+)
+```
+
+Use narrow fields with descriptions that a model can follow. Do not ask the
+agent to emit an entire pipeline when the directive needs only two prompts and
+their output keys.
+
+## 2. Validate the agent's proposal
+
+Validation should enforce the semantic invariants of the rewrite before any
+candidate is executed. Chaining currently checks three conditions:
+
+- Every generated map prompt contains an `{{ input.<key> }}` reference.
+- Every input key used by the original operation appears in at least one new
+  prompt.
+- The last map declares exactly the original operation's output keys.
+
+For the example, `summary` is a required original input and `treatments` is the
+required final output. A chain ending at `new_conditions` is therefore invalid.
+
+`{{ input.new_conditions }}` is valid in a later map because the earlier map
+produces `new_conditions`. The complete candidate is also passed through
+DocETL's static plan validation after `apply()`. If a new directive has stricter
+dependency rules, validate them in its instantiate schema rather than relying
+only on execution to expose an error.
+
+The agent can generate malformed or incomplete configurations even with
+structured output enabled. Return the validation error to the agent and retry a
+small, bounded number of times. `MAX_DIRECTIVE_INSTANTIATION_ATTEMPTS` is the
+shared limit used by the built-in directives.
+
+## 3. Describe the abstract strategy
+
+Create a subclass of `Directive` under
+`docetl/reasoning_optimizer/directives/`. The four descriptive fields are part
+of the search interface, not only documentation:
+
+```python
+class ChainingDirective(Directive):
+    name: str = Field(default="chaining")
+    formal_description: str = Field(default="Op => Map* -> Op")
+    nl_description: str = Field(
+        default=(
+            "Decompose a complex operation into a sequence by inserting one "
+            "or more Map steps that rewrite the input for the next operation."
+        )
+    )
+    when_to_use: str = Field(
+        default=(
+            "When the original task is too complex for one step and should be "
+            "split into a series of dependent steps."
+        )
+    )
+    instantiate_schema_type: Type[BaseModel] = ChainingInstantiateSchema
+```
+
+Write `when_to_use` so the search agent can decide among competing directives.
+State the observable property of a suitable target, such as dependent reasoning
+steps, rather than claiming that the directive always improves accuracy.
+
+The base class also requires an `example` and may include `test_cases`. The
+example becomes part of the rewrite agent's context, so use a complete example
+that preserves inputs, outputs, and prompt instructions.
+
+## 4. Instantiate the directive
+
+Implement `to_string_for_instantiate()` and `llm_instantiate()` to obtain the
+typed configuration:
+
+```python
+response = completion(
+    model=agent_llm,
+    messages=messages,
+    response_format=ChainingInstantiateSchema,
+)
+
+payload = json.loads(response.choices[0].message.content)
+rewrite = ChainingInstantiateSchema(**payload)
+ChainingInstantiateSchema.validate_chain(
+    new_ops=rewrite.new_ops,
+    required_input_keys=expected_input_keys,
+    expected_output_keys=expected_output_keys,
+)
+```
+
+`llm_instantiate()` should return the schema, updated message history, and the
+LLM call cost. MOAR includes the call cost in the total search cost.
+
+Implement `instantiate()` as the orchestration boundary:
+
+1. Check the number and types of target operations.
+2. Read the target's required input and output keys.
+3. Call `llm_instantiate()`.
+4. Call the deterministic `apply()` method.
+5. Return `(new_ops, message_history, call_cost)`.
+
+MOAR passes additional keyword arguments to every directive, including the
+optimization goal, dataset, allowed models, and input path. Accept `**kwargs`
+when a directive does not use all of them.
+
+## 5. Apply the rewrite
+
+`apply()` should not call a model. It should copy the operation list, construct
+the replacement operations from the validated schema, and return the new list.
+The essential chaining implementation is:
+
+```python
+def apply(self, global_default_model, ops_list, target_op, rewrite):
+    new_ops_list = deepcopy(ops_list)
+    position = next(
+        i for i, op in enumerate(new_ops_list) if op["name"] == target_op
+    )
+    original = new_ops_list[position]
+    model = original.get("model", global_default_model)
+
+    replacement = []
+    for index, step in enumerate(rewrite.new_ops):
+        output = (
+            original["output"]
+            if index == len(rewrite.new_ops) - 1
+            else {
+                "schema": {key: "string" for key in step.output_keys}
+            }
+        )
+        replacement.append(
+            {
+                "name": step.name,
+                "type": "map",
+                "prompt": step.prompt,
+                "model": model,
+                "litellm_completion_kwargs": {"temperature": 0},
+                "output": output,
+            }
+        )
+
+    new_ops_list[position : position + 1] = replacement
+    return new_ops_list
+```
+
+The last map reuses the original output block so the rewritten pipeline
+preserves the public output contract, including its field types.
+
+## 6. Register the directive
+
+Export and instantiate the directive in
+`docetl/reasoning_optimizer/directives/__init__.py`:
+
+```python
+from .my_directive import MyDirective
+
+ALL_DIRECTIVES = [
+    # ...
+    MyDirective(),
+]
+```
+
+Adding an instance to `ALL_DIRECTIVES` makes the directive available to the
+accuracy search and adds it to `DIRECTIVE_REGISTRY`. Also update `__all__`.
+
+Some directives require additional registration:
+
+| Registry | Add the directive when |
+| --- | --- |
+| `ALL_COST_DIRECTIVES` | Its description should be offered during cost optimization. |
+| `MULTI_INSTANCE_DIRECTIVES` | MOAR should ask for two distinct instantiations per selection. |
+| `DIRECTIVE_GROUPS` | A poor result should suppress a family of equivalent rewrites for the same operation. |
+
+Only add a directive to the cost list when its expected effect on cost is
+clear. A rewrite that merely adds model calls is normally an accuracy directive.
+
+## Test the directive
+
+Use separate test layers so a model-dependent test is not mistaken for a
+deterministic correctness test.
+
+### Schema tests
+
+Test valid and invalid configurations directly. Include missing original input
+keys, missing final outputs, empty chains, duplicate operation names, and
+references to unavailable intermediate keys when the directive forbids them.
+
+```python
+def test_chaining_rejects_wrong_final_output():
+    rewrite = ChainingInstantiateSchema(
+        new_ops=[
+            MapOpConfig(
+                name="identify_new_conditions",
+                prompt="Read {{ input.summary }}",
+                output_keys=["new_conditions"],
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="do not match"):
+        ChainingInstantiateSchema.validate_chain(
+            rewrite.new_ops,
+            required_input_keys=["summary"],
+            expected_output_keys=["treatments"],
+        )
+```
+
+### Deterministic apply tests
+
+Construct the schema by hand, call `apply()`, and assert the full operation
+shape. Verify operation order, names, models, intermediate schemas, and exact
+preservation of the final output schema. Add the test to
+`tests/reasoning_optimizer/test_directive_apply.py`.
+
+```bash
+uv run pytest tests/reasoning_optimizer/test_directive_apply.py -k chaining
+```
+
+### Pipeline validation and multi-step tests
+
+A locally plausible operation list can still break step references or later
+rewrites. Add a test to `tests/test_moar_multistep.py` that applies the rewrite,
+updates the pipeline, runs static plan validation, and, where relevant, applies
+a second directive to an inserted operation.
+
+```bash
+uv run pytest tests/test_moar_multistep.py -k chaining
+```
+
+### Live agent tests
+
+`Directive.run_tests()` calls a live model to instantiate the directive and a
+second live model call to judge the result. Use it as an integration check, not
+as the only correctness test:
+
+```bash
+uv run python -m tests.reasoning_optimizer.test_runner \
+  --directive chaining \
+  --model gpt-4.1
+```
+
+The command requires credentials for the selected model and may vary between
+runs. Record the model, prompt version, fixture, and repeated-run pass rate when
+comparing directive changes.
+
+## Confirm that MOAR uses the directive
+
+Registration, selection, successful construction, and measured improvement are
+different claims. Check each one explicitly:
+
+| Claim | Check |
+| --- | --- |
+| Registered | Print the names in `ALL_DIRECTIVES` or `DIRECTIVE_REGISTRY`. |
+| Offered to search | Find the directive in the action statistics in `moar_tree_log.txt`. |
+| Selected | Look for `Directive: <name>, Target ops: [...]` in the console, or a nonzero use count in the tree log. |
+| Constructed | Open the generated `<pipeline-name>_<node-id>.yaml` and inspect the rewritten operations. |
+| Helpful | Compare the candidate's evaluation metric and cost with its parent; check whether it reaches the Pareto frontier. |
+
+Confirm registration without making an LLM call:
+
+```bash
+uv run python -c \
+  "from docetl.reasoning_optimizer.directives import ALL_DIRECTIVES; print([d.name for d in ALL_DIRECTIVES])"
+```
+
+Then run a small MOAR experiment with an explicit `save_dir`. The search log is
+written to `<save_dir>/moar_tree_log.txt`:
+
+```bash
+rg -n "my_directive|Action: my_directive" results/moar_tree_log.txt
+```
+
+A zero use count means the directive was available but was not selected. A
+nonzero count means it was selected, but not necessarily that candidate
+construction or execution succeeded. Inspect the console output and generated
+YAML as well.
+
+For a deterministic MOAR integration test, construct `MOARSearch` with
+`available_actions={MyDirective()}` and a fixed evaluation fixture. Restricting
+the action set prevents the search agent from choosing a different directive.
+Keep an unrestricted benchmark too, because a good directive description must
+compete successfully with the rest of the registry.
+
+## Implementation checklist
+
+| Part | Chaining example |
+| --- | --- |
+| Pattern | One complex operation |
+| Replacement | A sequence of map operations |
+| Selection metadata | Use for dependent reasoning steps |
+| Instantiate schema | A list of map names, prompts, and output keys |
+| Validation | Preserve original inputs and final output contract |
+| Apply | Replace one operation with the generated sequence |
+| Deterministic tests | Schema, operation shape, and static plan validity |
+| Empirical tests | Selection rate, execution success, accuracy, and cost |
+
+The central interface is small: a developer specifies an abstract strategy and
+its invariants, an agent adapts the strategy to a particular pipeline, and MOAR
+tests the resulting candidate against the user's evaluation function.

--- a/docs/developer-reference/moar-extensibility.md
+++ b/docs/developer-reference/moar-extensibility.md
@@ -1,53 +1,57 @@
 # Adding a MOAR rewrite directive
 
-A rewrite directive defines one kind of pipeline transformation that MOAR can
-consider. The directive describes which operations it applies to, defines the
-structured output that the rewrite agent must produce, validates the agent's
-output, and constructs a new pipeline.
+A rewrite directive lets MOAR test a new kind of pipeline change. The directive
+contributor writes code for the following tasks:
 
-The built-in `chaining` directive replaces one complex operation with a sequence
-of simpler map operations:
+- Tell the search agent when it can use the directive.
+- Define the output that the rewrite agent must return.
+- Reject invalid agent output.
+- Build the changed pipeline.
+
+The `chaining` directive included with DocETL is one example. MOAR can use it to
+replace one complex operation with a sequence of simpler map operations.
 
 ```text
 Op  =>  Map* -> Op
 ```
 
-The directive implementation defines the permitted transformation. For each
-target operation, the rewrite agent generates the intermediate tasks and
-prompts. DocETL validates the resulting pipeline before MOAR executes and scores
-it.
+The contributor defines which pipeline changes are valid. During a search, the
+rewrite agent writes the intermediate tasks and prompts for one target
+operation. DocETL checks the changed pipeline before MOAR runs and scores it.
 
-This guide follows the implementation in
+The code examples follow the implementation in
 [`docetl/reasoning_optimizer/directives/chaining.py`](https://github.com/ucbepic/docetl/blob/main/docetl/reasoning_optimizer/directives/chaining.py).
 
 !!! note "Who provides each part?"
-    - **Pipeline author:** the original pipeline and evaluation function.
-    - **Directive contributor:** the instantiate schema, validation rules,
-      application code, registration, and tests.
-    - **Rewrite agent:** one task-specific instance of the directive during a
-      MOAR search.
+    - **The pipeline author** provides the original pipeline and evaluation
+      function.
+    - **The directive contributor** writes the instantiate schema, validation
+      rules, application code, registration, and tests.
+    - **The rewrite agent** creates one instance of the directive for a target
+      operation while MOAR runs.
 
 ## How MOAR uses a directive
 
-MOAR uses a directive in five stages:
+MOAR uses the same process for every directive.
 
 1. The search agent reads `name`, `formal_description`, `nl_description`, and
    `when_to_use`, then selects a directive and one or more target operations.
-2. The directive asks the rewrite agent for a typed instantiate schema.
-3. The schema and directive code validate the proposed configuration.
+2. The directive asks the rewrite agent for an object that matches the
+   instantiate schema.
+3. The contributor's validation code checks the proposed configuration.
 4. `apply()` returns a new operation list, and DocETL statically validates the
    complete candidate pipeline before executing it.
 5. MOAR runs the candidate and evaluates its accuracy and cost.
 
-The schema limits what the rewrite agent may propose. `apply()` performs the
-pipeline transformation without another model call.
+The schema limits what the rewrite agent may return. The `apply()` method builds
+the changed pipeline without another model call.
 
-## Running example: split a medical extraction
+## Medical extraction example
 
 Suppose a pipeline contains a map operation that must identify newly diagnosed
 conditions and associate treatments with them in one call.
 
-!!! example "Example input: the pipeline author's operation"
+!!! example "Example input, the pipeline author's operation"
     The pipeline author writes the original operation. The directive receives
     the operation as input during optimization.
 
@@ -69,24 +73,24 @@ The operation combines two dependent decisions:
 1. Which conditions are newly diagnosed?
 2. Which treatments were prescribed for those conditions?
 
-The chaining directive can replace the operation with two dependent maps:
+MOAR can apply chaining to replace the operation with two dependent maps.
 
 ![Before and after the chaining rewrite](../assets/moar-chaining-rewrite.svg)
 
-Both plans accept `summary` and produce `treatments`. The rewritten plan makes
-`new_conditions` an explicit intermediate result that the second map can use.
+Both plans accept `summary` and produce `treatments`. In the changed plan,
+`new_conditions` is an intermediate result for the second map.
 
-The directive contributor does not hardcode the two medical tasks. The rewrite
-agent generates them from the target operation during optimization.
+The contributor writes rules for any chaining rewrite. While MOAR runs, the
+rewrite agent chooses the medical tasks for the target operation.
 
 ## 1. Define the instantiate schema
 
-Add the Pydantic models that describe the agent's output to
-`docetl/reasoning_optimizer/instantiate_schemas.py`.
+An instantiate schema is a Pydantic model for the rewrite agent's output. Add
+the schema to `docetl/reasoning_optimizer/instantiate_schemas.py`.
 
-!!! abstract "Contributor code: the instantiate schema"
-    The directive contributor writes these classes. They define the fields that
-    the rewrite agent must return.
+!!! abstract "Contributor code, the instantiate schema"
+    The directive contributor writes the following classes. The classes define
+    the fields that the rewrite agent must return.
 
     ```python
     class MapOpConfig(BaseModel):
@@ -99,9 +103,9 @@ Add the Pydantic models that describe the agent's output to
         new_ops: list[MapOpConfig]
     ```
 
-!!! example "Runtime example: output from the rewrite agent"
-    The following object is an example of agent output for the medical operation
-    above. A pipeline author does not write this object.
+!!! example "Runtime example, output from the rewrite agent"
+    At runtime, the rewrite agent may return the following object for the
+    medical operation. A pipeline author does not write the object.
 
     ```python
     ChainingInstantiateSchema(
@@ -135,39 +139,39 @@ Add the Pydantic models that describe the agent's output to
     )
     ```
 
-Use narrow fields with descriptions that a model can follow. Do not ask the
-agent to emit an entire pipeline when the directive needs only two prompts and
-their output keys.
+Use narrow fields and describe them clearly. If a directive needs only two
+prompts and their output keys, do not ask the agent to return an entire
+pipeline.
 
 ## 2. Validate the agent's proposal
 
-Validation should enforce the semantic invariants of the rewrite before any
-candidate is executed. Chaining currently checks three conditions:
+Validate every requirement before MOAR runs a candidate. For chaining, reject
+the agent's proposal unless all of the following statements are true:
 
 - Every generated map prompt contains an `{{ input.<key> }}` reference.
 - Every input key used by the original operation appears in at least one new
   prompt.
 - The last map declares exactly the original operation's output keys.
 
-For the example, `summary` is a required original input and `treatments` is the
-required final output. A chain ending at `new_conditions` is therefore invalid.
+In the medical example, `summary` is a required input and `treatments` is the
+required final output. A chain that ends at `new_conditions` is invalid.
 
-`{{ input.new_conditions }}` is valid in a later map because the earlier map
-produces `new_conditions`. The complete candidate is also passed through
-DocETL's static plan validation after `apply()`. If a new directive has stricter
-dependency rules, validate them in its instantiate schema rather than relying
-only on execution to expose an error.
+The later map may use `{{ input.new_conditions }}` because the earlier map
+produces `new_conditions`. After `apply()` runs, DocETL also checks the complete
+pipeline without running it. If a directive has stricter rules for dependencies,
+check the rules in its instantiate schema. MOAR can then reject an error before
+execution.
 
-The agent can generate malformed or incomplete configurations even with
-structured output enabled. Return the validation error to the agent and retry a
-small, bounded number of times. `MAX_DIRECTIVE_INSTANTIATION_ATTEMPTS` is the
-shared limit used by the built-in directives.
+The agent can return an invalid or incomplete configuration even when you use
+structured output. Return the validation error to the agent, and limit the
+number of retries. The directives included with DocETL use
+`MAX_DIRECTIVE_INSTANTIATION_ATTEMPTS` as their shared limit.
 
-## 3. Describe when the directive applies
+## 3. Describe when MOAR should use the directive
 
 Create a subclass of `Directive` under
-`docetl/reasoning_optimizer/directives/`. The four descriptive fields are part
-of the search interface, not only documentation:
+`docetl/reasoning_optimizer/directives/`. The search agent reads the four
+descriptive fields when it chooses a directive.
 
 ```python
 class ChainingDirective(Directive):
@@ -188,18 +192,20 @@ class ChainingDirective(Directive):
     instantiate_schema_type: Type[BaseModel] = ChainingInstantiateSchema
 ```
 
-Write `when_to_use` so the search agent can decide among competing directives.
-State the observable property of a suitable target, such as dependent reasoning
-steps, rather than claiming that the directive always improves accuracy.
+Write `when_to_use` so the search agent can choose among the available
+directives. Describe a property that the search agent can find in a target
+operation. For example, chaining applies when an operation contains dependent
+reasoning steps. Do not claim that every use of the directive improves
+accuracy.
 
 The base class also requires an `example` and may include `test_cases`. The
-example becomes part of the rewrite agent's context, so use a complete example
-that preserves inputs, outputs, and prompt instructions.
+rewrite agent receives the example in its prompt. Use a complete example that
+preserves the input fields, output fields, and prompt instructions.
 
 ## 4. Generate and validate a rewrite instance
 
-Implement `to_string_for_instantiate()` and `llm_instantiate()` to obtain the
-typed configuration:
+Use `to_string_for_instantiate()` and `llm_instantiate()` to ask the rewrite
+agent for a configuration that matches the schema.
 
 ```python
 response = completion(
@@ -217,10 +223,11 @@ ChainingInstantiateSchema.validate_chain(
 )
 ```
 
-`llm_instantiate()` should return the schema, updated message history, and the
-LLM call cost. MOAR includes the call cost in the total search cost.
+Return the schema, updated message history, and model call cost from
+`llm_instantiate()`. MOAR adds the rewrite agent call cost to the total search
+cost.
 
-Implement `instantiate()` as the orchestration boundary:
+Use `instantiate()` to complete the following work in order:
 
 1. Check the number and types of target operations.
 2. Read the target's required input and output keys.
@@ -228,15 +235,15 @@ Implement `instantiate()` as the orchestration boundary:
 4. Call the deterministic `apply()` method.
 5. Return `(new_ops, message_history, call_cost)`.
 
-MOAR passes additional keyword arguments to every directive, including the
-optimization goal, dataset, allowed models, and input path. Accept `**kwargs`
-when a directive does not use all of them.
+MOAR provides every directive with additional values such as the optimization
+goal and dataset. It also provides the allowed models and input path. Accept
+`**kwargs` when the directive does not use every value.
 
 ## 5. Apply the rewrite
 
-`apply()` should not call a model. It should copy the operation list, construct
-the replacement operations from the validated schema, and return the new list.
-The essential chaining implementation is:
+Do not call a model from `apply()`. Copy the operation list and build the
+replacement operations from the validated schema. Then return the new list.
+The main part of the chaining implementation follows.
 
 ```python
 def apply(self, global_default_model, ops_list, target_op, rewrite):
@@ -271,13 +278,13 @@ def apply(self, global_default_model, ops_list, target_op, rewrite):
     return new_ops_list
 ```
 
-The last map reuses the original output block so the rewritten pipeline
-preserves the public output contract, including its field types.
+The last map uses the original output block. The changed pipeline therefore has
+the same final output fields and field types as the original pipeline.
 
 ## 6. Register the directive
 
-Export and instantiate the directive in
-`docetl/reasoning_optimizer/directives/__init__.py`:
+Import the directive and add an instance to
+`docetl/reasoning_optimizer/directives/__init__.py`.
 
 ```python
 from .my_directive import MyDirective
@@ -288,30 +295,33 @@ ALL_DIRECTIVES = [
 ]
 ```
 
-Adding an instance to `ALL_DIRECTIVES` makes the directive available to the
-accuracy search and adds it to `DIRECTIVE_REGISTRY`. Also update `__all__`.
+After you add the instance to `ALL_DIRECTIVES`, the accuracy search can use the
+directive. The code also adds the directive to `DIRECTIVE_REGISTRY`. Update
+`__all__` as well.
 
-Some directives require additional registration:
+Register the directive in another list only when one of the following
+conditions applies:
 
 | Registry | Add the directive when |
 | --- | --- |
-| `ALL_COST_DIRECTIVES` | Its description should be offered during cost optimization. |
+| `ALL_COST_DIRECTIVES` | The search agent should consider it during cost optimization. |
 | `MULTI_INSTANCE_DIRECTIVES` | MOAR should ask for two distinct instantiations per selection. |
-| `DIRECTIVE_GROUPS` | A poor result should suppress a family of equivalent rewrites for the same operation. |
+| `DIRECTIVE_GROUPS` | After a poor result, MOAR should skip equivalent rewrites for the same operation. |
 
-Only add a directive to the cost list when its expected effect on cost is
-clear. A rewrite that merely adds model calls is normally an accuracy directive.
+Only add a directive to the cost list when you can explain how it may reduce
+cost. A rewrite that only adds model calls normally belongs in the accuracy
+search.
 
 ## Test the directive
 
-Use separate test layers so a model-dependent test is not mistaken for a
-deterministic correctness test.
+Test code that does not call a model separately from tests that call a model.
 
 ### Schema tests
 
-Test valid and invalid configurations directly. Include missing original input
-keys, missing final outputs, empty chains, duplicate operation names, and
-references to unavailable intermediate keys when the directive forbids them.
+Test valid and invalid configurations directly. At minimum, test a missing
+original input and a missing final output. Also test an empty chain and
+duplicate operation names. If the directive limits intermediate fields, test a
+reference to a field that no earlier operation produced.
 
 ```python
 def test_chaining_rejects_wrong_final_output():
@@ -333,23 +343,24 @@ def test_chaining_rejects_wrong_final_output():
         )
 ```
 
-### Deterministic apply tests
+### Tests for `apply()`
 
-Construct the schema by hand, call `apply()`, and assert the full operation
-shape. Verify operation order, names, models, intermediate schemas, and exact
-preservation of the final output schema. Add the test to
+Construct the schema by hand and call `apply()`. Check the operation order,
+names, models, and intermediate schemas. Also check that the final output schema
+matches the original schema. Add the test to
 `tests/reasoning_optimizer/test_directive_apply.py`.
 
 ```bash
 uv run pytest tests/reasoning_optimizer/test_directive_apply.py -k chaining
 ```
 
-### Pipeline validation and multi-step tests
+### Tests for complete pipelines and several rewrites
 
-A locally plausible operation list can still break step references or later
-rewrites. Add a test to `tests/test_moar_multistep.py` that applies the rewrite,
-updates the pipeline, runs static plan validation, and, where relevant, applies
-a second directive to an inserted operation.
+An operation list can pass a test for `apply()` and still contain a broken input
+reference. A later rewrite can also fail on an operation that the first rewrite
+added. In `tests/test_moar_multistep.py`, add a test that updates the complete
+pipeline and runs plan validation. When relevant, apply a second directive to
+an operation that the first directive added.
 
 ```bash
 uv run pytest tests/test_moar_multistep.py -k chaining
@@ -357,9 +368,9 @@ uv run pytest tests/test_moar_multistep.py -k chaining
 
 ### Live agent tests
 
-`Directive.run_tests()` calls a live model to instantiate the directive and a
-second live model call to judge the result. Use it as an integration check, not
-as the only correctness test:
+`Directive.run_tests()` calls one model to create the rewrite and another model
+to judge it. Use the command as an integration test, but keep the deterministic
+tests described above.
 
 ```bash
 uv run python -m tests.reasoning_optimizer.test_runner \
@@ -367,47 +378,47 @@ uv run python -m tests.reasoning_optimizer.test_runner \
   --model gpt-4.1
 ```
 
-The command requires credentials for the selected model and may vary between
-runs. Record the model, prompt version, fixture, and repeated-run pass rate when
-comparing directive changes.
+The command requires credentials for the selected model. Model output may vary
+between runs, so record the model, prompt version, test data, and pass rate over
+repeated runs.
 
 ## Confirm that MOAR uses the directive
 
-Registration, selection, successful construction, and measured improvement are
-different claims. Check each one explicitly:
+Check each stage separately because registration does not prove that MOAR
+selected the directive, built a valid pipeline, or improved the score.
 
 | Claim | Check |
 | --- | --- |
 | Registered | Print the names in `ALL_DIRECTIVES` or `DIRECTIVE_REGISTRY`. |
-| Offered to search | Find the directive in the action statistics in `moar_tree_log.txt`. |
-| Selected | Look for `Directive: <name>, Target ops: [...]` in the console, or a nonzero use count in the tree log. |
-| Constructed | Open the generated `<pipeline-name>_<node-id>.yaml` and inspect the rewritten operations. |
-| Helpful | Compare the candidate's evaluation metric and cost with its parent; check whether it reaches the Pareto frontier. |
+| Available to search | Find the directive in the action counts in `moar_tree_log.txt`. |
+| Selected | Look for `Directive: <name>, Target ops: [...]` in the console or a nonzero use count in the tree log. |
+| Pipeline built | Open the generated `<pipeline-name>_<node-id>.yaml` and inspect the changed operations. |
+| Helpful | Compare its score and cost with its parent, and check whether MOAR keeps it among the best plans. |
 
-Confirm registration without making an LLM call:
+Confirm registration without making an LLM call.
 
 ```bash
 uv run python -c \
   "from docetl.reasoning_optimizer.directives import ALL_DIRECTIVES; print([d.name for d in ALL_DIRECTIVES])"
 ```
 
-Then run a small MOAR experiment with an explicit `save_dir`. The search log is
-written to `<save_dir>/moar_tree_log.txt`:
+Then run a small MOAR experiment with an explicit `save_dir`. MOAR writes the
+search log to `<save_dir>/moar_tree_log.txt`.
 
 ```bash
 rg -n "my_directive|Action: my_directive" results/moar_tree_log.txt
 ```
 
-A zero use count means the directive was available but was not selected. A
-nonzero count means it was selected, but not necessarily that candidate
-construction or execution succeeded. Inspect the console output and generated
-YAML as well.
+A zero use count means that the directive was available but MOAR did not select
+it. A nonzero count means that MOAR selected the directive. The count does not
+prove that MOAR built or ran the candidate, so also inspect the console output
+and generated YAML.
 
 For a deterministic MOAR integration test, construct `MOARSearch` with
-`available_actions={MyDirective()}` and a fixed evaluation fixture. Restricting
-the action set prevents the search agent from choosing a different directive.
-Keep an unrestricted benchmark too, because a good directive description must
-compete successfully with the rest of the registry.
+`available_actions={MyDirective()}` and a fixed test evaluation. The limited
+action set prevents the search agent from choosing another directive. Also keep
+a benchmark that includes every directive, because the search agent must
+recognize when the new directive applies.
 
 ## Implementation checklist
 
@@ -419,5 +430,5 @@ compete successfully with the rest of the registry.
 | Instantiate schema | A list of map names, prompts, and output keys |
 | Validation | Preserve original inputs and final output contract |
 | Apply | Replace one operation with the generated sequence |
-| Deterministic tests | Schema, operation shape, and static plan validity |
-| Empirical tests | Selection rate, execution success, accuracy, and cost |
+| Tests without model calls | Schema, operation shape, and static plan validity |
+| Tests with models and data | Selection rate, execution success, accuracy, and cost |

--- a/docs/developer-reference/moar-extensibility.md
+++ b/docs/developer-reference/moar-extensibility.md
@@ -1,26 +1,33 @@
-# Extending MOAR with rewrite directives
+# Adding a MOAR rewrite directive
 
-A rewrite directive teaches MOAR one abstract way to transform a pipeline. The
-directive does not hardcode the rewrite for a particular pipeline. It describes
-when a transformation is useful, defines the structured configuration that the
-rewrite agent must generate, validates that configuration, and applies it to the
-pipeline.
+A rewrite directive defines one kind of pipeline transformation that MOAR can
+consider. The directive describes which operations it applies to, defines the
+structured output that the rewrite agent must produce, validates the agent's
+output, and constructs a new pipeline.
 
-The built-in `chaining` directive is a compact example. It replaces one complex
-operation with a sequence of simpler map operations:
+The built-in `chaining` directive replaces one complex operation with a sequence
+of simpler map operations:
 
 ```text
 Op  =>  Map* -> Op
 ```
 
-The rewrite agent decides what the intermediate tasks and prompts should be.
-DocETL constructs the resulting pipeline, rejects invalid candidates, and MOAR
-measures whether the candidate improves the cost and accuracy frontier.
+The directive implementation defines the permitted transformation. For each
+target operation, the rewrite agent generates the intermediate tasks and
+prompts. DocETL validates the resulting pipeline before MOAR executes and scores
+it.
 
 This guide follows the implementation in
 [`docetl/reasoning_optimizer/directives/chaining.py`](https://github.com/ucbepic/docetl/blob/main/docetl/reasoning_optimizer/directives/chaining.py).
 
-## Directive lifecycle
+!!! note "Who provides each part?"
+    - **Pipeline author:** the original pipeline and evaluation function.
+    - **Directive contributor:** the instantiate schema, validation rules,
+      application code, registration, and tests.
+    - **Rewrite agent:** one task-specific instance of the directive during a
+      MOAR search.
+
+## How MOAR uses a directive
 
 MOAR uses a directive in five stages:
 
@@ -32,91 +39,101 @@ MOAR uses a directive in five stages:
    complete candidate pipeline before executing it.
 5. MOAR runs the candidate and evaluates its accuracy and cost.
 
-Keep the boundary between stages explicit. The schema describes what the agent
-may propose; `apply()` is deterministic pipeline construction.
+The schema limits what the rewrite agent may propose. `apply()` performs the
+pipeline transformation without another model call.
 
-## Example: decompose a complex extraction
+## Running example: split a medical extraction
 
-Suppose a map operation must identify newly diagnosed conditions and associate
-treatments with them in one call:
+Suppose a pipeline contains a map operation that must identify newly diagnosed
+conditions and associate treatments with them in one call.
 
-```yaml
-- name: extract_new_treatments
-  type: map
-  prompt: |
-    From this discharge summary, extract every treatment
-    prescribed specifically for a newly diagnosed condition.
+!!! example "Example input: the pipeline author's operation"
+    The pipeline author writes the original operation. The directive receives
+    the operation as input during optimization.
 
-    {{ input.summary }}
-  output:
-    schema:
-      treatments: list[str]
-```
+    ```yaml
+    - name: extract_new_treatments
+      type: map
+      prompt: |
+        From this discharge summary, extract every treatment
+        prescribed specifically for a newly diagnosed condition.
+
+        {{ input.summary }}
+      output:
+        schema:
+          treatments: list[str]
+    ```
 
 The operation combines two dependent decisions:
 
 1. Which conditions are newly diagnosed?
 2. Which treatments were prescribed for those conditions?
 
-Chaining can ask the agent to produce a decomposition such as:
+The chaining directive can replace the operation with two dependent maps:
 
 ![Before and after the chaining rewrite](../assets/moar-chaining-rewrite.svg)
 
 Both plans accept `summary` and produce `treatments`. The rewritten plan makes
 `new_conditions` an explicit intermediate result that the second map can use.
 
-The developer implements the general strategy. The rewrite agent supplies the
-task-specific steps.
+The directive contributor does not hardcode the two medical tasks. The rewrite
+agent generates them from the target operation during optimization.
 
 ## 1. Define the instantiate schema
 
 Add the Pydantic models that describe the agent's output to
-`docetl/reasoning_optimizer/instantiate_schemas.py`:
+`docetl/reasoning_optimizer/instantiate_schemas.py`.
 
-```python
-class MapOpConfig(BaseModel):
-    name: str
-    prompt: str
-    output_keys: list[str]
+!!! abstract "Contributor code: the instantiate schema"
+    The directive contributor writes these classes. They define the fields that
+    the rewrite agent must return.
+
+    ```python
+    class MapOpConfig(BaseModel):
+        name: str
+        prompt: str
+        output_keys: list[str]
 
 
-class ChainingInstantiateSchema(BaseModel):
-    new_ops: list[MapOpConfig]
-```
+    class ChainingInstantiateSchema(BaseModel):
+        new_ops: list[MapOpConfig]
+    ```
 
-For the medical operation, a valid agent response can be represented as:
+!!! example "Runtime example: output from the rewrite agent"
+    The following object is an example of agent output for the medical operation
+    above. A pipeline author does not write this object.
 
-```python
-ChainingInstantiateSchema(
-    new_ops=[
-        MapOpConfig(
-            name="identify_new_conditions",
-            prompt="""
-            Read this discharge summary:
+    ```python
+    ChainingInstantiateSchema(
+        new_ops=[
+            MapOpConfig(
+                name="identify_new_conditions",
+                prompt="""
+                Read this discharge summary:
 
-            {{ input.summary }}
+                {{ input.summary }}
 
-            List only conditions explicitly described as newly diagnosed.
-            """,
-            output_keys=["new_conditions"],
-        ),
-        MapOpConfig(
-            name="extract_treatments",
-            prompt="""
-            Read this discharge summary:
+                List only conditions explicitly described as newly diagnosed.
+                """,
+                output_keys=["new_conditions"],
+            ),
+            MapOpConfig(
+                name="extract_treatments",
+                prompt="""
+                Read this discharge summary:
 
-            {{ input.summary }}
+                {{ input.summary }}
 
-            Newly diagnosed conditions:
-            {{ input.new_conditions }}
+                Newly diagnosed conditions:
+                {{ input.new_conditions }}
 
-            List the treatments prescribed for each new condition.
-            """,
-            output_keys=["treatments"],
-        ),
-    ]
-)
-```
+                List the treatments prescribed for each new condition.
+                """,
+                output_keys=["treatments"],
+            ),
+        ]
+    )
+    ```
 
 Use narrow fields with descriptions that a model can follow. Do not ask the
 agent to emit an entire pipeline when the directive needs only two prompts and
@@ -146,7 +163,7 @@ structured output enabled. Return the validation error to the agent and retry a
 small, bounded number of times. `MAX_DIRECTIVE_INSTANTIATION_ATTEMPTS` is the
 shared limit used by the built-in directives.
 
-## 3. Describe the abstract strategy
+## 3. Describe when the directive applies
 
 Create a subclass of `Directive` under
 `docetl/reasoning_optimizer/directives/`. The four descriptive fields are part
@@ -179,7 +196,7 @@ The base class also requires an `example` and may include `test_cases`. The
 example becomes part of the rewrite agent's context, so use a complete example
 that preserves inputs, outputs, and prompt instructions.
 
-## 4. Instantiate the directive
+## 4. Generate and validate a rewrite instance
 
 Implement `to_string_for_instantiate()` and `llm_instantiate()` to obtain the
 typed configuration:
@@ -404,7 +421,3 @@ compete successfully with the rest of the registry.
 | Apply | Replace one operation with the generated sequence |
 | Deterministic tests | Schema, operation shape, and static plan validity |
 | Empirical tests | Selection rate, execution success, accuracy, and cost |
-
-The central interface is small: a developer specifies an abstract strategy and
-its invariants, an agent adapts the strategy to a particular pipeline, and MOAR
-tests the resulting candidate against the user's evaluation function.

--- a/docs/developer-reference/moar-extensibility.md
+++ b/docs/developer-reference/moar-extensibility.md
@@ -5,40 +5,25 @@ lets MOAR test a new kind of pipeline change. Follow steps 1 to 6 to implement
 and register the directive. Then test the directive and confirm that MOAR uses
 it during a search.
 
-The `chaining` directive included with DocETL is one example. MOAR can use it to
-replace one complex operation with a sequence of simpler map operations.
+## The chaining directive
+
+DocETL includes a rewrite directive named `chaining`. A chaining rewrite
+replaces one complex operation with a sequence of simpler map operations. Each
+new map handles one part of the original task, and a later map can use output
+from an earlier map.
 
 ```text
 Op  =>  Map* -> Op
 ```
 
-You define which pipeline changes are valid. During a search, the rewrite agent
-writes the intermediate tasks and prompts for one target operation. DocETL
-checks the changed pipeline before MOAR runs and scores it.
-
 The code examples follow the implementation in
 [`docetl/reasoning_optimizer/directives/chaining.py`](https://github.com/ucbepic/docetl/blob/main/docetl/reasoning_optimizer/directives/chaining.py).
 
-## How MOAR uses a directive
+## Example application
 
-MOAR uses the same process for every directive.
-
-1. The search agent reads `name`, `formal_description`, `nl_description`, and
-   `when_to_use`, then selects a directive and one or more target operations.
-2. The directive asks the rewrite agent for an object that matches the
-   instantiate schema.
-3. Your validation code checks the proposed configuration.
-4. `apply()` returns a new operation list, and DocETL statically validates the
-   complete candidate pipeline before executing it.
-5. MOAR runs the candidate and evaluates its accuracy and cost.
-
-The schema limits what the rewrite agent may return. The `apply()` method builds
-the changed pipeline without another model call.
-
-## Medical extraction example
-
-Suppose a pipeline contains a map operation that must identify newly diagnosed
-conditions and associate treatments with them in one call.
+To illustrate the chaining directive, suppose a medical pipeline contains a map
+operation that must identify newly diagnosed conditions and associate
+treatments with them in one call.
 
 !!! example "Example input, the pipeline author's operation"
     The pipeline author writes the original operation. The directive receives
@@ -69,11 +54,25 @@ MOAR can apply chaining to replace the operation with two dependent maps.
 Both plans accept `summary` and produce `treatments`. In the changed plan,
 `new_conditions` is an intermediate result for the second map.
 
-You write rules for any chaining rewrite. While MOAR runs, the rewrite agent
-chooses the medical tasks for the target operation.
+## How MOAR uses a directive
 
-You will use the medical example in each step, so you can compare the general
-instructions with the chaining code.
+MOAR uses the same process for every directive.
+
+1. The search agent reads `name`, `formal_description`, `nl_description`, and
+   `when_to_use`, then selects a directive and one or more target operations.
+2. The directive asks the rewrite agent for an object that matches the
+   instantiate schema.
+3. Your validation code checks the proposed configuration.
+4. `apply()` returns a new operation list, and DocETL statically validates the
+   complete candidate pipeline before executing it.
+5. MOAR runs the candidate and evaluates its accuracy and cost.
+
+The schema limits what the rewrite agent may return. The `apply()` method builds
+the changed pipeline without another model call.
+
+The next six sections go through each step needed to define the chaining
+directive. You will use the medical application in each step, so you can compare
+the general instructions with the chaining code.
 
 ## 1. Define the instantiate schema
 

--- a/docs/developer-reference/moar-extensibility.md
+++ b/docs/developer-reference/moar-extensibility.md
@@ -1,16 +1,17 @@
 # Adding a MOAR rewrite directive
 
-This guide describes how to add a rewrite directive to MOAR. A rewrite directive
-lets MOAR test a new kind of pipeline change. Follow steps 1 to 6 to implement
-and register the directive. Then test the directive and confirm that MOAR uses
-it during a search.
+This guide describes how to add your own rewrite directive to MOAR. It uses the
+existing `chaining` directive as an illustrative example. Steps 1 to 6 show the
+code you need to implement and register for any directive. The testing sections
+show how to confirm that MOAR can use your directive during a search.
 
 ## The chaining directive
 
-DocETL includes a rewrite directive named `chaining`. A chaining rewrite
-replaces one complex operation with a sequence of simpler map operations. Each
-new map handles one part of the original task, and a later map can use output
-from an earlier map.
+The `chaining` directive is already part of DocETL, so you do not need to add
+it. We walk through its existing implementation so you can see how to structure
+a directive of your own. A chaining rewrite replaces one complex operation with
+a sequence of simpler map operations. Each new map handles one part of the
+original task, and a later map can use output from an earlier map.
 
 ```text
 Op  =>  Map* -> Op
@@ -21,9 +22,10 @@ The code examples follow the implementation in
 
 ## Example application
 
-To illustrate the chaining directive, suppose a medical pipeline contains a map
-operation that must identify newly diagnosed conditions and associate
-treatments with them in one call.
+The medical pipeline below is an example input for chaining, not part of the
+directive implementation. Suppose the pipeline contains a map operation that
+must identify newly diagnosed conditions and associate treatments with them in
+one call.
 
 !!! example "Example input, the pipeline author's operation"
     The pipeline author writes the original operation. The directive receives
@@ -70,9 +72,10 @@ MOAR uses the same process for every directive.
 The schema limits what the rewrite agent may return. The `apply()` method builds
 the changed pipeline without another model call.
 
-The next six sections go through each step needed to define the chaining
-directive. You will use the medical application in each step, so you can compare
-the general instructions with the chaining code.
+The next six sections walk through each part of the existing chaining
+implementation. Use the same sequence when you define a directive of your own.
+The medical application appears in each step so you can see how the directive
+handles a specific operation.
 
 ## 1. Define the instantiate schema
 

--- a/docs/developer-reference/moar-extensibility.md
+++ b/docs/developer-reference/moar-extensibility.md
@@ -60,23 +60,7 @@ The operation combines two dependent decisions:
 
 Chaining can ask the agent to produce a decomposition such as:
 
-```mermaid
-flowchart TB
-    subgraph before["Before: one complex map"]
-        direction LR
-        S1["summary"] --> O["extract_new_treatments<br/>Identify new diagnoses and<br/>associate their treatments"]
-        O --> T1["treatments"]
-    end
-
-    subgraph after["After: chaining rewrite"]
-        direction LR
-        S2["summary"] --> C["identify_new_conditions"]
-        C --> N["new_conditions"]
-        S2 --> E["extract_treatments"]
-        N --> E
-        E --> T2["treatments"]
-    end
-```
+![Before and after the chaining rewrite](../assets/moar-chaining-rewrite.svg)
 
 Both plans accept `summary` and produce `treatments`. The rewritten plan makes
 `new_conditions` an explicit intermediate result that the second map can use.

--- a/docs/developer-reference/moar-extensibility.md
+++ b/docs/developer-reference/moar-extensibility.md
@@ -1,12 +1,9 @@
 # Adding a MOAR rewrite directive
 
-A rewrite directive lets MOAR test a new kind of pipeline change. The directive
-contributor writes code for the following tasks:
-
-- Tell the search agent when it can use the directive.
-- Define the output that the rewrite agent must return.
-- Reject invalid agent output.
-- Build the changed pipeline.
+This guide describes how to add a rewrite directive to MOAR. A rewrite directive
+lets MOAR test a new kind of pipeline change. Follow steps 1 to 6 to implement
+and register the directive. Then test the directive and confirm that MOAR uses
+it during a search.
 
 The `chaining` directive included with DocETL is one example. MOAR can use it to
 replace one complex operation with a sequence of simpler map operations.
@@ -15,20 +12,12 @@ replace one complex operation with a sequence of simpler map operations.
 Op  =>  Map* -> Op
 ```
 
-The contributor defines which pipeline changes are valid. During a search, the
-rewrite agent writes the intermediate tasks and prompts for one target
-operation. DocETL checks the changed pipeline before MOAR runs and scores it.
+You define which pipeline changes are valid. During a search, the rewrite agent
+writes the intermediate tasks and prompts for one target operation. DocETL
+checks the changed pipeline before MOAR runs and scores it.
 
 The code examples follow the implementation in
 [`docetl/reasoning_optimizer/directives/chaining.py`](https://github.com/ucbepic/docetl/blob/main/docetl/reasoning_optimizer/directives/chaining.py).
-
-!!! note "Who provides each part?"
-    - **The pipeline author** provides the original pipeline and evaluation
-      function.
-    - **The directive contributor** writes the instantiate schema, validation
-      rules, application code, registration, and tests.
-    - **The rewrite agent** creates one instance of the directive for a target
-      operation while MOAR runs.
 
 ## How MOAR uses a directive
 
@@ -38,7 +27,7 @@ MOAR uses the same process for every directive.
    `when_to_use`, then selects a directive and one or more target operations.
 2. The directive asks the rewrite agent for an object that matches the
    instantiate schema.
-3. The contributor's validation code checks the proposed configuration.
+3. Your validation code checks the proposed configuration.
 4. `apply()` returns a new operation list, and DocETL statically validates the
    complete candidate pipeline before executing it.
 5. MOAR runs the candidate and evaluates its accuracy and cost.
@@ -80,17 +69,21 @@ MOAR can apply chaining to replace the operation with two dependent maps.
 Both plans accept `summary` and produce `treatments`. In the changed plan,
 `new_conditions` is an intermediate result for the second map.
 
-The contributor writes rules for any chaining rewrite. While MOAR runs, the
-rewrite agent chooses the medical tasks for the target operation.
+You write rules for any chaining rewrite. While MOAR runs, the rewrite agent
+chooses the medical tasks for the target operation.
+
+You will use the medical example in each step, so you can compare the general
+instructions with the chaining code.
 
 ## 1. Define the instantiate schema
 
-An instantiate schema is a Pydantic model for the rewrite agent's output. Add
-the schema to `docetl/reasoning_optimizer/instantiate_schemas.py`.
+In this step, you define the Pydantic model for the rewrite agent's output.
+DocETL calls the model an instantiate schema. Add the schema to
+`docetl/reasoning_optimizer/instantiate_schemas.py`.
 
-!!! abstract "Contributor code, the instantiate schema"
-    The directive contributor writes the following classes. The classes define
-    the fields that the rewrite agent must return.
+!!! abstract "Your code, the instantiate schema"
+    You write the following classes to define the fields that the rewrite agent
+    must return.
 
     ```python
     class MapOpConfig(BaseModel):
@@ -145,8 +138,9 @@ pipeline.
 
 ## 2. Validate the agent's proposal
 
-Validate every requirement before MOAR runs a candidate. For chaining, reject
-the agent's proposal unless all of the following statements are true:
+In this step, you reject agent output that cannot produce a valid pipeline. For
+chaining, reject the agent's proposal unless all of the following statements
+are true:
 
 - Every generated map prompt contains an `{{ input.<key> }}` reference.
 - Every input key used by the original operation appears in at least one new
@@ -169,7 +163,8 @@ number of retries. The directives included with DocETL use
 
 ## 3. Describe when MOAR should use the directive
 
-Create a subclass of `Directive` under
+In this step, you describe the directive so the search agent knows when to
+choose it. Create a subclass of `Directive` under
 `docetl/reasoning_optimizer/directives/`. The search agent reads the four
 descriptive fields when it chooses a directive.
 
@@ -204,8 +199,9 @@ preserves the input fields, output fields, and prompt instructions.
 
 ## 4. Generate and validate a rewrite instance
 
-Use `to_string_for_instantiate()` and `llm_instantiate()` to ask the rewrite
-agent for a configuration that matches the schema.
+In this step, you ask the rewrite agent for a configuration and check the
+configuration against the schema. Use `to_string_for_instantiate()` and
+`llm_instantiate()` for the model call.
 
 ```python
 response = completion(
@@ -241,9 +237,10 @@ goal and dataset. It also provides the allowed models and input path. Accept
 
 ## 5. Apply the rewrite
 
+In this step, you build the changed pipeline from the validated configuration.
 Do not call a model from `apply()`. Copy the operation list and build the
-replacement operations from the validated schema. Then return the new list.
-The main part of the chaining implementation follows.
+replacement operations, then return the new list. The main part of the chaining
+implementation follows.
 
 ```python
 def apply(self, global_default_model, ops_list, target_op, rewrite):
@@ -283,8 +280,8 @@ the same final output fields and field types as the original pipeline.
 
 ## 6. Register the directive
 
-Import the directive and add an instance to
-`docetl/reasoning_optimizer/directives/__init__.py`.
+In this step, you make the directive available to MOAR. Import the directive and
+add an instance to `docetl/reasoning_optimizer/directives/__init__.py`.
 
 ```python
 from .my_directive import MyDirective

--- a/docs/optimization/moar.md
+++ b/docs/optimization/moar.md
@@ -20,7 +20,7 @@ When optimizing pipelines, you trade off cost and accuracy. MOAR explores many d
 - **[Understanding Results](moar/results.md)** - What MOAR outputs and how to interpret it
 - **[Examples](moar/examples.md)** - Complete working examples
 - **[Troubleshooting](moar/troubleshooting.md)** - Common issues and solutions
-- **[Extending MOAR](../developer-reference/moar-extensibility.md)** - How to implement and test a rewrite directive
+- **[Adding a Rewrite Directive](../developer-reference/moar-extensibility.md)** - How to implement and test a MOAR rewrite
 
 ## When to Use MOAR
 
@@ -59,12 +59,12 @@ MOAR separates rewrite directives from the search policy. A directive describes
 one pipeline transformation, while the search decides where to try it and the
 evaluation function measures the result. Developers can therefore add a new
 optimization strategy without changing the MCTS implementation. See
-[Extending MOAR with rewrite directives](../developer-reference/moar-extensibility.md)
+[Adding a MOAR rewrite directive](../developer-reference/moar-extensibility.md)
 for the implementation, registration, testing, and observability workflow.
 
 Useful contribution areas include:
 
-- **Novel rewrite directives.** Add a transformation with explicit
+- **New rewrite directives.** Add a transformation with explicit
   applicability rules, a narrow instantiate schema, deterministic validation,
   and benchmarks on more than one workload.
 - **Better directive testing.** Improve deterministic schema and pipeline tests,
@@ -83,4 +83,4 @@ The lightweight policy is especially useful for small pipelines and development
 smoke tests. MCTS remains useful when interactions among several rewrites and a
 larger cost-accuracy frontier justify the additional search calls.
 
-Ready to get started? Head to the [Getting Started guide](moar/getting-started.md).
+See the [Getting Started guide](moar/getting-started.md) to run an optimization.

--- a/docs/optimization/moar.md
+++ b/docs/optimization/moar.md
@@ -1,86 +1,91 @@
-# MOAR Optimizer
+# MOAR optimizer
 
-The MOAR (Multi-Objective Agentic Rewrites) optimizer explores different ways to optimize your pipeline, finding solutions that balance accuracy and cost.
+MOAR searches for pipeline changes that improve accuracy or reduce cost. It
+evaluates each candidate with your evaluation function and returns several
+plans. Each returned plan represents a different balance between cost and
+accuracy.
 
-## What is MOAR?
-
-When optimizing pipelines, you trade off cost and accuracy. MOAR explores many different pipeline configurations (like changing models, adding validation steps, combining operations, etc.) and evaluates each one to find the best trade-offs. It returns a frontier of plans that balance cost and accuracy, giving you multiple optimized options to choose from based on your budget and accuracy requirements.
-
-!!! info "MOAR paper (VLDB 2026)"
+!!! info "MOAR paper, VLDB 2026"
     Lindsey Linxi Wei, Shreya Shankar, Sepanta Zeighami, Yeounoh Chung,
     Fatma Ozcan, and Aditya G. Parameswaran.
-    “[Multi-Objective Agentic Rewrites for Unstructured Data Processing](https://arxiv.org/abs/2512.02289).”
+    ["Multi-Objective Agentic Rewrites for Unstructured Data Processing"](https://arxiv.org/abs/2512.02289).
     *Proceedings of the VLDB Endowment*, 2026.
 
-## Quick Navigation
+## Guides
 
-- **[Getting Started](moar/getting-started.md)** - Step-by-step guide to run your first MOAR optimization
-- **[Configuration](moar/configuration.md)** - Complete reference for all configuration options
-- **[Evaluation Functions](moar/evaluation.md)** - How to write and use evaluation functions
-- **[Understanding Results](moar/results.md)** - What MOAR outputs and how to interpret it
-- **[Examples](moar/examples.md)** - Complete working examples
-- **[Troubleshooting](moar/troubleshooting.md)** - Common issues and solutions
-- **[Adding a Rewrite Directive](../developer-reference/moar-extensibility.md)** - How to implement and test a MOAR rewrite
+- **[Getting started](moar/getting-started.md).** Run your first MOAR search.
+- **[Configuration](moar/configuration.md).** Set models, budgets, and other options.
+- **[Evaluation functions](moar/evaluation.md).** Write the function that scores each candidate.
+- **[Understanding results](moar/results.md).** Read the plans that MOAR returns.
+- **[Examples](moar/examples.md).** See complete examples.
+- **[Troubleshooting](moar/troubleshooting.md).** Fix common errors.
+- **[Adding a rewrite directive](../developer-reference/moar-extensibility.md).** Add and test a new kind of pipeline change.
 
-## When to Use MOAR
+## When to use MOAR
 
-!!! success "Good for"
-    - Finding cost-accuracy trade-offs across different models
-    - When you want multiple optimization options to choose from
-    - Custom evaluation metrics specific to your use case
-    - Exploring different pipeline configurations automatically
+!!! success "MOAR is useful when"
+    - You want to compare cost and accuracy across models.
+    - You want several optimized plans with different costs.
+    - You have an evaluation function for your pipeline.
+    - You want MOAR to test several kinds of pipeline changes.
 
-## Basic Workflow
+## Basic workflow
 
-1. **Create your pipeline** — Define your DocETL pipeline in Python or YAML
-2. **Write an evaluation function** — Create a Python function to measure accuracy
-3. **Run optimization** — Call `frame.optimize()` with your eval function:
+1. **Create a pipeline.** Define the pipeline in Python or YAML.
+2. **Write an evaluation function.** Create a Python function that measures accuracy.
+3. **Run MOAR.** Call `frame.optimize()` with the evaluation function.
 
     ```python
     optimized = frame.optimize(eval_fn=evaluate, metric_key="score")
     ```
 
-    Or via CLI: `docetl build pipeline.yaml`
+    You can also run MOAR from the command line.
 
-4. **Review results** — Run the optimized pipeline, or browse the cost-accuracy frontier:
+    ```bash
+    docetl build pipeline.yaml
+    ```
+
+4. **Review the results.** Run one optimized pipeline or compare all plans that
+   MOAR returned.
 
     ```python
-    rows = optimized.collect()           # Execute the optimized pipeline
+    rows = optimized.collect()         # Run the optimized pipeline
 
     results = optimized.search_results
     best = results.best()              # Highest accuracy
     cheap = results.cheapest()         # Lowest cost
-    print(results.to_df())             # All explored plans
+    print(results.to_df())             # All plans that MOAR tested
     ```
 
 ## Extending and contributing to MOAR
 
-MOAR separates rewrite directives from the search policy. A directive describes
-one pipeline transformation, while the search decides where to try it and the
-evaluation function measures the result. Developers can therefore add a new
-optimization strategy without changing the MCTS implementation. See
-[Adding a MOAR rewrite directive](../developer-reference/moar-extensibility.md)
-for the implementation, registration, testing, and observability workflow.
+In MOAR, rewrite directives are separate from the search method. When you add a
+directive, you define one way to change a pipeline. The search method chooses
+where to try the directive, and your evaluation function scores the changed
+pipeline. You can add a directive without changing the code for Monte Carlo
+tree search (MCTS).
 
-Useful contribution areas include:
+See [Adding a MOAR rewrite directive](../developer-reference/moar-extensibility.md)
+for instructions on implementation, registration, testing, and logs.
 
-- **New rewrite directives.** Add a transformation with explicit
-  applicability rules, a narrow instantiate schema, deterministic validation,
-  and benchmarks on more than one workload.
-- **Better directive testing.** Improve deterministic schema and pipeline tests,
-  add replayable rewrite-agent responses, and measure selection rate, valid-plan
-  rate, accuracy change, cost change, and variance across repeated runs.
-- **A lightweight search policy.** Add a one-pass, greedy, best-first, or small
-  beam search that reuses the directive registry, evaluator, candidate
-  validation, and result format without running the full MCTS loop. Treat the
-  policy as a comparable search backend rather than a separate optimizer, and
-  make model-call and execution budgets explicit.
-- **Search observability.** Record structured action traces that connect a
-  selected directive to its generated plan, validation result, evaluation, and
-  parent pipeline.
+Possible contributions include the following work:
 
-The lightweight policy is especially useful for small pipelines and development
-smoke tests. MCTS remains useful when interactions among several rewrites and a
-larger cost-accuracy frontier justify the additional search calls.
+- **New rewrite directives.** Add a new pipeline change with clear rules for
+  when MOAR should use it. Define the agent output and reject invalid output.
+  Test the directive on more than one workload.
+- **Tests for directives.** Add tests for schemas and complete pipelines. Store
+  model responses so tests can replay them without a model call. Benchmarks can
+  record how often MOAR selects the directive and builds a valid pipeline. They
+  can also record changes in cost and accuracy.
+- **Search methods that use fewer model calls.** For example, add a search
+  method that tries each chosen directive once and keeps only the best
+  candidates. Reuse the existing directive list, evaluator, validation code,
+  and result format. Set clear limits for model calls and pipeline runs.
+- **Logs for each search.** Save the selected directive and the pipeline that
+  MOAR built. Also save the validation result and the candidate's score.
 
-See the [Getting Started guide](moar/getting-started.md) to run an optimization.
+A search method with fewer model calls can help with small pipelines and quick
+development tests. MCTS is more useful when you want to combine several
+rewrites or inspect more balances between cost and accuracy.
+
+See the [Getting started guide](moar/getting-started.md) to run an optimization.

--- a/docs/optimization/moar.md
+++ b/docs/optimization/moar.md
@@ -14,6 +14,7 @@ When optimizing pipelines, you trade off cost and accuracy. MOAR explores many d
 - **[Understanding Results](moar/results.md)** - What MOAR outputs and how to interpret it
 - **[Examples](moar/examples.md)** - Complete working examples
 - **[Troubleshooting](moar/troubleshooting.md)** - Common issues and solutions
+- **[Extending MOAR](../developer-reference/moar-extensibility.md)** - How to implement and test a rewrite directive
 
 ## When to Use MOAR
 
@@ -45,5 +46,35 @@ When optimizing pipelines, you trade off cost and accuracy. MOAR explores many d
     cheap = results.cheapest()         # Lowest cost
     print(results.to_df())             # All explored plans
     ```
+
+## Extending and contributing to MOAR
+
+MOAR separates rewrite directives from the search policy. A directive describes
+one pipeline transformation, while the search decides where to try it and the
+evaluation function measures the result. Developers can therefore add a new
+optimization strategy without changing the MCTS implementation. See
+[Extending MOAR with rewrite directives](../developer-reference/moar-extensibility.md)
+for the implementation, registration, testing, and observability workflow.
+
+Useful contribution areas include:
+
+- **Novel rewrite directives.** Add a transformation with explicit
+  applicability rules, a narrow instantiate schema, deterministic validation,
+  and benchmarks on more than one workload.
+- **Better directive testing.** Improve deterministic schema and pipeline tests,
+  add replayable rewrite-agent responses, and measure selection rate, valid-plan
+  rate, accuracy change, cost change, and variance across repeated runs.
+- **A lightweight search policy.** Add a one-pass, greedy, best-first, or small
+  beam search that reuses the directive registry, evaluator, candidate
+  validation, and result format without running the full MCTS loop. Treat the
+  policy as a comparable search backend rather than a separate optimizer, and
+  make model-call and execution budgets explicit.
+- **Search observability.** Record structured action traces that connect a
+  selected directive to its generated plan, validation result, evaluation, and
+  parent pipeline.
+
+The lightweight policy is especially useful for small pipelines and development
+smoke tests. MCTS remains useful when interactions among several rewrites and a
+larger cost-accuracy frontier justify the additional search calls.
 
 Ready to get started? Head to the [Getting Started guide](moar/getting-started.md).

--- a/docs/optimization/moar.md
+++ b/docs/optimization/moar.md
@@ -6,6 +6,12 @@ The MOAR (Multi-Objective Agentic Rewrites) optimizer explores different ways to
 
 When optimizing pipelines, you trade off cost and accuracy. MOAR explores many different pipeline configurations (like changing models, adding validation steps, combining operations, etc.) and evaluates each one to find the best trade-offs. It returns a frontier of plans that balance cost and accuracy, giving you multiple optimized options to choose from based on your budget and accuracy requirements.
 
+!!! info "MOAR paper (VLDB 2026)"
+    Lindsey Linxi Wei, Shreya Shankar, Sepanta Zeighami, Yeounoh Chung,
+    Fatma Ozcan, and Aditya G. Parameswaran.
+    “[Multi-Objective Agentic Rewrites for Unstructured Data Processing](https://arxiv.org/abs/2512.02289).”
+    *Proceedings of the VLDB Endowment*, 2026.
+
 ## Quick Navigation
 
 - **[Getting Started](moar/getting-started.md)** - Step-by-step guide to run your first MOAR optimization

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
     - PDF Analysis (NTSB Airplane Crashes): examples/pdf-analysis-gemini.md
   
   - Developer Reference:
+      - Extending MOAR: developer-reference/moar-extensibility.md
       - Technical Guides:
           - Custom Data Parsing: examples/custom-parsing.md
           - Rate Limiting Implementation: examples/rate-limiting.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,8 +90,8 @@ nav:
     - PDF Analysis (NTSB Airplane Crashes): examples/pdf-analysis-gemini.md
   
   - Developer Reference:
-      - Extending MOAR: developer-reference/moar-extensibility.md
-      - Technical Guides:
+      - Development Guides:
+          - MOAR Rewrite Directives: developer-reference/moar-extensibility.md
           - Custom Data Parsing: examples/custom-parsing.md
           - Rate Limiting Implementation: examples/rate-limiting.md
       - API Reference:


### PR DESCRIPTION
## Summary

- add a developer reference for implementing, validating, registering, and testing MOAR rewrite directives
- use the built-in chaining directive as a concrete accuracy-rewrite example, with an accessible before/after pipeline diagram
- document how to distinguish registration, selection, candidate construction, and measured improvement in MOAR
- cite the MOAR VLDB 2026 paper in the optimizer overview
- add MOAR contribution ideas, including stronger directive testing and a lightweight search backend that reuses the existing directive and evaluation interfaces
- link the guide from the MOAR overview and MkDocs navigation

## Why

MOAR's public documentation explained how to run optimization but did not explain how its rewrite action space can be extended. The new guide makes the existing directive contract and verification workflow accessible to contributors without requiring them to reconstruct it from implementation files and stale internal notes.

## Validation

- `uv run mkdocs build --strict --site-dir /tmp/docetl-mkdocs-extensibility-paper-build`
- visually verified the chaining diagram in the local MkDocs preview
- invoked `test_chaining_apply` directly through the project environment