### PR TITLE
fix(server): confine filesystem routes to storage root

### DIFF
--- a/server/app/routes/filesystem.py
+++ b/server/app/routes/filesystem.py
@@ -1,13 +1,14 @@
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException
-from fastapi.responses import FileResponse, JSONResponse
-import os
-import yaml
-import shutil
-import httpx
-import json
 import csv
+import json
+import os
+import shutil
 from io import StringIO
 from pathlib import Path
+
+import httpx
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+
 from server.app.models import PipelineConfigRequest, WorkspaceSaveRequest
 
 router = APIRouter()
@@ -17,10 +18,52 @@ def get_home_dir() -> str:
     """Get the home directory from env var or user home"""
     return os.getenv("DOCETL_HOME_DIR", os.path.expanduser("~"))
 
+
+def get_storage_root() -> Path:
+    """Return the canonical root for all server-managed files."""
+    return (Path(get_home_dir()).expanduser() / ".docetl").resolve()
+
+
+def resolve_storage_path(path: str | Path) -> Path:
+    """Resolve a path and reject targets outside the server storage root."""
+    root = get_storage_root()
+    try:
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid file path")
+
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail="Path escapes the DocETL storage root"
+        )
+    return resolved
+
+
+def resolve_storage_child(parent: Path, name: str, label: str) -> Path:
+    """Resolve a single path component beneath a storage directory."""
+    if (
+        not name
+        or name in {".", ".."}
+        or Path(name).is_absolute()
+        or "/" in name
+        or "\\" in name
+        or "\x00" in name
+    ):
+        raise HTTPException(status_code=400, detail=f"Invalid {label}")
+    return resolve_storage_path(parent / name)
+
+
 def get_namespace_dir(namespace: str) -> Path:
     """Get the namespace directory path"""
-    home_dir = get_home_dir()
-    return Path(home_dir) / ".docetl" / namespace
+    if not namespace:
+        raise HTTPException(status_code=400, detail="Invalid namespace")
+    return resolve_storage_path(namespace)
+
 
 @router.post("/check-namespace")
 async def check_namespace(namespace: str):
@@ -28,13 +71,18 @@ async def check_namespace(namespace: str):
     try:
         namespace_dir = get_namespace_dir(namespace)
         exists = namespace_dir.exists()
-        
+
         if not exists:
             namespace_dir.mkdir(parents=True, exist_ok=True)
-            
+
         return {"exists": exists}
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to check/create namespace: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to check/create namespace: {str(e)}"
+        )
+
 
 def validate_json_content(content: bytes) -> None:
     """Validate that content can be parsed as JSON"""
@@ -43,84 +91,91 @@ def validate_json_content(content: bytes) -> None:
     except json.JSONDecodeError as e:
         raise HTTPException(status_code=400, detail=f"Invalid JSON format: {str(e)}")
 
+
 def convert_csv_to_json(csv_content: bytes) -> bytes:
     """Convert CSV content to JSON format"""
     try:
         # Decode bytes to string and create a StringIO object
-        csv_string = csv_content.decode('utf-8')
+        csv_string = csv_content.decode("utf-8")
         csv_file = StringIO(csv_string)
-        
+
         # Read CSV and convert to list of dictionaries
         reader = csv.DictReader(csv_file)
         data = list(reader)
-        
+
         if not data:
             raise HTTPException(status_code=400, detail="CSV file is empty")
-            
+
         # Convert back to JSON bytes
-        return json.dumps(data).encode('utf-8')
+        return json.dumps(data).encode("utf-8")
     except UnicodeDecodeError:
         raise HTTPException(status_code=400, detail="Invalid CSV encoding")
     except csv.Error as e:
         raise HTTPException(status_code=400, detail=f"Invalid CSV format: {str(e)}")
 
+
 def is_likely_csv(content: bytes, filename: str) -> bool:
     """Check if content is likely to be CSV based on content and filename"""
     # Check filename extension
-    if filename.lower().endswith('.csv'):
+    if filename.lower().endswith(".csv"):
         return True
-        
+
     # If no clear extension, try to detect CSV content
     try:
         # Take first line and check if it looks like CSV
-        first_line = content.split(b'\n')[0].decode('utf-8')
+        first_line = content.split(b"\n")[0].decode("utf-8")
         # Check if line contains commas and no obvious JSON characters
-        return ',' in first_line and not any(c in first_line for c in '{}[]')
-    except:
+        return "," in first_line and not any(c in first_line for c in "{}[]")
+    except UnicodeDecodeError:
         return False
+
 
 @router.post("/upload-file")
 async def upload_file(
     file: UploadFile | None = File(None),
     url: str | None = Form(None),
-    namespace: str = Form(...)
+    namespace: str = Form(...),
 ):
     """Upload a file to the namespace files directory, either from a direct upload or a URL"""
     try:
         if not file and not url:
-            raise HTTPException(status_code=400, detail="Either file or url must be provided")
-            
-        upload_dir = get_namespace_dir(namespace) / "files"
+            raise HTTPException(
+                status_code=400, detail="Either file or url must be provided"
+            )
+
+        upload_dir = resolve_storage_path(get_namespace_dir(namespace) / "files")
         upload_dir.mkdir(parents=True, exist_ok=True)
-        
+
         if url:
             # Get filename from URL or default to dataset.json
             filename = url.split("/")[-1] or "dataset.json"
-            
-            file_path = upload_dir / filename.replace('.csv', '.json')
-            
+
+            file_path = resolve_storage_child(
+                upload_dir, filename.replace(".csv", ".json"), "filename"
+            )
+
             # Handle URL download
             async with httpx.AsyncClient() as client:
                 async with client.stream(
-                    'GET',
+                    "GET",
                     url,
                     follow_redirects=True,
                 ) as response:
                     if response.status_code != 200:
                         raise HTTPException(
                             status_code=400,
-                            detail=f"Failed to download from URL: {response.status_code}"
+                            detail=f"Failed to download from URL: {response.status_code}",
                         )
-                    
+
                     # Save the file in chunks
                     content_chunks = []
                     async for chunk in response.aiter_bytes(chunk_size=8192):
                         if chunk:  # filter out keep-alive new chunks
                             content_chunks.append(chunk)
-                    
+
                     # Combine chunks
-                    content = b''.join(content_chunks)
-                    
+                    content = b"".join(content_chunks)
+
                     # Check if content is CSV and convert if needed
                     if is_likely_csv(content, filename):
                         try:
@@ -128,91 +183,113 @@ async def upload_file(
                         except HTTPException as e:
                             raise HTTPException(
                                 status_code=400,
-                                detail=f"Failed to convert CSV to JSON: {str(e.detail)}"
+                                detail=f"Failed to convert CSV to JSON: {str(e.detail)}",
                             )
-                    
+
                     # Validate JSON content
                     validate_json_content(content)
-                    
+
                     # Write to file
                     with file_path.open("wb") as f:
                         f.write(content)
         else:
             # Handle direct file upload
+            if not file.filename:
+                raise HTTPException(status_code=400, detail="Invalid filename")
             file_content = await file.read()
-            
+
             # Check if content is CSV and convert if needed
-            if file.filename.lower().endswith('.csv'):
+            if file.filename.lower().endswith(".csv"):
                 try:
                     file_content = convert_csv_to_json(file_content)
                 except HTTPException as e:
                     raise HTTPException(
                         status_code=400,
-                        detail=f"Failed to convert CSV to JSON: {str(e.detail)}"
+                        detail=f"Failed to convert CSV to JSON: {str(e.detail)}",
                     )
-            
+
             # Validate JSON content
             validate_json_content(file_content)
-            
+
             # Always save as .json
-            file_path = upload_dir / file.filename.replace('.csv', '.json')
+            file_path = resolve_storage_child(
+                upload_dir, file.filename.replace(".csv", ".json"), "filename"
+            )
             with file_path.open("wb") as f:
                 f.write(file_content)
-            
+
         return {"path": str(file_path)}
+    except HTTPException:
+        raise
     except Exception as e:
-        if isinstance(e, HTTPException):
-            raise e
         raise HTTPException(status_code=500, detail=f"Failed to upload file: {str(e)}")
 
+
 @router.post("/save-documents")
-async def save_documents(files: list[UploadFile] = File(...), namespace: str = Form(...)):
+async def save_documents(
+    files: list[UploadFile] = File(...), namespace: str = Form(...)
+):
     """Save multiple documents to the namespace documents directory"""
     try:
-        uploads_dir = get_namespace_dir(namespace) / "documents"
+        uploads_dir = resolve_storage_path(get_namespace_dir(namespace) / "documents")
         uploads_dir.mkdir(parents=True, exist_ok=True)
-        
+
         saved_files = []
         for file in files:
             # Create safe filename
-            safe_name = "".join(c if c.isalnum() or c in ".-" else "_" for c in file.filename)
-            file_path = uploads_dir / safe_name
-            
+            safe_name = "".join(
+                c if c.isalnum() or c in ".-" else "_" for c in file.filename
+            )
+            file_path = resolve_storage_child(uploads_dir, safe_name, "filename")
+
             with file_path.open("wb") as f:
                 shutil.copyfileobj(file.file, f)
-                
-            saved_files.append({
-                "name": file.filename,
-                "path": str(file_path)
-            })
-            
+
+            saved_files.append({"name": file.filename, "path": str(file_path)})
+
         return {"files": saved_files}
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to save documents: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to save documents: {str(e)}"
+        )
+
 
 @router.post("/write-pipeline-config")
 async def write_pipeline_config(request: PipelineConfigRequest):
     """Write pipeline configuration YAML file"""
     try:
-        home_dir = get_home_dir()
-        pipeline_dir = Path(home_dir) / ".docetl" / request.namespace / "pipelines"
-        config_dir = pipeline_dir / "configs"
-        name_dir = pipeline_dir / request.name / "intermediates"
-        
+        pipeline_dir = resolve_storage_path(
+            get_namespace_dir(request.namespace) / "pipelines"
+        )
+        config_dir = resolve_storage_path(pipeline_dir / "configs")
+        pipeline_name = resolve_storage_child(
+            pipeline_dir, request.name, "pipeline name"
+        )
+        name_dir = resolve_storage_path(pipeline_name / "intermediates")
+
         config_dir.mkdir(parents=True, exist_ok=True)
         name_dir.mkdir(parents=True, exist_ok=True)
-        
-        file_path = config_dir / f"{request.name}.yaml"
+
+        file_path = resolve_storage_child(
+            config_dir, f"{request.name}.yaml", "pipeline filename"
+        )
         with file_path.open("w") as f:
             f.write(request.config)
-            
+
         return {
             "filePath": str(file_path),
             "inputPath": request.input_path,
-            "outputPath": request.output_path
+            "outputPath": request.output_path,
         }
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to write pipeline configuration: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to write pipeline configuration: {str(e)}"
+        )
+
 
 @router.get("/read-file")
 async def read_file(path: str):
@@ -220,66 +297,75 @@ async def read_file(path: str):
     try:
         if path.startswith(("http://", "https://")):
             # For HTTP URLs, we'll need to implement request handling
-            raise HTTPException(status_code=400, detail="HTTP URLs not supported in this endpoint")
-            
-        file_path = Path(path)
-        if not file_path.exists():
+            raise HTTPException(
+                status_code=400, detail="HTTP URLs not supported in this endpoint"
+            )
+
+        file_path = resolve_storage_path(path)
+        if not file_path.is_file():
             raise HTTPException(status_code=404, detail="File not found")
-            
-        return FileResponse(path)
+
+        return FileResponse(file_path)
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to read file: {str(e)}")
+
 
 @router.get("/read-file-page")
 async def read_file_page(path: str, page: int = 0, chunk_size: int = 500000):
     """Read file contents by page"""
     try:
-        file_path = Path(path)
-        if not file_path.exists():
+        file_path = resolve_storage_path(path)
+        if not file_path.is_file():
             raise HTTPException(status_code=404, detail="File not found")
-            
+
         file_size = file_path.stat().st_size
         start = page * chunk_size
-        
+
         with file_path.open("rb") as f:
             f.seek(start)
             content = f.read(chunk_size).decode("utf-8")
-            
+
         return {
             "content": content,
             "totalSize": file_size,
             "page": page,
-            "hasMore": start + len(content) < file_size
+            "hasMore": start + len(content) < file_size,
         }
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to read file: {str(e)}")
+
 
 @router.get("/serve-document/{path:path}")
 async def serve_document(path: str):
     """Serve document files"""
     try:
-        # Security check for path traversal
-        if ".." in path:
-            raise HTTPException(status_code=400, detail="Invalid file path")
-            
-        file_path = Path(path)
-        if not file_path.exists():
+        file_path = resolve_storage_path(path)
+        if not file_path.is_file():
             raise HTTPException(status_code=404, detail="File not found")
-            
+
         return FileResponse(
             path=file_path,
             filename=file_path.name,
-            headers={"Cache-Control": "public, max-age=3600"}
+            headers={"Cache-Control": "public, max-age=3600"},
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to serve file: {str(e)}")
 
-@router.get("/workspace/{workspace_id}")
+
+@router.get("/workspace/{workspace_id:path}")
 async def load_workspace(workspace_id: str):
     """Load workspace state YAML for a given workspace UUID"""
     try:
-        workspace_file = get_namespace_dir(workspace_id) / "workspace.yaml"
-        if not workspace_file.exists():
+        workspace_file = resolve_storage_path(
+            get_namespace_dir(workspace_id) / "workspace.yaml"
+        )
+        if not workspace_file.is_file():
             raise HTTPException(status_code=404, detail="Workspace not found")
         with workspace_file.open("r") as f:
             content = f.read()
@@ -287,27 +373,37 @@ async def load_workspace(workspace_id: str):
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to load workspace: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to load workspace: {str(e)}"
+        )
 
-@router.post("/workspace/{workspace_id}")
+
+@router.post("/workspace/{workspace_id:path}")
 async def save_workspace(workspace_id: str, request: WorkspaceSaveRequest):
     """Save workspace state YAML for a given workspace UUID"""
     try:
         namespace_dir = get_namespace_dir(workspace_id)
         namespace_dir.mkdir(parents=True, exist_ok=True)
-        workspace_file = namespace_dir / "workspace.yaml"
+        workspace_file = resolve_storage_path(namespace_dir / "workspace.yaml")
         with workspace_file.open("w") as f:
             f.write(request.content)
         return {"ok": True}
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to save workspace: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to save workspace: {str(e)}"
+        )
+
 
 @router.get("/check-file")
 async def check_file(path: str):
     """Check if a file exists without reading it"""
     try:
-        file_path = Path(path)
+        file_path = resolve_storage_path(path)
         exists = file_path.exists()
         return {"exists": exists}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to check file: {str(e)}")

--- a/tests/test_filesystem_security.py
+++ b/tests/test_filesystem_security.py
@@ -1,0 +1,248 @@
+import asyncio
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, HTTPException, UploadFile
+from fastapi.testclient import TestClient
+
+from server.app.models import PipelineConfigRequest, WorkspaceSaveRequest
+from server.app.routes import filesystem
+
+
+@pytest.fixture
+def storage_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("DOCETL_HOME_DIR", str(home))
+    root = home / ".docetl"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(filesystem.router, prefix="/fs")
+    return TestClient(app)
+
+
+def assert_bad_path(awaitable) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(awaitable)
+    assert exc_info.value.status_code == 400
+
+
+def test_raw_path_routes_reject_files_outside_storage_root(
+    client: TestClient, storage_root: Path, tmp_path: Path
+) -> None:
+    outside_file = tmp_path / "outside.json"
+    outside_file.write_text('{"safe_fixture": true}')
+
+    for route in ("read-file", "read-file-page", "check-file"):
+        response = client.get(f"/fs/{route}", params={"path": str(outside_file)})
+        assert response.status_code == 400
+
+    assert_bad_path(filesystem.serve_document(str(outside_file)))
+
+
+def test_namespace_routes_reject_traversal(storage_root: Path, tmp_path: Path) -> None:
+    outside_dir = storage_root.parent / "escaped"
+    pipeline_request = PipelineConfigRequest(
+        namespace="../escaped",
+        name="pipeline",
+        config="pipeline: {}",
+        input_path="",
+        output_path="",
+    )
+
+    assert_bad_path(filesystem.check_namespace("../escaped"))
+    assert_bad_path(
+        filesystem.upload_file(
+            file=UploadFile(
+                filename="data.json", file=BytesIO(b'{"safe_fixture": true}')
+            ),
+            url=None,
+            namespace="../escaped",
+        )
+    )
+    assert_bad_path(
+        filesystem.save_documents(
+            files=[UploadFile(filename="doc.txt", file=BytesIO(b"document"))],
+            namespace="../escaped",
+        )
+    )
+    assert_bad_path(filesystem.write_pipeline_config(pipeline_request))
+    assert_bad_path(filesystem.load_workspace("../escaped"))
+    assert_bad_path(
+        filesystem.save_workspace(
+            "../escaped", WorkspaceSaveRequest(content="workspace: {}")
+        )
+    )
+
+    assert not outside_dir.exists()
+
+
+def test_leaf_names_cannot_escape_their_directories(storage_root: Path) -> None:
+    assert_bad_path(
+        filesystem.upload_file(
+            file=UploadFile(
+                filename="../escaped.json",
+                file=BytesIO(b'{"safe_fixture": true}'),
+            ),
+            url=None,
+            namespace="workspace",
+        )
+    )
+
+    assert_bad_path(
+        filesystem.write_pipeline_config(
+            PipelineConfigRequest(
+                namespace="workspace",
+                name="../escaped",
+                config="pipeline: {}",
+                input_path="",
+                output_path="",
+            )
+        )
+    )
+
+    assert not (storage_root / "workspace" / "escaped.json").exists()
+    assert not (storage_root / "workspace" / "escaped").exists()
+
+
+def test_absolute_and_relative_paths_inside_storage_root_still_work(
+    client: TestClient, storage_root: Path
+) -> None:
+    workspace = storage_root / "workspace"
+    workspace.mkdir()
+    data_file = workspace / "report..json"
+    data_file.write_text('{"inside": true}')
+
+    absolute_response = client.get("/fs/read-file", params={"path": str(data_file)})
+    relative_response = client.get(
+        "/fs/read-file", params={"path": "workspace/report..json"}
+    )
+    check_response = client.get("/fs/check-file", params={"path": str(data_file)})
+
+    assert absolute_response.status_code == 200
+    assert absolute_response.json() == {"inside": True}
+    assert relative_response.status_code == 200
+    assert relative_response.json() == {"inside": True}
+    assert check_response.json() == {"exists": True}
+
+
+def test_valid_write_routes_remain_available(storage_root: Path) -> None:
+    absolute_namespace = storage_root / "team" / "workspace"
+
+    namespace_result = asyncio.run(filesystem.check_namespace(str(absolute_namespace)))
+    upload_result = asyncio.run(
+        filesystem.upload_file(
+            file=UploadFile(filename="data.json", file=BytesIO(b'{"inside": true}')),
+            url=None,
+            namespace="team/workspace",
+        )
+    )
+    documents_result = asyncio.run(
+        filesystem.save_documents(
+            files=[UploadFile(filename="report..txt", file=BytesIO(b"document"))],
+            namespace="team/workspace",
+        )
+    )
+    pipeline_result = asyncio.run(
+        filesystem.write_pipeline_config(
+            PipelineConfigRequest(
+                namespace="team/workspace",
+                name="pipeline",
+                config="pipeline: {}",
+                input_path="",
+                output_path="",
+            )
+        )
+    )
+    workspace_result = asyncio.run(
+        filesystem.save_workspace(
+            "team/workspace", WorkspaceSaveRequest(content="workspace: {}")
+        )
+    )
+
+    assert namespace_result == {"exists": False}
+    assert Path(upload_result["path"]).is_file()
+    assert Path(documents_result["files"][0]["path"]).is_file()
+    assert Path(pipeline_result["filePath"]).is_file()
+    assert workspace_result == {"ok": True}
+    assert asyncio.run(filesystem.load_workspace("team/workspace")) == {
+        "content": "workspace: {}"
+    }
+
+
+def test_nested_workspace_routes_remain_available(
+    client: TestClient, storage_root: Path
+) -> None:
+    save_response = client.post(
+        "/fs/workspace/team/workspace", json={"content": "workspace: {}"}
+    )
+    load_response = client.get("/fs/workspace/team/workspace")
+
+    assert save_response.status_code == 200
+    assert save_response.json() == {"ok": True}
+    assert load_response.status_code == 200
+    assert load_response.json() == {"content": "workspace: {}"}
+    assert (storage_root / "team" / "workspace" / "workspace.yaml").is_file()
+
+
+def test_sibling_prefix_and_symlink_escapes_are_rejected(
+    storage_root: Path, tmp_path: Path
+) -> None:
+    sibling = storage_root.parent / ".docetl-outside"
+    sibling.mkdir()
+    sibling_file = sibling / "data.json"
+    sibling_file.write_text("{}")
+    assert_bad_path(filesystem.read_file(str(sibling_file)))
+
+    outside = tmp_path / "symlink-target"
+    outside.mkdir()
+    outside_file = outside / "data.json"
+    outside_file.write_text("{}")
+    link = storage_root / "link"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    assert_bad_path(filesystem.read_file(str(link / "data.json")))
+    assert_bad_path(filesystem.check_namespace("link/created"))
+    assert not (outside / "created").exists()
+
+
+def test_workspace_leaf_symlink_escape_is_rejected(
+    storage_root: Path, tmp_path: Path
+) -> None:
+    outside_file = tmp_path / "outside-workspace.yaml"
+    outside_file.write_text("secret: fixture")
+    workspace = storage_root / "workspace"
+    workspace.mkdir()
+    try:
+        (workspace / "workspace.yaml").symlink_to(outside_file)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    assert_bad_path(filesystem.load_workspace("workspace"))
+
+
+def test_malformed_paths_return_bad_request(
+    client: TestClient, storage_root: Path
+) -> None:
+    for route in ("read-file", "read-file-page", "check-file"):
+        response = client.get(f"/fs/{route}", params={"path": "bad\x00path"})
+        assert response.status_code == 400
+
+
+def test_missing_inside_paths_preserve_not_found_status(storage_root: Path) -> None:
+    with pytest.raises(HTTPException) as read_error:
+        asyncio.run(filesystem.read_file(str(storage_root / "missing.json")))
+    assert read_error.value.status_code == 404
+
+    with pytest.raises(HTTPException) as workspace_error:
+        asyncio.run(filesystem.load_workspace("missing"))
+    assert workspace_error.value.status_code == 404


### PR DESCRIPTION
Addresses the filesystem-confinement portion of #505. Canonicalizes every `/fs` filesystem path beneath `$DOCETL_HOME_DIR/.docetl`, rejects traversal, outside absolute paths, sibling-prefix paths, and symlink escapes, while preserving valid inside-root and nested workspace paths. Adds model-free route regressions and preserves intentional 400/404 responses. Authentication, URL-ingest SSRF, Docker binding, and local symlink-swap.