### PR TITLE
Add deferred provider and vLLM batch execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ tests/tui_demo/*_output.json
 cascade-report.html
 .docetl_server_port
 .docetl_feedback.log
+.docetl/

--- a/docetl/execution/__init__.py
+++ b/docetl/execution/__init__.py
@@ -1,0 +1,19 @@
+"""Execution backends for materialized LLM request batches."""
+
+from .batch import (
+    BatchExecutionError,
+    BatchRequest,
+    BatchResult,
+    SUPPORTED_LITELLM_BATCH_PROVIDERS,
+    execute_batch,
+    partition_batch_requests,
+)
+
+__all__ = [
+    "BatchExecutionError",
+    "BatchRequest",
+    "BatchResult",
+    "SUPPORTED_LITELLM_BATCH_PROVIDERS",
+    "execute_batch",
+    "partition_batch_requests",
+]

--- a/docetl/execution/batch.py
+++ b/docetl/execution/batch.py
@@ -1,0 +1,384 @@
+"""Durable execution of OpenAI-compatible JSONL request batches.
+
+Both OpenAI's Batch API and vLLM's ``run-batch`` command consume nearly the
+same request envelope.  Keeping that envelope at the DocETL boundary lets an
+operation materialize requests once and choose hosted or self-hosted execution
+without changing its prompt or result parsing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+TERMINAL_BATCH_STATES = {"completed", "failed", "expired", "cancelled"}
+SUPPORTED_LITELLM_BATCH_PROVIDERS = frozenset(
+    {"openai", "azure", "vertex_ai", "bedrock", "hosted_vllm"}
+)
+
+
+class BatchExecutionError(RuntimeError):
+    """Raised when a materialized batch cannot produce all requested results."""
+
+
+@dataclass(frozen=True)
+class BatchRequest:
+    """One request in the OpenAI Batch JSONL format."""
+
+    custom_id: str
+    body: dict[str, Any]
+    url: str = "/v1/chat/completions"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "custom_id": self.custom_id,
+            "method": "POST",
+            "url": self.url,
+            "body": self.body,
+        }
+
+
+@dataclass(frozen=True)
+class BatchResult:
+    """A provider-neutral response for one materialized request."""
+
+    custom_id: str
+    body: dict[str, Any] | None
+    error: Any | None = None
+    status_code: int | None = None
+
+
+def _atomic_write(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(contents, encoding="utf-8")
+    temporary.replace(path)
+
+
+def _jsonl(rows: Iterable[dict[str, Any]]) -> str:
+    return "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows)
+
+
+def partition_batch_requests(
+    requests: list[BatchRequest],
+    *,
+    max_requests: int,
+    max_bytes: int | None = None,
+) -> list[list[BatchRequest]]:
+    """Partition requests without exceeding provider count or file limits."""
+    if max_requests <= 0:
+        raise ValueError("max_requests must be greater than zero")
+    if max_bytes is not None and max_bytes <= 0:
+        raise ValueError("max_bytes must be greater than zero")
+
+    chunks: list[list[BatchRequest]] = []
+    current: list[BatchRequest] = []
+    current_bytes = 0
+    for request in requests:
+        request_bytes = len(
+            (json.dumps(request.as_dict(), sort_keys=True) + "\n").encode("utf-8")
+        )
+        if max_bytes is not None and request_bytes > max_bytes:
+            raise BatchExecutionError(
+                f"Batch request {request.custom_id!r} is {request_bytes} bytes, "
+                f"exceeding max_batch_bytes={max_bytes}"
+            )
+        if current and (
+            len(current) >= max_requests
+            or (max_bytes is not None and current_bytes + request_bytes > max_bytes)
+        ):
+            chunks.append(current)
+            current = []
+            current_bytes = 0
+        current.append(request)
+        current_bytes += request_bytes
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _job_directory(requests: list[BatchRequest], config: dict[str, Any]) -> Path:
+    # Exclude polling/lifecycle settings: changing how often we check must not
+    # create and bill a duplicate provider job for the same logical requests.
+    identity_config = {
+        key: value
+        for key, value in config.items()
+        if key not in {"poll_interval_seconds", "timeout_seconds", "work_dir"}
+    }
+    material = _jsonl(request.as_dict() for request in requests)
+    digest = hashlib.sha256(
+        (
+            json.dumps(identity_config, sort_keys=True, default=str) + "\n" + material
+        ).encode()
+    ).hexdigest()[:20]
+    return Path(config.get("work_dir", ".docetl/batches")) / digest
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise BatchExecutionError(
+                f"Invalid JSON on line {line_number} of {path}"
+            ) from exc
+    return rows
+
+
+def _result_from_row(row: dict[str, Any]) -> BatchResult:
+    response = row.get("response")
+    if response is None:
+        return BatchResult(row["custom_id"], None, row.get("error"))
+
+    # OpenAI wraps the endpoint response in {status_code, body}; vLLM's
+    # offline runner writes the endpoint response directly.
+    if isinstance(response, dict) and "body" in response:
+        return BatchResult(
+            custom_id=row["custom_id"],
+            body=response.get("body"),
+            error=row.get("error"),
+            status_code=response.get("status_code"),
+        )
+    return BatchResult(
+        custom_id=row["custom_id"],
+        body=response,
+        error=row.get("error"),
+        status_code=200,
+    )
+
+
+def _ordered_results(
+    requests: list[BatchRequest], rows: list[dict[str, Any]]
+) -> list[BatchResult]:
+    parsed = [_result_from_row(row) for row in rows]
+    if len({result.custom_id for result in parsed}) != len(parsed):
+        raise BatchExecutionError("Batch output contains duplicate custom_id values")
+    by_id = {result.custom_id: result for result in parsed}
+    missing = [
+        request.custom_id for request in requests if request.custom_id not in by_id
+    ]
+    if missing:
+        preview = ", ".join(missing[:5])
+        raise BatchExecutionError(
+            f"Batch output is missing {len(missing)} request(s): {preview}"
+        )
+    return [by_id[request.custom_id] for request in requests]
+
+
+def _get(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, bytes):
+        return content.decode("utf-8")
+    if isinstance(content, str):
+        return content
+    text = getattr(content, "text", None)
+    if callable(text):
+        text = text()
+    if isinstance(text, str):
+        return text
+    raw = getattr(content, "content", None)
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8")
+    raise BatchExecutionError("Batch file response did not contain text content")
+
+
+def _provider_kwargs(config: dict[str, Any]) -> dict[str, Any]:
+    kwargs = dict(config.get("provider_kwargs", {}))
+    kwargs["custom_llm_provider"] = config.get("provider", "openai")
+    return kwargs
+
+
+def _execute_provider_batch(
+    requests: list[BatchRequest], config: dict[str, Any], job_dir: Path
+) -> list[BatchResult]:
+    from litellm import create_batch, create_file, file_content, retrieve_batch
+
+    input_path = job_dir / "input.jsonl"
+    output_path = job_dir / "output.jsonl"
+    error_path = job_dir / "errors.jsonl"
+    manifest_path = job_dir / "manifest.json"
+    if output_path.exists():
+        rows = _read_jsonl(output_path)
+        if error_path.exists():
+            rows.extend(_read_jsonl(error_path))
+        return _ordered_results(requests, rows)
+
+    _atomic_write(input_path, _jsonl(request.as_dict() for request in requests))
+    provider_kwargs = _provider_kwargs(config)
+
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        batch_id = manifest["batch_id"]
+    else:
+        if config.get("routing_model"):
+            provider_kwargs["model"] = config["routing_model"]
+        with input_path.open("rb") as input_file:
+            uploaded = create_file(
+                file=input_file,
+                purpose="batch",
+                **provider_kwargs,
+            )
+        batch = create_batch(
+            completion_window=config.get("completion_window", "24h"),
+            endpoint=requests[0].url,
+            input_file_id=_get(uploaded, "id"),
+            metadata=config.get("metadata"),
+            **provider_kwargs,
+        )
+        batch_id = _get(batch, "id")
+        _atomic_write(
+            manifest_path,
+            json.dumps(
+                {
+                    "backend": "litellm",
+                    "batch_id": batch_id,
+                    "input_file_id": _get(uploaded, "id"),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+        )
+
+    started = time.monotonic()
+    poll_interval = float(config.get("poll_interval_seconds", 30))
+    timeout_seconds = config.get("timeout_seconds")
+    while True:
+        batch = retrieve_batch(batch_id=batch_id, **provider_kwargs)
+        status = _get(batch, "status")
+        if status in TERMINAL_BATCH_STATES:
+            break
+        if timeout_seconds is not None and time.monotonic() - started > float(
+            timeout_seconds
+        ):
+            raise TimeoutError(
+                f"Batch {batch_id} did not finish within {timeout_seconds} seconds; "
+                f"rerun the pipeline to resume it"
+            )
+        time.sleep(poll_interval)
+
+    output_file_id = _get(batch, "output_file_id")
+    error_file_id = _get(batch, "error_file_id")
+    if output_file_id:
+        _atomic_write(
+            output_path,
+            _content_text(file_content(file_id=output_file_id, **provider_kwargs)),
+        )
+    if error_file_id:
+        _atomic_write(
+            error_path,
+            _content_text(file_content(file_id=error_file_id, **provider_kwargs)),
+        )
+    if status != "completed" and not output_path.exists():
+        raise BatchExecutionError(f"Batch {batch_id} ended with status {status!r}")
+
+    rows = _read_jsonl(output_path) if output_path.exists() else []
+    if error_path.exists():
+        rows.extend(_read_jsonl(error_path))
+    return _ordered_results(requests, rows)
+
+
+def _cli_args(engine_args: dict[str, Any]) -> list[str]:
+    args: list[str] = []
+    for key, value in engine_args.items():
+        flag = "--" + key.replace("_", "-")
+        if isinstance(value, bool):
+            if value:
+                args.append(flag)
+        elif isinstance(value, list):
+            for item in value:
+                args.extend([flag, str(item)])
+        elif value is not None:
+            args.extend([flag, str(value)])
+    return args
+
+
+def _execute_vllm_batch(
+    requests: list[BatchRequest], config: dict[str, Any], job_dir: Path
+) -> list[BatchResult]:
+    input_path = job_dir / "input.jsonl"
+    output_path = job_dir / "output.jsonl"
+    if output_path.exists():
+        return _ordered_results(requests, _read_jsonl(output_path))
+
+    model = config.get("model")
+    if not model:
+        models = {request.body.get("model") for request in requests}
+        if len(models) != 1:
+            raise ValueError("vLLM batch execution requires exactly one model")
+        model = models.pop()
+
+    request_defaults = config.get("request_defaults", {})
+    materialized = []
+    for request in requests:
+        body = {**request_defaults, **request.body, "model": model}
+        materialized.append(BatchRequest(request.custom_id, body, request.url))
+    _atomic_write(input_path, _jsonl(item.as_dict() for item in materialized))
+
+    command = config.get("command", ["vllm", "run-batch"])
+    if not isinstance(command, list) or not all(
+        isinstance(part, str) for part in command
+    ):
+        raise ValueError("vLLM batch 'command' must be a list of strings")
+    argv = [
+        *command,
+        "-i",
+        str(input_path),
+        "-o",
+        str(output_path),
+        "--model",
+        str(model),
+        *_cli_args(config.get("engine_args", {})),
+    ]
+    try:
+        subprocess.run(argv, check=True)
+    except FileNotFoundError as exc:
+        raise BatchExecutionError(
+            f"vLLM batch command was not found: {command[0]!r}"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise BatchExecutionError(
+            f"vLLM batch command exited with status {exc.returncode}; "
+            f"input remains at {input_path}"
+        ) from exc
+    if not output_path.exists():
+        raise BatchExecutionError("vLLM batch command did not create its output file")
+    return _ordered_results(requests, _read_jsonl(output_path))
+
+
+def execute_batch(
+    requests: list[BatchRequest], config: dict[str, Any]
+) -> list[BatchResult]:
+    """Execute *requests* with the configured durable batch backend."""
+    if not requests:
+        return []
+    endpoints = {request.url for request in requests}
+    if len(endpoints) != 1:
+        raise ValueError("A batch may target only one endpoint")
+    ids = [request.custom_id for request in requests]
+    if len(ids) != len(set(ids)):
+        raise ValueError("Batch request custom_id values must be unique")
+
+    job_dir = _job_directory(requests, config)
+    backend = config.get("backend", "litellm")
+    if backend == "litellm":
+        return _execute_provider_batch(requests, config, job_dir)
+    if backend == "vllm":
+        return _execute_vllm_batch(requests, config, job_dir)
+    raise ValueError(f"Unknown batch execution backend {backend!r}")

--- a/docetl/frame.py
+++ b/docetl/frame.py
@@ -360,6 +360,7 @@ class Frame:
         calibrate: bool | None = None,
         num_calibration_docs: int | None = None,
         retriever: Retriever | str | None = None,
+        execution: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> Frame:
         return self._append_op(
@@ -388,6 +389,7 @@ class Frame:
                 "calibrate": calibrate,
                 "num_calibration_docs": num_calibration_docs,
                 "retriever": retriever,
+                "execution": execution,
                 **kwargs,
             },
         )

--- a/docetl/operations/map.py
+++ b/docetl/operations/map.py
@@ -14,6 +14,10 @@ from litellm.utils import ModelResponse
 from pydantic import Field, field_validator, model_validator
 from tqdm import tqdm
 
+from docetl.execution import (
+    BatchExecutionError,
+    SUPPORTED_LITELLM_BATCH_PROVIDERS,
+)
 from docetl.operations.base import BaseOperation, Cardinality
 from docetl.operations.code_operations import extract_eval_field_reads
 from docetl.operations.utils import (
@@ -57,6 +61,7 @@ class MapOperation(BaseOperation):
         # Calibration parameters
         calibrate: bool = False
         num_calibration_docs: int = Field(10, gt=0)
+        execution: dict[str, Any] | None = None
 
         @field_validator("batch_prompt")
         def validate_batch_prompt(cls, v):
@@ -111,6 +116,43 @@ class MapOperation(BaseOperation):
                 if self.output and not self.output.get("schema"):
                     raise ValueError("Missing 'schema' in 'output' configuration")
 
+            return self
+
+        @model_validator(mode="after")
+        def validate_materialized_batch_execution(self):
+            if self.execution is None:
+                return self
+            if self.execution.get("mode") != "batch":
+                raise ValueError("execution.mode must be 'batch'")
+            backend = self.execution.get("backend", "litellm")
+            if backend not in {"litellm", "vllm"}:
+                raise ValueError("execution.backend must be 'litellm' or 'vllm'")
+            if (
+                backend == "litellm"
+                and self.execution.get("provider", "openai")
+                not in SUPPORTED_LITELLM_BATCH_PROVIDERS
+            ):
+                raise ValueError(
+                    "LiteLLM batch execution currently supports provider values "
+                    "openai, azure, vertex_ai, bedrock, and hosted_vllm"
+                )
+            incompatible = [
+                name
+                for name, value in (
+                    ("agent", self.agent),
+                    ("gleaning", self.gleaning),
+                    ("validate", self.validation_rules),
+                    ("calibrate", self.calibrate),
+                    ("batch_prompt", self.batch_prompt),
+                    ("pdf_url_key", self.pdf_url_key),
+                )
+                if value
+            ]
+            if incompatible:
+                raise ValueError(
+                    "batch execution cannot yet be combined with "
+                    + ", ".join(incompatible)
+                )
             return self
 
     def __init__(
@@ -279,7 +321,7 @@ Sample inputs and their outputs:
             for i, (input_doc, output_doc) in enumerate(
                 zip(calibration_sample, calibration_results)
             ):
-                calibration_prompt += f"\n--- Example {i+1} ---\n"
+                calibration_prompt += f"\n--- Example {i + 1} ---\n"
                 calibration_prompt += f"Input: {input_doc}\n"
                 calibration_prompt += f"Output: {output_doc}\n"
 
@@ -332,6 +374,93 @@ Reference anchors:"""
         finally:
             # Restore original calibration setting
             self.config["calibrate"] = original_calibrate
+
+    def _execute_materialized_batch(
+        self, input_data: list[dict]
+    ) -> tuple[list[dict], float]:
+        """Materialize independent row calls and execute them as one batch."""
+        if not self._limit_applies_to_inputs() and self.config.get("limit"):
+            raise ValueError(
+                "batch execution cannot be combined with a filter limit because "
+                "the passing rows are not known until after the batch completes"
+            )
+        if self.config.get("cascade"):
+            raise ValueError("batch execution cannot yet be combined with cascade")
+
+        prepared: list[tuple[dict, str, str]] = []
+        calls: list[dict[str, Any]] = []
+        model = self.config.get("model", self.default_model)
+        for item in input_data:
+            retrieval_context = self._maybe_build_retrieval_context({"input": item})
+            rendered = strict_render(
+                self.config["prompt"],
+                {"input": item, "retrieval_context": retrieval_context},
+            )
+            prompt = (
+                f"Here is some extra context:\n{retrieval_context}\n\n{rendered}"
+                if retrieval_context
+                and "retrieval_context" not in self.config["prompt"]
+                else rendered
+            )
+            prepared.append((item, prompt, retrieval_context))
+            calls.append(
+                {
+                    "model": model,
+                    # Preserve the existing MapOperation call contract; Filter
+                    # inherits this path and currently uses the map system prompt.
+                    "op_type": "map",
+                    "messages": [{"role": "user", "content": prompt}],
+                    "output_schema": self.config["output"]["schema"],
+                    "bypass_cache": self.config.get("bypass_cache", self.bypass_cache),
+                    "litellm_completion_kwargs": self.config.get(
+                        "litellm_completion_kwargs", {}
+                    ),
+                    "op_config": self.config,
+                }
+            )
+
+        llm_results = self.runner.api.call_llm_materialized_batch(
+            calls, self.config["execution"]
+        )
+        structured_mode = (
+            self.config.get("output", {}).get("mode")
+            == OutputMode.STRUCTURED_OUTPUT.value
+        )
+        results: list[dict] = []
+        total_cost = 0.0
+        for (item, prompt, retrieval_context), llm_result in zip(prepared, llm_results):
+            total_cost += llm_result.total_cost
+            if not llm_result.validated or llm_result.response is None:
+                if self.config.get("skip_on_error", False):
+                    self.console.log(
+                        f"[bold red]Batch request failed in {self.config['name']}; "
+                        "skipping item[/bold red]"
+                    )
+                    continue
+                raise BatchExecutionError(
+                    f"Batch request failed in operation {self.config['name']!r}"
+                )
+            outputs = self.runner.api.parse_llm_response(
+                llm_result.response,
+                schema=self.config["output"]["schema"],
+                manually_fix_errors=self.manually_fix_errors,
+                use_structured_output=structured_mode,
+            )
+            for parsed in outputs:
+                output = {**item, **parsed}
+                if self.config.get("enable_observability", False):
+                    output[f"_observability_{self.config['name']}"] = {"prompt": prompt}
+                if self.config.get("save_retriever_output", False):
+                    output[f"_{self.config['name']}_retrieved_context"] = (
+                        retrieval_context if retrieval_context else ""
+                    )
+                for key in self.config.get("drop_keys", []):
+                    output.pop(key, None)
+                handled, _ = self._handle_result(output)
+                if handled is not None:
+                    results.append(handled)
+
+        return results, total_cost
 
     def execute(self, input_data: list[dict]) -> tuple[list[dict], float]:
         """
@@ -393,13 +522,21 @@ Reference anchors:"""
                     f"[bold yellow]Extra context on how to improve consistency failed to generate for map ({self.config['name']}); continuing with prompt as is.[/bold yellow]"
                 )
 
+        if self.config.get("execution", {}).get("mode") == "batch":
+            if self.status:
+                self.status.stop()
+            try:
+                return self._execute_materialized_batch(input_data)
+            finally:
+                if self.status:
+                    self.status.start()
+
         if self.status:
             self.status.stop()
 
         def _process_map_item(
             item: dict, initial_result: dict | None = None
         ) -> tuple[dict | None, float]:
-
             # Build retrieval context (if configured)
             retrieval_context = self._maybe_build_retrieval_context({"input": item})
             ctx = {"input": item, "retrieval_context": retrieval_context}

--- a/docetl/operations/utils/api.py
+++ b/docetl/operations/utils/api.py
@@ -16,6 +16,7 @@ from litellm import (
     ServiceUnavailableError,
     completion,
     embedding,
+    get_llm_provider,
 )
 from litellm.types.utils import ChatCompletionMessageToolCall, Function
 from rich import print as rprint
@@ -23,6 +24,12 @@ from rich.console import Console, Group
 from rich.panel import Panel
 from rich.text import Text
 
+from docetl.execution import (
+    BatchRequest,
+    SUPPORTED_LITELLM_BATCH_PROVIDERS,
+    execute_batch,
+    partition_batch_requests,
+)
 from docetl.utils import completion_cost
 
 from .cache import cache, cache_key, freezeargs
@@ -151,9 +158,9 @@ class APIWrapper(object):
             prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
             completion_tokens = getattr(usage, "completion_tokens", 0) or 0
             self.runner.total_token_usage[model]["prompt_tokens"] += prompt_tokens
-            self.runner.total_token_usage[model][
-                "completion_tokens"
-            ] += completion_tokens
+            self.runner.total_token_usage[model]["completion_tokens"] += (
+                completion_tokens
+            )
 
             # Track cached/cache-creation tokens if available
             cached = 0
@@ -268,6 +275,265 @@ class APIWrapper(object):
             litellm_completion_kwargs=litellm_completion_kwargs,
             op_config=op_config,
         )
+
+    def _prepare_materialized_completion(
+        self,
+        model: str,
+        op_type: str,
+        messages: list[dict[str, Any]],
+        output_schema: dict[str, str],
+        litellm_completion_kwargs: dict[str, Any],
+        op_config: dict[str, Any],
+        execution_config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build one OpenAI-compatible request without executing it.
+
+        Deferred backends deliberately support the non-agentic, row-local call
+        shape first.  Validation, gleaning, and agent loops need more than one
+        dependent round and are rejected by ``MapOperation`` before this point.
+        """
+        props = {key: convert_val(value) for key, value in output_schema.items()}
+        output_mode = op_config.get("output", {}).get("mode", OutputMode.TOOLS.value)
+        use_structured_output = output_mode == OutputMode.STRUCTURED_OUTPUT.value
+        use_tools = not (
+            len(props) == 1
+            and next(iter(props.values())).get("type") == "string"
+            and ("sagemaker" in model or is_deepseek_r1(model))
+        )
+
+        persona = self.runner.config.get("system_prompt", {}).get(
+            "persona", "a helpful assistant"
+        )
+        dataset_description = self.runner.config.get("system_prompt", {}).get(
+            "dataset_description", "a collection of unstructured documents"
+        )
+        base_prompt = (
+            f"You are a {persona}, helping the user make sense of their data. "
+            f"The dataset description is: {dataset_description}. You will be "
+            f"performing a {op_type} operation (one input:one output). You will "
+            "perform the specified task on the provided data, as precisely and "
+            "exhaustively (i.e., high recall) as possible."
+        )
+
+        body: dict[str, Any] = dict(litellm_completion_kwargs)
+        # These configure a LiteLLM client, not an endpoint request body.
+        for client_key in (
+            "api_base",
+            "base_url",
+            "api_key",
+            "custom_llm_provider",
+            "allowed_openai_params",
+        ):
+            body.pop(client_key, None)
+        if "n" in op_config.get("output", {}):
+            body["n"] = op_config["output"]["n"]
+        if "gpt-5" in model:
+            body.pop("temperature", None)
+
+        if execution_config.get("backend", "litellm") == "litellm":
+            normalized_model, provider, _, _ = get_llm_provider(model)
+            configured_provider = execution_config.get("provider", "openai")
+            if provider != configured_provider:
+                raise ValueError(
+                    f"Batch backend provider {configured_provider!r} cannot execute "
+                    f"model {model!r} (LiteLLM provider {provider!r})"
+                )
+            body["model"] = normalized_model
+        else:
+            body["model"] = execution_config.get("model", model)
+
+        system_prompt = base_prompt
+        if use_structured_output:
+            system_prompt += (
+                " Respond with a JSON object that follows the required schema."
+            )
+            body["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "structured_output",
+                    "schema": {
+                        "type": "object",
+                        "properties": props,
+                        "required": list(props),
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                },
+            }
+        elif use_tools:
+            system_prompt += (
+                " The result should be a structured output that you will send "
+                "back to the user, with the `send_output` function. Do not "
+                "influence your answers too much based on the `send_output` "
+                "function parameter names; just use them to send the result "
+                "back to the user."
+            )
+            parameters: dict[str, Any] = {
+                "type": "object",
+                "properties": props,
+                "required": list(props),
+            }
+            if "gemini" not in model and "claude" not in model:
+                parameters["additionalProperties"] = False
+            tool: dict[str, Any] = {
+                "type": "function",
+                "function": {
+                    "name": "send_output",
+                    "description": "Send output back to the user",
+                    "parameters": parameters,
+                },
+            }
+            if "claude" not in model:
+                tool["additionalProperties"] = False
+                tool["strict"] = True
+            body["tools"] = [tool]
+            body["tool_choice"] = {
+                "type": "function",
+                "function": {"name": "send_output"},
+            }
+        else:
+            system_prompt = base_prompt
+
+        body["messages"] = truncate_messages(
+            [{"role": "system", "content": system_prompt}] + messages,
+            model,
+        )
+        return body
+
+    def call_llm_materialized_batch(
+        self,
+        calls: list[dict[str, Any]],
+        execution_config: dict[str, Any],
+    ) -> list[LLMResult]:
+        """Execute independent LLM calls as one durable backend batch."""
+        execution_config = dict(execution_config)
+        if (
+            execution_config.get("backend", "litellm") == "litellm"
+            and "provider" not in execution_config
+            and calls
+        ):
+            providers = {get_llm_provider(call["model"])[1] for call in calls}
+            if len(providers) != 1:
+                raise ValueError(
+                    "A provider batch requires models from exactly one LiteLLM provider"
+                )
+            execution_config["provider"] = providers.pop()
+        if (
+            execution_config.get("backend", "litellm") == "litellm"
+            and execution_config.get("provider", "openai")
+            not in SUPPORTED_LITELLM_BATCH_PROVIDERS
+        ):
+            raise ValueError(
+                "LiteLLM batch execution currently supports provider values "
+                "openai, azure, vertex_ai, bedrock, and hosted_vllm"
+            )
+        results: list[LLMResult | None] = [None] * len(calls)
+        pending_requests: list[BatchRequest] = []
+        pending: list[tuple[int, str, str]] = []
+
+        with cache as c:
+            for index, call in enumerate(calls):
+                key = cache_key(
+                    call["model"],
+                    call["op_type"],
+                    call["messages"],
+                    call["output_schema"],
+                    None,
+                    self.runner.config.get("system_prompt", {}),
+                    call["op_config"],
+                )
+                cached = c.get(key)
+                if cached is not None and not call.get("bypass_cache", False):
+                    results[index] = LLMResult(
+                        response=cached, total_cost=0.0, validated=True
+                    )
+                    continue
+                custom_id = f"request-{index}"
+                body = self._prepare_materialized_completion(
+                    call["model"],
+                    call["op_type"],
+                    call["messages"],
+                    call["output_schema"],
+                    call.get("litellm_completion_kwargs", {}),
+                    call["op_config"],
+                    execution_config,
+                )
+                pending_requests.append(BatchRequest(custom_id=custom_id, body=body))
+                pending.append((index, key, call["model"]))
+
+        if pending_requests:
+            default_batch_size = (
+                50_000
+                if execution_config.get("backend", "litellm") == "litellm"
+                else len(pending_requests)
+            )
+            max_batch_requests = int(
+                execution_config.get("max_batch_requests", default_batch_size)
+            )
+            max_batch_bytes = execution_config.get(
+                "max_batch_bytes",
+                200_000_000
+                if execution_config.get("backend", "litellm") == "litellm"
+                else None,
+            )
+            batch_results = []
+            chunks = partition_batch_requests(
+                pending_requests,
+                max_requests=max_batch_requests,
+                max_bytes=(
+                    int(max_batch_bytes) if max_batch_bytes is not None else None
+                ),
+            )
+            for chunk in chunks:
+                batch_results.extend(
+                    execute_batch(
+                        chunk,
+                        execution_config,
+                    )
+                )
+            multiplier = float(
+                execution_config.get(
+                    "cost_multiplier",
+                    (
+                        0.5
+                        if execution_config.get("provider", "openai") == "openai"
+                        else 1.0
+                    )
+                    if execution_config.get("backend", "litellm") == "litellm"
+                    else 0.0,
+                )
+            )
+            with cache as c:
+                for (index, key, model), batch_result in zip(pending, batch_results):
+                    if (
+                        batch_result.error is not None
+                        or batch_result.body is None
+                        or (
+                            batch_result.status_code is not None
+                            and not 200 <= batch_result.status_code < 300
+                        )
+                    ):
+                        results[index] = LLMResult(
+                            response=None, total_cost=0.0, validated=False
+                        )
+                        continue
+                    response = ModelResponse(**batch_result.body)
+                    estimated_cost = completion_cost(response) * multiplier
+                    setattr(response, "_completion_cost", estimated_cost)
+                    self._track_token_usage(model, response)
+                    c.set(key, response)
+                    results[index] = LLMResult(
+                        response=response,
+                        total_cost=estimated_cost,
+                        validated=True,
+                    )
+
+        return [
+            result
+            if result is not None
+            else LLMResult(response=None, total_cost=0.0, validated=False)
+            for result in results
+        ]
 
     def _cached_call_llm(
         self,
@@ -636,7 +902,10 @@ class APIWrapper(object):
             raise ValueError(
                 f"Invalid output mode '{output_mode_str}'. Must be 'tools' or 'structured_output'."
             )
-        if agent_config is not None and output_mode_str == OutputMode.STRUCTURED_OUTPUT.value:
+        if (
+            agent_config is not None
+            and output_mode_str == OutputMode.STRUCTURED_OUTPUT.value
+        ):
             raise ValueError(
                 "agent cannot be combined with output.mode='structured_output'; "
                 "agentic operations use the OpenAI Agents SDK final output schema."

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -105,6 +105,7 @@ frame.map(
 | `timeout` | `int` | `None` | Timeout per LLM call (seconds) |
 | `max_batch_size` | `int` | `None` | Batch size for batch processing |
 | `batch_prompt` | `str` | `None` | Jinja2 template for batch mode |
+| `execution` | `dict` | `None` | Deferred provider or vLLM batch execution. See [Deferred Batch Execution](../execution/batch.md). |
 | `retriever` | `Retriever` | `None` | Retriever for context augmentation |
 | `optimize` | `bool` | `None` | Mark for optimization |
 | `limit` | `int` | `None` | Max documents to process |

--- a/docs/execution/batch.md
+++ b/docs/execution/batch.md
@@ -1,0 +1,147 @@
+# Deferred Batch Execution
+
+DocETL normally sends each LLM request immediately. For large, non-interactive
+map and filter operations, you can instead materialize all independent requests
+as OpenAI-compatible JSONL and run them with either a hosted provider Batch API
+or a short-lived local vLLM job.
+
+This is different from `batch_prompt`:
+
+| Feature | What is batched | LLM requests |
+| --- | --- | --- |
+| `batch_prompt` | Several input rows inside one prompt | One request per group |
+| `execution.mode: batch` | Independent request envelopes | One request per row, submitted as one job |
+
+The second form preserves row-level prompts and output parsing while moving the
+execution schedule out of the per-row thread pool.
+
+## Hosted provider batches through LiteLLM
+
+DocETL uses LiteLLM's Files and Batches abstraction for the hosted job
+lifecycle. LiteLLM currently documents Batch support for OpenAI, Azure OpenAI,
+Vertex AI, Bedrock, and hosted vLLM. This is a smaller set than the providers
+supported by ordinary LiteLLM completions.
+
+=== "YAML"
+
+    ```yaml
+    - name: classify_documents
+      type: map
+      model: openai/gpt-4o-mini
+      prompt: Classify this document: {{ input.text }}
+      output:
+        schema:
+          category: string
+      execution:
+        mode: batch
+        backend: litellm
+        provider: openai # optional when it can be inferred from model
+        completion_window: 24h
+        poll_interval_seconds: 30
+    ```
+
+=== "Python"
+
+    ```python
+    results = (
+        docetl.read_json("documents.json")
+        .map(
+            prompt="Classify this document: {{ input.text }}",
+            output={"schema": {"category": "string"}},
+            model="openai/gpt-4o-mini",
+            execution={
+                "mode": "batch",
+                "backend": "litellm",
+                "provider": "openai",
+                "completion_window": "24h",
+                "poll_interval_seconds": 30,
+            },
+        )
+        .collect()
+    )
+    ```
+
+DocETL infers the provider adapter from a normal LiteLLM model string, so for
+supported providers changing `openai/gpt-4o-mini` to a model such as
+`vertex_ai/gemini-...` is enough. Set `provider` explicitly when using a model
+alias or custom routing. If you use a LiteLLM model alias for multi-account
+routing, set `routing_model` in the execution block as well.
+
+OpenAI advertises 50% lower token prices and a completion window of up to 24
+hours for its Batch API. Other providers have their own pricing and lifecycle
+rules. DocETL therefore applies the OpenAI 0.5 cost multiplier only when
+`provider: openai`; set `cost_multiplier` explicitly for other providers if you
+want DocETL's estimated cost to reflect their batch pricing.
+
+Provider batches are split at 50,000 requests or 200 MB by default, matching
+OpenAI's per-batch limits. Set `max_batch_requests` or `max_batch_bytes` to a
+smaller provider-specific limit when needed.
+
+## Offline batches with vLLM
+
+The vLLM backend writes the same JSONL requests and invokes `vllm run-batch` as
+a subprocess. This is useful for an ephemeral GPU worker: start the worker,
+load the model once, process the materialized dataset, write the results, and
+shut the worker down.
+
+```yaml
+- name: classify_documents
+  type: map
+  model: Qwen/Qwen3-8B
+  prompt: Classify this document: {{ input.text }}
+  output:
+    schema:
+      category: string
+  execution:
+    mode: batch
+    backend: vllm
+    model: Qwen/Qwen3-8B
+    request_defaults:
+      max_tokens: 512
+      min_tokens: 1
+    engine_args:
+      tensor_parallel_size: 2
+      gpu_memory_utilization: 0.9
+      max_model_len: 4096
+      max_num_seqs: 256
+      enforce_eager: false
+```
+
+`request_defaults` become fields in each request body. `engine_args` become
+vLLM CLI flags by converting underscores to hyphens; for example,
+`tensor_parallel_size` becomes `--tensor-parallel-size`. Use vLLM's own option
+names (`max_model_len`, not `max_model_length`). A false boolean is omitted,
+while a true boolean becomes a flag.
+
+An always-on vLLM or SGLang OpenAI-compatible server can already be used for
+ordinary DocETL calls through LiteLLM. That provides continuous batching inside
+the server, but it is not a durable offline job and does not start or stop GPU
+capacity. Use the vLLM backend above when the job lifecycle is the objective.
+
+## Durability and ordering
+
+DocETL writes batch artifacts under `.docetl/batches/<job-hash>/` by default:
+
+- `input.jsonl` contains the materialized logical requests.
+- `manifest.json` records a hosted provider batch ID.
+- `output.jsonl` and `errors.jsonl` contain downloaded results.
+
+If the process stops after submission, rerunning the same operation resumes the
+provider job from the manifest instead of creating a duplicate. Completed
+outputs are reused locally. Provider output order is not trusted; DocETL joins
+responses to inputs by `custom_id` and restores input order.
+
+Use `work_dir` to put these artifacts on persistent storage when the process or
+node filesystem is ephemeral.
+
+## Current compatibility
+
+The first batch execution slice supports independent `map` calls and the normal
+non-cascade `filter` path. It supports DocETL's tool-call and structured-output
+modes, caching, retrieval context, observability, and `skip_on_error`.
+
+Features that create dependent follow-up calls are rejected rather than
+silently changing semantics: agents, gleaning, validation retries, calibration,
+and cascades. `batch_prompt` and PDF inputs are also not currently combined with
+deferred execution. A filter `limit` is rejected because DocETL cannot know
+which rows pass until the full batch has run.

--- a/docs/operators/map.md
+++ b/docs/operators/map.md
@@ -194,6 +194,7 @@ flowchart LR
 | `num_calibration_docs` | Number of documents to use sample and generate outputs for, for calibration. | 10                          |
 | `retriever` | Name of a retriever to use for RAG. See [Retrievers](../retrievers.md). | None                          |
 | `save_retriever_output` | If true, saves the retrieved context to `_<operation_name>_retrieved_context` in the output. | False                          |
+| `execution` | Materialize row requests for a hosted provider or offline vLLM batch. See [Deferred Batch Execution](../execution/batch.md). | None |
 
 Note: If `drop_keys` is specified, `prompt` and `output` become optional parameters.
 
@@ -207,6 +208,13 @@ Set `limit` when you only need the first _N_ map results or want to cap LLM spen
     For more details on validation techniques and implementation, see [operators](../concepts/operators.md#validation).
 
 ### Batch Processing
+
+!!! note "Prompt batching versus execution batching"
+
+    This section describes `batch_prompt`, which combines several rows into
+    one prompt. To keep one request per row and submit those requests through a
+    provider Batch API or `vllm run-batch`, see
+    [Deferred Batch Execution](../execution/batch.md).
 
 The `batch_prompt` parameter processes multiple documents in a single prompt. This reduces LLM call counts for simple tasks and short documents, but larger batch sizes (even > 5) can lead to more incorrect results.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
           - TopK: operators/topk.md
           - Code: operators/code.md
       - Retrievers: retrievers.md
+      - Deferred Batch Execution: execution/batch.md
       - Interactive Progress View: execution/interactive-progress.md
       - Python API Reference: api-reference/python.md
       - Pandas Accessor: pandas/index.md

--- a/tests/test_batch_execution.py
+++ b/tests/test_batch_execution.py
@@ -1,0 +1,442 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from docetl.execution import (
+    BatchExecutionError,
+    BatchRequest,
+    BatchResult,
+    execute_batch,
+    partition_batch_requests,
+)
+from docetl.operations.map import MapOperation
+from docetl.runner import DSLRunner
+
+
+def _response_row(custom_id: str, value: str) -> dict:
+    return {
+        "custom_id": custom_id,
+        "response": {
+            "status_code": 200,
+            "body": {
+                "id": f"completion-{custom_id}",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": f"call-{custom_id}",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "send_output",
+                                        "arguments": json.dumps({"label": value}),
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 2,
+                    "total_tokens": 12,
+                },
+            },
+        },
+        "error": None,
+    }
+
+
+def test_openai_batch_persists_and_orders_results(tmp_path, monkeypatch):
+    import litellm
+
+    calls = {"upload": 0, "create": 0, "retrieve": 0, "content": 0}
+
+    def create_file(**kwargs):
+        calls["upload"] += 1
+        assert kwargs["purpose"] == "batch"
+        return SimpleNamespace(id="file-input")
+
+    def create_batch(**kwargs):
+        calls["create"] += 1
+        assert kwargs["endpoint"] == "/v1/chat/completions"
+        return SimpleNamespace(id="batch-1")
+
+    def retrieve_batch(**kwargs):
+        calls["retrieve"] += 1
+        return SimpleNamespace(
+            status="completed", output_file_id="file-output", error_file_id=None
+        )
+
+    def file_content(**kwargs):
+        calls["content"] += 1
+        # Providers do not guarantee output order.
+        return SimpleNamespace(
+            text="".join(
+                json.dumps(row) + "\n"
+                for row in [
+                    _response_row("second", "B"),
+                    _response_row("first", "A"),
+                ]
+            )
+        )
+
+    monkeypatch.setattr(litellm, "create_file", create_file)
+    monkeypatch.setattr(litellm, "create_batch", create_batch)
+    monkeypatch.setattr(litellm, "retrieve_batch", retrieve_batch)
+    monkeypatch.setattr(litellm, "file_content", file_content)
+
+    requests = [
+        BatchRequest("first", {"model": "gpt-4o-mini", "messages": []}),
+        BatchRequest("second", {"model": "gpt-4o-mini", "messages": []}),
+    ]
+    config = {"backend": "litellm", "work_dir": str(tmp_path)}
+    results = execute_batch(requests, config)
+
+    assert [result.custom_id for result in results] == ["first", "second"]
+    assert calls == {"upload": 1, "create": 1, "retrieve": 1, "content": 1}
+
+    # Completed output is a durable checkpoint; a rerun must not resubmit.
+    assert execute_batch(requests, config) == results
+    assert calls == {"upload": 1, "create": 1, "retrieve": 1, "content": 1}
+
+
+def test_openai_batch_resumes_existing_provider_job(tmp_path, monkeypatch):
+    import litellm
+    from docetl.execution import batch as batch_module
+
+    requests = [BatchRequest("one", {"model": "gpt-4o-mini", "messages": []})]
+    config = {"backend": "litellm", "work_dir": str(tmp_path)}
+    job_dir = batch_module._job_directory(requests, config)
+    job_dir.mkdir(parents=True)
+    (job_dir / "manifest.json").write_text(
+        json.dumps({"batch_id": "existing-batch"}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        litellm,
+        "create_file",
+        lambda **kwargs: pytest.fail("resume must not upload a second file"),
+    )
+    monkeypatch.setattr(
+        litellm,
+        "create_batch",
+        lambda **kwargs: pytest.fail("resume must not create a second batch"),
+    )
+    monkeypatch.setattr(
+        litellm,
+        "retrieve_batch",
+        lambda **kwargs: SimpleNamespace(
+            status="completed", output_file_id="output", error_file_id=None
+        ),
+    )
+    monkeypatch.setattr(
+        litellm,
+        "file_content",
+        lambda **kwargs: SimpleNamespace(
+            text=json.dumps(_response_row("one", "done")) + "\n"
+        ),
+    )
+
+    assert execute_batch(requests, config)[0].custom_id == "one"
+
+
+def test_batch_rejects_duplicate_output_ids(tmp_path):
+    from docetl.execution import batch as batch_module
+
+    requests = [
+        BatchRequest("one", {"model": "m", "messages": []}),
+        BatchRequest("two", {"model": "m", "messages": []}),
+    ]
+    config = {"backend": "vllm", "work_dir": str(tmp_path), "model": "m"}
+    job_dir = batch_module._job_directory(requests, config)
+    job_dir.mkdir(parents=True)
+    duplicate = _response_row("one", "x")
+    duplicate["response"] = duplicate["response"]["body"]
+    (job_dir / "output.jsonl").write_text(
+        json.dumps(duplicate) + "\n" + json.dumps(duplicate) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BatchExecutionError, match="duplicate custom_id"):
+        execute_batch(requests, config)
+
+
+def test_vllm_batch_uses_safe_argv_and_openai_jsonl(tmp_path, monkeypatch):
+    from docetl.execution import batch as batch_module
+
+    captured = {}
+
+    def fake_run(argv, check):
+        captured["argv"] = argv
+        assert check is True
+        input_path = Path(argv[argv.index("-i") + 1])
+        output_path = Path(argv[argv.index("-o") + 1])
+        request = json.loads(input_path.read_text(encoding="utf-8"))
+        assert request["body"]["model"] == "Qwen/Qwen3-8B"
+        assert request["body"]["max_tokens"] == 512
+        response = _response_row("one", "local")
+        # vLLM writes the endpoint body directly rather than OpenAI's wrapper.
+        response["response"] = response["response"]["body"]
+        output_path.write_text(json.dumps(response) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(batch_module.subprocess, "run", fake_run)
+    results = execute_batch(
+        [BatchRequest("one", {"model": "ignored", "messages": []})],
+        {
+            "backend": "vllm",
+            "work_dir": str(tmp_path),
+            "model": "Qwen/Qwen3-8B",
+            "request_defaults": {"max_tokens": 512},
+            "engine_args": {
+                "tensor_parallel_size": 2,
+                "gpu_memory_utilization": 0.9,
+                "enforce_eager": True,
+            },
+        },
+    )
+
+    assert results[0].body["model"] == "gpt-4o-mini"
+    assert captured["argv"][:2] == ["vllm", "run-batch"]
+    assert "--tensor-parallel-size" in captured["argv"]
+    assert "--enforce-eager" in captured["argv"]
+
+
+def test_batch_partition_respects_count_and_encoded_bytes():
+    requests = [
+        BatchRequest(str(index), {"model": "m", "messages": [], "value": "x" * 20})
+        for index in range(3)
+    ]
+    one_size = len(
+        (json.dumps(requests[0].as_dict(), sort_keys=True) + "\n").encode("utf-8")
+    )
+
+    assert [
+        len(chunk) for chunk in partition_batch_requests(requests, max_requests=2)
+    ] == [2, 1]
+    assert [
+        len(chunk)
+        for chunk in partition_batch_requests(
+            requests, max_requests=10, max_bytes=one_size * 2 - 1
+        )
+    ] == [1, 1, 1]
+
+
+def test_map_materializes_one_request_per_row_and_preserves_order(monkeypatch):
+    import docetl.operations.utils.api as api_module
+
+    seen = {}
+
+    def fake_execute_batch(requests, config):
+        seen["requests"] = requests
+        seen["config"] = config
+        return [
+            BatchResult(
+                request.custom_id,
+                _response_row(request.custom_id, value)["response"]["body"],
+            )
+            for request, value in zip(requests, ["A", "B"])
+        ]
+
+    monkeypatch.setattr(api_module, "execute_batch", fake_execute_batch)
+    runner = DSLRunner(
+        {
+            "default_model": "gpt-4o-mini",
+            "operations": [],
+            "pipeline": {"steps": [], "output": {"path": "/tmp/out.json"}},
+        },
+        max_threads=2,
+    )
+    operation = MapOperation(
+        runner,
+        {
+            "name": "classify",
+            "type": "map",
+            "prompt": "Classify {{ input.text }}",
+            "output": {"schema": {"label": "string"}},
+            "execution": {"mode": "batch", "backend": "litellm"},
+            "bypass_cache": True,
+        },
+        "gpt-4o-mini",
+        2,
+    )
+
+    output, _ = operation.execute([{"text": "one"}, {"text": "two"}])
+
+    assert output == [
+        {"text": "one", "label": "A"},
+        {"text": "two", "label": "B"},
+    ]
+    assert len(seen["requests"]) == 2
+    assert seen["requests"][0].body["tools"][0]["function"]["name"] == "send_output"
+
+
+def test_map_splits_provider_request_limit(monkeypatch):
+    import docetl.operations.utils.api as api_module
+
+    batch_sizes = []
+
+    def fake_execute_batch(requests, config):
+        batch_sizes.append(len(requests))
+        return [
+            BatchResult(
+                request.custom_id,
+                _response_row(request.custom_id, "ok")["response"]["body"],
+            )
+            for request in requests
+        ]
+
+    monkeypatch.setattr(api_module, "execute_batch", fake_execute_batch)
+    runner = DSLRunner(
+        {
+            "default_model": "gpt-4o-mini",
+            "operations": [],
+            "pipeline": {"steps": [], "output": {"path": "/tmp/out.json"}},
+        }
+    )
+    operation = MapOperation(
+        runner,
+        {
+            "name": "classify",
+            "type": "map",
+            "prompt": "Classify {{ input.text }}",
+            "output": {"schema": {"label": "string"}},
+            "execution": {
+                "mode": "batch",
+                "backend": "litellm",
+                "max_batch_requests": 2,
+            },
+            "bypass_cache": True,
+        },
+        "gpt-4o-mini",
+        2,
+    )
+
+    output, _ = operation.execute([{"text": str(i)} for i in range(5)])
+
+    assert len(output) == 5
+    assert batch_sizes == [2, 2, 1]
+
+
+def test_litellm_provider_is_inferred_from_model(monkeypatch):
+    import docetl.operations.utils.api as api_module
+
+    captured = {}
+
+    def fake_execute_batch(requests, config):
+        captured["provider"] = config["provider"]
+        captured["model"] = requests[0].body["model"]
+        return [
+            BatchResult(
+                requests[0].custom_id,
+                _response_row(requests[0].custom_id, "ok")["response"]["body"],
+            )
+        ]
+
+    monkeypatch.setattr(api_module, "execute_batch", fake_execute_batch)
+    runner = DSLRunner(
+        {
+            "default_model": "vertex_ai/gemini-2.5-flash",
+            "operations": [],
+            "pipeline": {"steps": [], "output": {"path": "/tmp/out.json"}},
+        }
+    )
+    operation = MapOperation(
+        runner,
+        {
+            "name": "classify",
+            "type": "map",
+            "model": "vertex_ai/gemini-2.5-flash",
+            "prompt": "Classify {{ input.text }}",
+            "output": {"schema": {"label": "string"}},
+            "execution": {"mode": "batch", "backend": "litellm"},
+            "bypass_cache": True,
+        },
+        "vertex_ai/gemini-2.5-flash",
+        1,
+    )
+
+    operation.execute([{"text": "one"}])
+
+    assert captured == {"provider": "vertex_ai", "model": "gemini-2.5-flash"}
+
+
+def test_vllm_deepseek_string_request_preserves_no_tool_call_path():
+    runner = DSLRunner(
+        {
+            "default_model": "deepseek-r1",
+            "operations": [],
+            "pipeline": {"steps": [], "output": {"path": "/tmp/out.json"}},
+        }
+    )
+
+    body = runner.api._prepare_materialized_completion(
+        model="deepseek-r1",
+        op_type="map",
+        messages=[{"role": "user", "content": "Summarize"}],
+        output_schema={"summary": "string"},
+        litellm_completion_kwargs={},
+        op_config={"output": {"schema": {"summary": "string"}}},
+        execution_config={
+            "mode": "batch",
+            "backend": "vllm",
+            "model": "deepseek-ai/DeepSeek-R1",
+        },
+    )
+
+    assert body["model"] == "deepseek-ai/DeepSeek-R1"
+    assert "tools" not in body
+    assert "tool_choice" not in body
+
+
+def test_inferred_unsupported_litellm_batch_provider_is_rejected():
+    runner = DSLRunner(
+        {
+            "default_model": "anthropic/claude-sonnet-4-5",
+            "operations": [],
+            "pipeline": {"steps": [], "output": {"path": "/tmp/out.json"}},
+        }
+    )
+
+    with pytest.raises(ValueError, match="currently supports provider values"):
+        runner.api.call_llm_materialized_batch(
+            [
+                {
+                    "model": "anthropic/claude-sonnet-4-5",
+                    "op_type": "map",
+                    "messages": [{"role": "user", "content": "Classify"}],
+                    "output_schema": {"label": "string"},
+                    "op_config": {"output": {"schema": {"label": "string"}}},
+                    "bypass_cache": True,
+                }
+            ],
+            {"mode": "batch", "backend": "litellm"},
+        )
+
+
+@pytest.mark.parametrize("field", ["agent", "gleaning", "validate", "calibrate"])
+def test_batch_execution_rejects_multi_round_map_features(field):
+    config = {
+        "name": "classify",
+        "type": "map",
+        "prompt": "Classify {{ input.text }}",
+        "output": {"schema": {"label": "string"}},
+        "execution": {"mode": "batch", "backend": "litellm"},
+    }
+    config[field] = (
+        {"num_rounds": 1, "validation_prompt": "check"}
+        if field == "gleaning"
+        else ["output['label']"]
+        if field == "validate"
+        else True
+    )
+    with pytest.raises(ValueError, match="cannot yet be combined"):
+        MapOperation.schema.model_validate(config)


### PR DESCRIPTION
## Summary

- add a canonical OpenAI-compatible JSONL request/result boundary for deferred LLM execution
- execute hosted batches through LiteLLM's Files and Batches abstraction, with provider inference for OpenAI, Azure, Vertex AI, Bedrock, and hosted vLLM
- execute self-hosted offline batches with `vllm run-batch`, including request defaults and safe CLI argument construction
- persist inputs, provider job manifests, outputs, and errors so interrupted hosted jobs resume without intentional resubmission
- restore input order by `custom_id` and partition hosted jobs by request-count and encoded-file-size limits
- expose the execution block through `Frame.map()` and document how execution batching differs from `batch_prompt`

## Why

DocETL's existing map batching combines several rows into one ordinary prompt. That can reduce request count, but it does not expose provider Batch API discounts or support an ephemeral offline GPU job. Large row-local transformations benefit from materializing the same logical requests once and selecting either a hosted batch lifecycle or a local vLLM runner.

The first slice is deliberately limited to independent map calls and the normal non-cascade filter path. Features that require dependent follow-up calls (agents, gleaning, validation retries, calibration, and cascades) fail early instead of silently falling back to synchronous billing. Deferred execution is also not currently combined with `batch_prompt`, PDF inputs, or filter limits.

## Validation

- `uv run pytest -q tests/test_batch_execution.py tests/test_plan_roundtrip.py tests/test_frame.py -k 'not execute and not collect and not show and not count'` — 84 passed, 1 skipped, 5 deselected
- `uv run ruff check docetl/execution docetl/operations/utils/api.py docetl/operations/map.py docetl/frame.py tests/test_batch_execution.py`
- `uv run mypy --explicit-package-bases docetl/execution/batch.py`
- `uv run mkdocs build --strict --site-dir /tmp/docetl-docs-verify-019fb7fc`

The provider and vLLM lifecycles are covered with deterministic fakes, including resume, output reordering, provider inference, request/file partitioning, and safe subprocess construction. A paid provider Batch job and a GPU-backed vLLM smoke test have not been run from this development machine.
